### PR TITLE
Depend on tfjs-core 0.6.0-alpha7 and update tfjs-layers to 0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@tensorflow/tfjs-layers",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "description": "TensorFlow layers API in JavaScript",
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "devDependencies": {
-    "@tensorflow/tfjs-core": "0.0.2",
+    "@tensorflow/tfjs-core": "0.6.0-alpha7",
     "@types/jasmine": "~2.5.53",
     "@types/underscore": "^1.8.7",
     "browserify": "~16.1.0",
@@ -41,6 +41,6 @@
     "underscore": "~1.8.3"
   },
   "peerDependencies": {
-    "@tensorflow/tfjs-core": "0.0.2"
+    "@tensorflow/tfjs-core": "0.6.0-alpha7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@tensorflow/tfjs-core@0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.0.2.tgz#3275ec114db4cc89ca729ffad67a25849236aa61"
+"@tensorflow/tfjs-core@0.6.0-alpha7":
+  version "0.6.0-alpha7"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.6.0-alpha7.tgz#72e010b7176e302ce3a99627e7bca8d5da88bd15"
   dependencies:
     seedrandom "~2.4.3"
     utf8 "~2.1.2"


### PR DESCRIPTION
We had to release 0.6.0-alpha7 of tfjs-core so that the github tag in djls repo 0.6.0-alpha7 matches the version . This unblocks doc generator.

When we official release, we change tfjs-core from 0.6.0-alpha7 to 0.6.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/89)
<!-- Reviewable:end -->
