### PR TITLE
[FIX] TypeError: this.history[keys[n]][indices[n]].dispose is not a f…

### DIFF
--- a/src/callbacks.ts
+++ b/src/callbacks.ts
@@ -377,7 +377,9 @@ export class History extends Callback {
     }
     const values = await Promise.all(promises);
     for (let n = 0; n < values.length; ++n) {
-      (this.history[keys[n]][indices[n]] as Tensor).dispose();
+      if ((this.history[keys[n]][indices[n]] as Tensor).dispose) {
+        (this.history[keys[n]][indices[n]] as Tensor).dispose();
+      }
       this.history[keys[n]][indices[n]] = values[n][0];
     }
   }


### PR DESCRIPTION
Hi, thanks for this awesome project.
I am having a problem, when ported this model to tfs: https://github.com/bhaveshoswal/CNN-text-classification-keras
after the model trains i get the error `TypeError: this.history[keys[n]][indices[n]].dispose is not a function`
Tried using and not using `dispose` and `tidy`, but getting the same error, the only solution i found is what this PR does. Thanks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/112)
<!-- Reviewable:end -->
