### PR TITLE
Add benchmarks for RNNs

### DIFF
--- a/scripts/benchmarks.py
+++ b/scripts/benchmarks.py
@@ -284,8 +284,8 @@ def main():
     print('train_time = %g s' % train_time)
     print('predict_time = %g s' % predict_time)
 
-    with open(os.path.join(FLAGS.data_root, 'benchmarks.json'), 'wt') as f:
-      json.dump(benchmarks, f)
+  with open(os.path.join(FLAGS.data_root, 'benchmarks.json'), 'wt') as f:
+    json.dump(benchmarks, f)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Convering the three most frequently used RNN cell types:
  * SimpleRNN
  * GRU
  * LSTM
* Now the benchmarks "demo" is complete in terms of covering all
  three major types of common models: MLP, convolutional and RNN.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/80)
<!-- Reviewable:end -->
