### PR TITLE
Change Constraint | Initializer | Regularizer return types in exports.ts to be consistent with layers.

### DIFF
--- a/src/constraints.ts
+++ b/src/constraints.ts
@@ -69,7 +69,6 @@ export interface MaxNormConfig {
  *       - [Dropout: A Simple Way to Prevent Neural Networks from Overfitting
  * Srivastava, Hinton, et al.
  * 2014](http://www.cs.toronto.edu/~rsalakhu/papers/srivastava14a.pdf)
- * @docalias Constraint
  */
 export class MaxNorm extends Constraint {
   private maxValue: number;
@@ -118,7 +117,6 @@ export interface UnitNormConfig {
 
 /**
  * Constrains the weights incident to each hidden unit to have unit norm.
- * @docalias Constraint
  */
 export class UnitNorm extends Constraint {
   private axis: number;
@@ -143,7 +141,6 @@ ClassNameMap.register('UnitNorm', UnitNorm);
 
 /**
  * Constains the weight to be non-negative.
- * @docalias Constraint
  */
 export class NonNeg extends Constraint {
   apply(w: Tensor): Tensor {
@@ -186,7 +183,6 @@ export interface MinMaxNormConfig {
   rate?: number;
 }
 
-/** @docalias Constraint */
 export class MinMaxNorm extends Constraint {
   private minValue: number;
   private maxValue: number;

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -15,10 +15,10 @@
 // tslint:disable:max-line-length
 import {doc} from '@tensorflow/tfjs-core';
 
-import {MaxNorm, MaxNormConfig, MinMaxNorm, MinMaxNormConfig, NonNeg, UnitNorm, UnitNormConfig} from './constraints';
+import {Constraint, MaxNorm, MaxNormConfig, MinMaxNorm, MinMaxNormConfig, NonNeg, UnitNorm, UnitNormConfig} from './constraints';
 import {ContainerConfig, Input, InputConfig, InputLayer, InputLayerConfig, Layer, LayerConfig} from './engine/topology';
 import {Model} from './engine/training';
-import {Constant, ConstantConfig, GlorotNormal, GlorotUniform, HeNormal, Identity, IdentityConfig, LeCunNormal, Ones, Orthogonal, OrthogonalConfig, RandomNormal, RandomNormalConfig, RandomUniform, RandomUniformConfig, SeedOnlyInitializerConfig, TruncatedNormal, TruncatedNormalConfig, VarianceScaling, VarianceScalingConfig, Zeros} from './initializers';
+import {Constant, ConstantConfig, GlorotNormal, GlorotUniform, HeNormal, Identity, IdentityConfig, Initializer, LeCunNormal, Ones, Orthogonal, OrthogonalConfig, RandomNormal, RandomNormalConfig, RandomUniform, RandomUniformConfig, SeedOnlyInitializerConfig, TruncatedNormal, TruncatedNormalConfig, VarianceScaling, VarianceScalingConfig, Zeros} from './initializers';
 import {Conv1D, Conv2D, ConvLayerConfig} from './layers/convolutional';
 import {DepthwiseConv2D, DepthwiseConv2DLayerConfig} from './layers/convolutional_depthwise';
 import {Activation, ActivationLayerConfig, Dense, DenseLayerConfig, Dropout, DropoutLayerConfig, Flatten, RepeatVector, RepeatVectorLayerConfig} from './layers/core';
@@ -29,7 +29,7 @@ import {AvgPooling1D, AvgPooling2D, GlobalAveragePooling1D, GlobalAveragePooling
 import {GRU, GRUCell, GRUCellLayerConfig, GRULayerConfig, LSTM, LSTMCell, LSTMCellLayerConfig, LSTMLayerConfig, RNN, RNNCell, RNNLayerConfig, SimpleRNN, SimpleRNNCell, SimpleRNNCellLayerConfig, SimpleRNNLayerConfig, StackedRNNCells, StackedRNNCellsConfig} from './layers/recurrent';
 import {Bidirectional, BidirectionalLayerConfig, TimeDistributed, WrapperLayerConfig} from './layers/wrappers';
 import {loadModelInternal, Sequential, SequentialConfig} from './models';
-import {l1, L1Config, L1L2, L1L2Config, l2, L2Config} from './regularizers';
+import {l1, L1Config, L1L2, L1L2Config, l2, L2Config, Regularizer} from './regularizers';
 import {SymbolicTensor} from './types';
 
 // tslint:enable:max-line-length
@@ -525,7 +525,7 @@ export class LayerExports {
     useDocsFrom: 'RNN',
     configParamIndices: [0]
   })
-  static rnn(config: RNNLayerConfig): RNN {
+  static rnn(config: RNNLayerConfig): Layer {
     return new RNN(config);
   }
 
@@ -572,7 +572,7 @@ export class ConstraintExports {
     useDocsFrom: 'MaxNorm',
     configParamIndices: [0]
   })
-  static maxNorm(config: MaxNormConfig): MaxNorm {
+  static maxNorm(config: MaxNormConfig): Constraint {
     return new MaxNorm(config);
   }
 
@@ -582,13 +582,13 @@ export class ConstraintExports {
     useDocsFrom: 'UnitNorm',
     configParamIndices: [0]
   })
-  static unitNorm(config: UnitNormConfig): UnitNorm {
+  static unitNorm(config: UnitNormConfig): Constraint {
     return new UnitNorm(config);
   }
 
   @doc(
       {heading: 'Constraints', namespace: 'constraints', useDocsFrom: 'NonNeg'})
-  static nonNeg(): NonNeg {
+  static nonNeg(): Constraint {
     return new NonNeg();
   }
 
@@ -598,7 +598,7 @@ export class ConstraintExports {
     useDocsFrom: 'MinMaxNormConfig',
     configParamIndices: [0]
   })
-  static minMaxNorm(config: MinMaxNormConfig): MinMaxNorm {
+  static minMaxNorm(config: MinMaxNormConfig): Constraint {
     return new MinMaxNorm(config);
   }
 }
@@ -615,7 +615,7 @@ export class InitializerExports {
 
   @doc(
       {heading: 'Initializers', namespace: 'initializers', useDocsFrom: 'Ones'})
-  static ones(): Ones {
+  static ones(): Initializer {
     return new Ones();
   }
 
@@ -626,7 +626,7 @@ export class InitializerExports {
     configParamIndices: [0]
 
   })
-  static constant(config: ConstantConfig): Constant {
+  static constant(config: ConstantConfig): Initializer {
     return new Constant(config);
   }
 
@@ -637,7 +637,7 @@ export class InitializerExports {
     configParamIndices: [0]
 
   })
-  static randomUniform(config: RandomUniformConfig): RandomUniform {
+  static randomUniform(config: RandomUniformConfig): Initializer {
     return new RandomUniform(config);
   }
 
@@ -648,7 +648,7 @@ export class InitializerExports {
     configParamIndices: [0]
 
   })
-  static randomNormal(config: RandomNormalConfig): RandomNormal {
+  static randomNormal(config: RandomNormalConfig): Initializer {
     return new RandomNormal(config);
   }
 
@@ -659,7 +659,7 @@ export class InitializerExports {
     configParamIndices: [0]
 
   })
-  static truncatedNormal(config: TruncatedNormalConfig): TruncatedNormal {
+  static truncatedNormal(config: TruncatedNormalConfig): Initializer {
     return new TruncatedNormal(config);
   }
 
@@ -670,7 +670,7 @@ export class InitializerExports {
     configParamIndices: [0]
 
   })
-  static identity(config: IdentityConfig): Identity {
+  static identity(config: IdentityConfig): Initializer {
     return new Identity(config);
   }
 
@@ -681,7 +681,7 @@ export class InitializerExports {
     configParamIndices: [0]
 
   })
-  static varianceScaling(config: VarianceScalingConfig): VarianceScaling {
+  static varianceScaling(config: VarianceScalingConfig): Initializer {
     return new VarianceScaling(config);
   }
 
@@ -692,7 +692,7 @@ export class InitializerExports {
     configParamIndices: [0]
 
   })
-  static glorotUniform(config: SeedOnlyInitializerConfig): GlorotUniform {
+  static glorotUniform(config: SeedOnlyInitializerConfig): Initializer {
     return new GlorotUniform(config);
   }
 
@@ -703,7 +703,7 @@ export class InitializerExports {
     configParamIndices: [0]
 
   })
-  static glorotNormal(config: SeedOnlyInitializerConfig): GlorotNormal {
+  static glorotNormal(config: SeedOnlyInitializerConfig): Initializer {
     return new GlorotNormal(config);
   }
 
@@ -714,10 +714,9 @@ export class InitializerExports {
     configParamIndices: [0]
 
   })
-  static heNormal(config: SeedOnlyInitializerConfig): HeNormal {
+  static heNormal(config: SeedOnlyInitializerConfig): Initializer {
     return new HeNormal(config);
   }
-
 
   @doc({
     heading: 'Initializers',
@@ -726,7 +725,7 @@ export class InitializerExports {
     configParamIndices: [0]
 
   })
-  static leCunNormal(config: SeedOnlyInitializerConfig): LeCunNormal {
+  static leCunNormal(config: SeedOnlyInitializerConfig): Initializer {
     return new LeCunNormal(config);
   }
 
@@ -736,7 +735,7 @@ export class InitializerExports {
     useDocsFrom: 'Orthogonal',
     configParamIndices: [0]
   })
-  static orthogonal(config: OrthogonalConfig): Orthogonal {
+  static orthogonal(config: OrthogonalConfig): Initializer {
     return new Orthogonal(config);
   }
 }
@@ -744,19 +743,19 @@ export class InitializerExports {
 export class RegularizerExports {
   @doc(
       {heading: 'Regularizers', namespace: 'regularizers', useDocsFrom: 'L1L2'})
-  static l1l2(config?: L1L2Config): L1L2 {
+  static l1l2(config?: L1L2Config): Regularizer {
     return new L1L2(config);
   }
 
   @doc(
       {heading: 'Regularizers', namespace: 'regularizers', useDocsFrom: 'L1L2'})
-  static l1(config?: L1Config): L1L2 {
+  static l1(config?: L1Config): Regularizer {
     return l1(config);
   }
 
   @doc(
       {heading: 'Regularizers', namespace: 'regularizers', useDocsFrom: 'L1L2'})
-  static l2(config?: L2Config): L1L2 {
+  static l2(config?: L2Config): Regularizer {
     return l2(config);
   }
 }

--- a/src/initializers.ts
+++ b/src/initializers.ts
@@ -82,7 +82,6 @@ export abstract class Initializer {
 
 /**
  * Initializer that generates tensors initialized to 0.
- * @docalias Initializer
  */
 export class Zeros extends Initializer {
   apply(shape: Shape, dtype?: DType): Tensor {
@@ -93,7 +92,6 @@ ClassNameMap.register('Zeros', Zeros);
 
 /**
  * Initializer that generates tensors initialized to 1.
- * @docalias Initializer
  */
 export class Ones extends Initializer {
   apply(shape: Shape, dtype?: DType): Tensor {
@@ -109,7 +107,6 @@ export interface ConstantConfig {
 
 /**
  * Initializer that generates values initialized to some constant.
- * @docalias Initializer
  */
 export class Constant extends Initializer {
   private value: number;
@@ -146,7 +143,6 @@ export interface RandomUniformConfig {
  *
  * Values will be distributed uniformly between the configured minval and
  * maxval.
- * @docalias Initializer
  */
 export class RandomUniform extends Initializer {
   readonly DEFAULT_MINVAL = -0.05;
@@ -184,7 +180,6 @@ export interface RandomNormalConfig {
 /**
  * Initializer that generates random values initialized to a normal
  * distribution.
- * @docalias Initializer
  */
 export class RandomNormal extends Initializer {
   readonly DEFAULT_MEAN = 0.;
@@ -226,7 +221,6 @@ export interface TruncatedNormalConfig {
  * These values are similar to values from a `RandomNormal` except that values
  * more than two standard deviations from the mean are discarded and re-drawn.
  * This is the recommended initializer for neural network weights and filters.
- * @docalias Initializer
  */
 export class TruncatedNormal extends Initializer {
   readonly DEFAULT_MEAN = 0.;
@@ -262,7 +256,6 @@ export interface IdentityConfig {
 /**
  * Initializer that generates the identity matrix.
  * Only use for square 2D matrices.
- * @docalias Initializer
  */
 export class Identity extends Initializer {
   private gain: Scalar;
@@ -345,7 +338,6 @@ export interface VarianceScalingConfig {
  * With distribution=UNIFORM,
  * samples are drawn from a uniform distribution
  * within [-limit, limit], with `limit = sqrt(3 * scale / n)`.
- * @docalias Initializer
  */
 export class VarianceScaling extends Initializer {
   private scale: number;
@@ -420,7 +412,6 @@ export interface SeedOnlyInitializerConfig {
  * Reference:
  *   Glorot & Bengio, AISTATS 2010
  *       http://jmlr.org/proceedings/papers/v9/glorot10a/glorot10a.pdf.
- * @docalias Initializer
  */
 export class GlorotUniform extends VarianceScaling {
   /**
@@ -451,7 +442,6 @@ ClassNameMap.register('GlorotUniform', GlorotUniform);
  * Reference:
  *   Glorot & Bengio, AISTATS 2010
  *       http://jmlr.org/proceedings/papers/v9/glorot10a/glorot10a.pdf
- * @docalias Initializer
  */
 export class GlorotNormal extends VarianceScaling {
   /**
@@ -481,7 +471,6 @@ ClassNameMap.register('GlorotNormal', GlorotNormal);
  *
  * Reference:
  *     He et al., http://arxiv.org/abs/1502.01852
- * @docalias Initializer
  */
 export class HeNormal extends VarianceScaling {
   constructor(config?: SeedOnlyInitializerConfig) {
@@ -501,7 +490,6 @@ ClassNameMap.register('HeNormal', HeNormal);
  * References:
  *   [Self-Normalizing Neural Networks](https://arxiv.org/abs/1706.02515)
  *   [Efficient Backprop](http://yann.lecun.com/exdb/publis/pdf/lecun-98b.pdf)
- * @docalias Initializer
  */
 export class LeCunNormal extends VarianceScaling {
   constructor(config?: SeedOnlyInitializerConfig) {


### PR DESCRIPTION
We used to docalias these so they would show up generically in the docs, but returning the parent class type is a more robust approach and consistent with layers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/75)
<!-- Reviewable:end -->
