### PR TITLE
Fix and improve runnable code snippets

### DIFF
--- a/src/engine/topology.ts
+++ b/src/engine/topology.ts
@@ -807,7 +807,7 @@ export class Layer {
    * // output1.shape is [null, 4]. The first dimension is the undetermined
    * // batch size. The second dimension comes from flattening the [2, 2]
    * // shape.
-   * console.log(output1.shape);
+   * console.log(JSON.stringify(output1.shape));
    *
    * // The output SymbolicTensor of the flatten layer can be used to call
    * // the apply() of the dense layer:
@@ -816,7 +816,7 @@ export class Layer {
    * // output2.shape is [null, 1]. The first dimension is the undetermined
    * // batch size. The second dimension matches the number of units of the
    * // dense layer.
-   * console.log(output2.shape);
+   * console.log(JSON.stringify(output2.shape));
    *
    * // The input and output and be used to construct a model that consists
    * // of the flatten and dense layers.

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -103,7 +103,7 @@ export class ModelExports {
    * ```js
    * const model = tf.sequential();
    *
-   * // First layer must have a defined input shape
+   * // First layer must have an input shape defined.
    * model.add(tf.layers.dense({units: 32, inputShape: [50]}));
    * // Afterwards, TF.js does automatic shape inference.
    * model.add(tf.layers.dense({units: 4}));
@@ -111,7 +111,7 @@ export class ModelExports {
    * // Inspect the inferred shape of the model's output, which equals
    * // `[null, 4]`. The 1st dimension is the undetermined batch dimension; the
    * // 2nd is the output size of the model's last layer.
-   * console.log(model.outputs[0].shape);
+   * console.log(JSON.stringify(model.outputs[0].shape));
    * ```
    *
    * It is also possible to specify a batch size (with potentially undetermined
@@ -127,7 +127,7 @@ export class ModelExports {
    * model.add(tf.layers.dense({units: 4}));
    *
    * // Inspect the inferred shape of the model's output.
-   * console.log(model.outputs[0].shape);
+   * console.log(JSON.stringify(model.outputs[0].shape));
    * ```
    *
    * You can also use an `Array` of already-constructed `Layer`s to create
@@ -138,7 +138,7 @@ export class ModelExports {
    *   layers: [tf.layers.dense({units: 32, inputShape: [50]}),
    *            tf.layers.dense({units: 4})]
    * });
-   * console.log(model.outputs[0].shape);
+   * console.log(JSON.stringify(model.outputs[0].shape));
    * ```
    */
   @doc({heading: 'Models', subheading: 'Creation', configParamIndices: [0]})

--- a/src/layers/core.ts
+++ b/src/layers/core.ts
@@ -327,7 +327,7 @@ generic_utils.ClassNameMap.register('Dense', Dense);
  * // Inspect the inferred output shape of the flatten layer, which
  * // equals `[null, 12]`. The 2nd dimension is 4 * 3, i.e., the result of the
  * // flattening. (The 1st dimension is the undermined batch size.)
- * console.log(flattenLayer.apply(input).shape);
+ * console.log(JSON.stringify(flattenLayer.apply(input).shape));
  * ```
  */
 export class Flatten extends Layer {

--- a/src/layers/merge.ts
+++ b/src/layers/merge.ts
@@ -240,7 +240,7 @@ export class Merge extends Layer {
  * const input2 = tf.input({shape: [2, 2]});
  * const addLayer = tf.layers.add();
  * const sum = addLayer.apply([input1, input2]);
- * console.log(sum.shape);
+ * console.log(JSON.stringify(sum.shape));
  * // You get [null, 2, 2], with the first dimension as the undetermined batch
  * // dimension.
  * ```
@@ -417,7 +417,7 @@ export function multiply(config?: SymbolicTensor[]|Tensor[]|LayerConfig): Layer|
  * const input2 = tf.input({shape: [2, 2]});
  * const averageLayer = tf.layers.average();
  * const average = averageLayer.apply([input1, input2]);
- * console.log(average.shape);
+ * console.log(JSON.stringify(average.shape));
  * // You get [null, 2, 2], with the first dimension as the undetermined batch
  * // dimension.
  * ```
@@ -506,7 +506,7 @@ export function average(config?: SymbolicTensor[]|Tensor[]|LayerConfig): Layer|
  * const input2 = tf.input({shape: [2, 2]});
  * const maxLayer = tf.layers.maximum();
  * const max = maxLayer.apply([input1, input2]);
- * console.log(max.shape);
+ * console.log(JSON.stringify(max.shape));
  * // You get [null, 2, 2], with the first dimension as the undetermined batch
  * // dimension.
  * ```
@@ -594,7 +594,7 @@ export function maximum(config?: SymbolicTensor[]|Tensor[]|LayerConfig): Layer|
  * const input2 = tf.input({shape: [2, 2]});
  * const minLayer = tf.layers.minimum();
  * const min = minLayer.apply([input1, input2]);
- * console.log(min.shape);
+ * console.log(JSON.stringify(min.shape));
  * // You get [null, 2, 2], with the first dimension as the undetermined batch
  * // dimension.
  * ```
@@ -690,7 +690,7 @@ export interface ConcatenateLayerConfig extends LayerConfig {
  * const input2 = tf.input({shape: [2, 3]});
  * const concatLayer = tf.layers.concatenate();
  * const output = concatLayer.apply([input1, input2]);
- * console.log(output.shape);
+ * console.log(JSON.stringify(output.shape));
  * // You get [null, 2, 5], with the first dimension as the undetermined batch
  * // dimension. The last dimension (5) is the result of concatenating the
  * // last dimensions of the inputs (2 and 3).

--- a/src/layers/recurrent.ts
+++ b/src/layers/recurrent.ts
@@ -750,7 +750,7 @@ export interface SimpleRNNCellLayerConfig extends LayerConfig {
  * const input = tf.input({shape: [10]});
  * const output = cell.apply(input);
  *
- * console.log(output.shape);
+ * console.log(JSON.stringify(output.shape));
  * // [null, 10]: This is the cell's output at a single time step. The 1st
  * // dimension is the unknown batch size.
  * ```
@@ -771,7 +771,7 @@ export interface SimpleRNNCellLayerConfig extends LayerConfig {
  * const input = tf.input({shape: [10, 20]});
  * const output = rnn.apply(input);
  *
- * console.log(output);
+ * console.log(JSON.stringify(output.shape));
  * // [null, 10, 8]: 1st dimension is unknown batch size; 2nd dimension is the
  * // same as the sequence length of `input`, due to `returnSequences`: `true`;
  * // 3rd dimension is the last `SimpleRNNCell`'s number of units.
@@ -1024,7 +1024,7 @@ export interface SimpleRNNLayerConfig extends BaseRNNLayerConfig {
  * const input = tf.input({shape: [10, 20]});
  * const output = rnn.apply(input);
  *
- * console.log(output);
+ * console.log(JSON.stringify(output.shape));
  * // [null, 10, 8]: 1st dimension is unknown batch size; 2nd dimension is the
  * // same as the sequence length of `input`, due to `returnSequences`: `true`;
  * // 3rd dimension is the `SimpleRNNCell`'s number of units.
@@ -1168,7 +1168,7 @@ export interface GRUCellLayerConfig extends SimpleRNNCellLayerConfig {
  * const input = tf.input({shape: [10]});
  * const output = cell.apply(input);
  *
- * console.log(output.shape);
+ * console.log(JSON.stringify(output.shape));
  * // [null, 10]: This is the cell's output at a single time step. The 1st
  * // dimension is the unknown batch size.
  * ```
@@ -1189,7 +1189,7 @@ export interface GRUCellLayerConfig extends SimpleRNNCellLayerConfig {
  * const input = tf.input({shape: [10, 20]});
  * const output = rnn.apply(input);
  *
- * console.log(output);
+ * console.log(JSON.stringify(output.shape));
  * // [null, 10, 8]: 1st dimension is unknown batch size; 2nd dimension is the
  * // same as the sequence length of `input`, due to `returnSequences`: `true`;
  * // 3rd dimension is the last `gruCell`'s number of units.
@@ -1449,7 +1449,7 @@ export interface GRULayerConfig extends SimpleRNNLayerConfig {
  * const input = tf.input({shape: [10, 20]});
  * const output = rnn.apply(input);
  *
- * console.log(output);
+ * console.log(JSON.stringify(output.shape));
  * // [null, 10, 8]: 1st dimension is unknown batch size; 2nd dimension is the
  * // same as the sequence length of `input`, due to `returnSequences`: `true`;
  * // 3rd dimension is the `GRUCell`'s number of units.
@@ -1617,7 +1617,7 @@ export interface LSTMCellLayerConfig extends SimpleRNNCellLayerConfig {
  * const input = tf.input({shape: [10]});
  * const output = cell.apply(input);
  *
- * console.log(output.shape);
+ * console.log(JSON.stringify(output.shape));
  * // [null, 10]: This is the cell's output at a single time step. The 1st
  * // dimension is the unknown batch size.
  * ```
@@ -1638,7 +1638,7 @@ export interface LSTMCellLayerConfig extends SimpleRNNCellLayerConfig {
  * const input = tf.input({shape: [10, 20]});
  * const output = rnn.apply(input);
  *
- * console.log(output);
+ * console.log(JSON.stringify(output.shape));
  * // [null, 10, 8]: 1st dimension is unknown batch size; 2nd dimension is the
  * // same as the sequence length of `input`, due to `returnSequences`: `true`;
  * // 3rd dimension is the last `lstmCell`'s number of units.
@@ -1930,9 +1930,9 @@ export interface LSTMLayerConfig extends SimpleRNNLayerConfig {
  *
  * // Create an input with 10 time steps.
  * const input = tf.input({shape: [10, 20]});
- * const output = rnn.apply(input);
+ * const output = lstm.apply(input);
  *
- * console.log(output);
+ * console.log(JSON.stringify(output.shape));
  * // [null, 10, 8]: 1st dimension is unknown batch size; 2nd dimension is the
  * // same as the sequence length of `input`, due to `returnSequences`: `true`;
  * // 3rd dimension is the `LSTMCell`'s number of units.

--- a/src/layers/wrappers.ts
+++ b/src/layers/wrappers.ts
@@ -170,6 +170,7 @@ export abstract class Wrapper extends Layer {
  *
  * // In subsequent layers, there is no need for `inputShape`:
  * model.add(tf.layers.timeDistributed({layer: tf.layers.dense({units: 32})}));
+ * console.log(JSON.stringify(model.outputs[0].shape));
  * // Now model.outputShape = [null, 10, 32].
  * ```
  *
@@ -184,6 +185,7 @@ export abstract class Wrapper extends Layer {
  *   layer: tf.layers.conv2d({filters: 64, kernelSize: [3, 3]}),
  *   inputShape: [10, 299, 299, 3],
  * }));
+ * console.log(JSON.stringify(model.outputs[0].shape));
  * ```
  */
 export class TimeDistributed extends Wrapper {

--- a/src/models.ts
+++ b/src/models.ts
@@ -388,8 +388,8 @@ export class Sequential extends Model {
    */
   @doc({heading: 'Models', subheading: 'Classes', configParamIndices: [2]})
   evaluate(
-      x: Tensor|Tensor[], y: Tensor|Tensor[],
-      config: ModelEvaluateConfig = {}): Scalar|Scalar[] {
+      x: Tensor|Tensor[], y: Tensor|Tensor[], config: ModelEvaluateConfig = {}):
+      Scalar|Scalar[] {
     if (!this.built) {
       throw new RuntimeError(
           'The model needs to be compiled before being used.');
@@ -475,6 +475,7 @@ export class Sequential extends Model {
    *   batchSize: 4,
    *   epochs: 3
    * });
+   * ```
    *
    * @param x `Tensor` of training data, or an array of `Tensor`s if the model
    *   has multiple inputs. If all inputs in the model are named, you can also


### PR DESCRIPTION
* Fix a blatant bug in tf.layers.lstm() runnable snippet.
* Some snippets didn't print anything. Make sure they print something.
* Some snippets printed uninformative shapes like ',10', instead of the
  full shape like '[null,10]'. Using `JSON.stringify` to fix that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/103)
<!-- Reviewable:end -->
