### PR TITLE
Update tfjs-layers to depend on tfjs-core 0.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "devDependencies": {
-    "@tensorflow/tfjs-core": "0.0.1",
+    "@tensorflow/tfjs-core": "0.0.2",
     "@types/jasmine": "~2.5.53",
     "@types/underscore": "^1.8.7",
     "browserify": "~16.1.0",
@@ -42,6 +42,6 @@
     "underscore": "~1.8.3"
   },
   "peerDependencies": {
-    "@tensorflow/tfjs-core": "0.0.1"
+    "@tensorflow/tfjs-core": "0.0.2"
   }
 }

--- a/src/backend/deeplearnjs_backend.ts
+++ b/src/backend/deeplearnjs_backend.ts
@@ -1482,7 +1482,7 @@ export function depthwiseConv2d(
   }
   y = tfc.depthwiseConv2d(
       y as Tensor4D, depthwiseKernel as Tensor4D, strides,
-      padding === 'same' ? 'same' : 'valid', dilationRate);
+      padding === 'same' ? 'same' : 'valid', 'NHWC', dilationRate);
   if (dataFormat === 'channelFirst') {
     y = tfc.transpose(y, [0, 3, 1, 2]);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@tensorflow/tfjs-core@0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.0.1.tgz#087be00020ed2e581c9e35dea2ca8dd2be537707"
+"@tensorflow/tfjs-core@0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.0.2.tgz#3275ec114db4cc89ca729ffad67a25849236aa61"
   dependencies:
     seedrandom "~2.4.3"
     utf8 "~2.1.2"


### PR DESCRIPTION
conv1d, conv2d and depthwiseConv2d had a small API change with this [tfjs-core PR](https://github.com/PAIR-code/deeplearnjs/pull/794)  where we added `dataFormat` and `dilations` to align fully with `tf.nn.conv2d()` and such.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/58)
<!-- Reviewable:end -->
