### PR TITLE
Export version as version_layers to avoid conflict at the union package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensorflow/tfjs-layers",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "TensorFlow layers API in JavaScript",
   "private": false,
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export {Callback, CallbackList, CustomCallback, CustomCallbackConfig, Logs} from
 export {Model} from './engine/training';
 export {ModelAndWeightsConfig, Sequential} from './models';
 export {SymbolicTensor} from './types';
-export {version} from './version';
+export {version as version_layers} from './version';
 
 export {dl};  // TODO(cais): Remove this export (b/74099819).
 export {backend};

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,5 +1,5 @@
 /** @license See the LICENSE file. */
 
 // This code is auto-generated, do not modify this file!
-const version = '0.0.2';
+const version = '0.0.3';
 export {version};


### PR DESCRIPTION
Export version as version_layers to avoid conflict at the union package.
At the union, we will import `version_layers` and `version_core` and export them as:
```js
version = {
  'tfjs-layers': version_layers,
  'tfjs-core': version_core,
  'tfjs': version // Read from the union package.json
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/33)
<!-- Reviewable:end -->
