### PR TITLE
Add ZeroPadding2D layer; Fix ts-python logic for padding

### DIFF
--- a/src/backend/tfjs_backend.ts
+++ b/src/backend/tfjs_backend.ts
@@ -249,6 +249,79 @@ export function squeeze(x: Tensor, axis: number): Tensor {
 }
 
 /**
+ * Pads the middle dimension of a 3D tensor.
+ *
+ * @param x Input `Tensor` to be padded.
+ * @param padding `Array` of 2 integers, how many zeros to add at the start and
+ *   end of the middle dimension (i.e., dimension 1).
+ * @return A padded 3D `Tensor`.
+ */
+export function temporalPadding(x: Tensor, padding?: [number, number]): Tensor {
+  if (ndim(x) !== 3) {
+    throw new ValueError(
+        `temporalPadding expects input tensor to be 3-D, but received a ` +
+        `${ndim(x)}-D tensor.`);
+  }
+
+  if (padding == null) {
+    padding = [1, 1];
+  }
+  if (padding.length !== 2) {
+    throw new ValueError(
+        `temporalPadding expects input padding pattern to be a length-2 ` +
+        `array, but received a length-${padding.length} array.`);
+  }
+
+  const pattern: Array<[number, number]> = [[0, 0], padding, [0, 0]];
+  return tfc.pad(x, pattern);
+}
+
+/**
+ * Pads the 2nd and 3rd dimensions of a 4D tensor.
+ *
+ * @param x Input `Tensor` to be padded.
+ * @param padding `Array` of two `Array`s, each of which is an `Array` of two
+ *   integers. The amount of padding at the beginning and end of the 2nd and 3rd
+ *   dimensions, respectively.
+ * @param dataFormat 'channelsLast' (default) or 'channelsFirst'.
+ */
+export function spatial2dPadding(
+    x: Tensor, padding?: [[number, number], [number, number]],
+    dataFormat?: DataFormat): Tensor {
+  if (ndim(x) !== 4) {
+    throw new ValueError(
+        `temporalPadding expects input tensor to be 4-D, but received a ` +
+        `${ndim(x)}-D tensor.`);
+  }
+
+  if (padding == null) {
+    padding = [[1, 1], [1, 1]];
+  }
+  if (padding.length !== 2 || padding[0].length !== 2 ||
+      padding[1].length !== 2) {
+    throw new ValueError(
+        'spatial2dPadding expects `padding` to be an Array of two Arrays, ' +
+        'each of which is an Array of two integers.');
+  }
+
+  if (dataFormat == null) {
+    dataFormat = imageDataFormat();
+  }
+  if (dataFormat in ['channelsLast', 'channelsFirst']) {
+    throw new ValueError(`Unknown data format: ${dataFormat}`);
+  }
+
+  let pattern: Array<[number, number]>;
+  if (dataFormat === 'channelsFirst') {
+    pattern = [[0, 0], [0, 0], padding[0], padding[1]];
+  } else {
+    pattern = [[0, 0], padding[0], padding[1], [0, 0]];
+  }
+
+  return tfc.pad(x, pattern);
+}
+
+/**
  * Repeats a 2D tensor.
  *
  * If `x` has shape `[samples, dim]` and `n` is 2, for example, the output

--- a/src/backend/tfjs_backend.ts
+++ b/src/backend/tfjs_backend.ts
@@ -284,6 +284,7 @@ export function temporalPadding(x: Tensor, padding?: [number, number]): Tensor {
  *   integers. The amount of padding at the beginning and end of the 2nd and 3rd
  *   dimensions, respectively.
  * @param dataFormat 'channelsLast' (default) or 'channelsFirst'.
+ * @return Padded 4D `Tensor`.
  */
 export function spatial2dPadding(
     x: Tensor, padding?: [[number, number], [number, number]],
@@ -307,7 +308,7 @@ export function spatial2dPadding(
   if (dataFormat == null) {
     dataFormat = imageDataFormat();
   }
-  if (dataFormat in ['channelsLast', 'channelsFirst']) {
+  if (dataFormat !== 'channelsLast' && dataFormat !== 'channelsFirst') {
     throw new ValueError(`Unknown data format: ${dataFormat}`);
   }
 

--- a/src/backend/tfjs_backend.ts
+++ b/src/backend/tfjs_backend.ts
@@ -309,7 +309,9 @@ export function spatial2dPadding(
     dataFormat = imageDataFormat();
   }
   if (dataFormat !== 'channelsLast' && dataFormat !== 'channelsFirst') {
-    throw new ValueError(`Unknown data format: ${dataFormat}`);
+    throw new ValueError(
+        `Unknown data format: ${dataFormat}. ` +
+        `Supported data formats are 'channelsLast' and 'channelsFirst.`);
   }
 
   let pattern: Array<[number, number]>;

--- a/src/backend/tfjs_backend_test.ts
+++ b/src/backend/tfjs_backend_test.ts
@@ -420,11 +420,15 @@ describeMathCPUAndGPU('spatial2dPadding', () => {
     const y = K.spatial2dPadding(x);
 
     expect(y.shape).toEqual([2, 5, 6, 3]);
-    expectTensorsClose(
-        slice(y, [0, 0, 0, 0], [2, 1, 1, 3]), K.zeros([2, 1, 1, 3]));
     expectTensorsClose(slice(y, [0, 1, 1, 0], [2, 3, 4, 3]), x);
     expectTensorsClose(
-        slice(y, [0, 4, 5, 0], [2, 1, 1, 3]), K.zeros([2, 1, 1, 3]));
+        slice(y, [0, 0, 0, 0], [2, 1, 6, 3]), K.zeros([2, 1, 6, 3]));
+    expectTensorsClose(
+        slice(y, [0, 4, 0, 0], [2, 1, 6, 3]), K.zeros([2, 1, 6, 3]));
+    expectTensorsClose(
+        slice(y, [0, 0, 0, 0], [2, 5, 1, 3]), K.zeros([2, 5, 1, 3]));
+    expectTensorsClose(
+        slice(y, [0, 0, 5, 0], [2, 5, 1, 3]), K.zeros([2, 5, 1, 3]));
   });
 
   it('custom padding 2-2-3-0', () => {
@@ -432,9 +436,13 @@ describeMathCPUAndGPU('spatial2dPadding', () => {
     const y = K.spatial2dPadding(x, [[2, 2], [3, 0]]);
     expect(y.shape).toEqual([2, 7, 7, 3]);
 
-    expectTensorsClose(
-        slice(y, [0, 0, 0, 0], [2, 2, 3, 3]), K.zeros([2, 2, 3, 3]));
     expectTensorsClose(slice(y, [0, 2, 3, 0], [2, 3, 4, 3]), x);
+    expectTensorsClose(
+        slice(y, [0, 0, 0, 0], [2, 2, 7, 3]), K.zeros([2, 2, 7, 3]));
+    expectTensorsClose(
+        slice(y, [0, 5, 0, 0], [2, 2, 7, 3]), K.zeros([2, 2, 7, 3]));
+    expectTensorsClose(
+        slice(y, [0, 0, 0, 0], [2, 7, 3, 3]), K.zeros([2, 7, 3, 3]));
   });
 });
 

--- a/src/backend/tfjs_backend_test.ts
+++ b/src/backend/tfjs_backend_test.ts
@@ -13,7 +13,7 @@
  */
 
 // tslint:disable:max-line-length
-import {Scalar, scalar, Tensor, tensor1d, tensor2d, tensor3d, tensor4d, Tensor4D, zeros} from '@tensorflow/tfjs-core';
+import {Scalar, scalar, slice, Tensor, tensor1d, tensor2d, tensor3d, tensor4d, Tensor4D, zeros} from '@tensorflow/tfjs-core';
 import * as _ from 'underscore';
 
 import {DataFormat, PaddingMode, PoolMode} from '../common';
@@ -21,8 +21,7 @@ import {ConcreteTensor, DType, LayerVariable, SymbolicTensor} from '../types';
 import {describeMathCPU, describeMathCPUAndGPU, expectTensorsClose} from '../utils/test_utils';
 
 import * as K from './tfjs_backend';
-
-// tslint:enable
+// tslint:enable:max-line-length
 
 const CT = ConcreteTensor;
 
@@ -392,6 +391,50 @@ describeMathCPUAndGPU('squeeze', () => {
     const x = tensor2d([[10, 20, 30]]);
     const y = tensor1d([10, 20, 30]);
     expectTensorsClose(K.squeeze(x, 0), y);
+  });
+});
+
+describeMathCPUAndGPU('temporalPadding', () => {
+  it('default padding 1-1', () => {
+    const x = tensor3d([[[1, 2], [3, 4]], [[-1, -2], [-3, -4]]]);
+    const y = K.temporalPadding(x);
+    expectTensorsClose(y, tensor3d([
+                         [[0, 0], [1, 2], [3, 4], [0, 0]],
+                         [[0, 0], [-1, -2], [-3, -4], [0, 0]]
+                       ]));
+  });
+  it('custom padding 2-2', () => {
+    const x = tensor3d([[[1, 2], [3, 4]], [[-1, -2], [-3, -4]]]);
+    const y = K.temporalPadding(x, [2, 2]);
+    expectTensorsClose(
+        y, tensor3d([
+          [[0, 0], [0, 0], [1, 2], [3, 4], [0, 0], [0, 0]],
+          [[0, 0], [0, 0], [-1, -2], [-3, -4], [0, 0], [0, 0]]
+        ]));
+  });
+});
+
+describeMathCPUAndGPU('spatial2dPadding', () => {
+  it('default padding 1-1-1-1', () => {
+    const x = K.ones([2, 3, 4, 3]);
+    const y = K.spatial2dPadding(x);
+
+    expect(y.shape).toEqual([2, 5, 6, 3]);
+    expectTensorsClose(
+        slice(y, [0, 0, 0, 0], [2, 1, 1, 3]), K.zeros([2, 1, 1, 3]));
+    expectTensorsClose(slice(y, [0, 1, 1, 0], [2, 3, 4, 3]), x);
+    expectTensorsClose(
+        slice(y, [0, 4, 5, 0], [2, 1, 1, 3]), K.zeros([2, 1, 1, 3]));
+  });
+
+  it('custom padding 2-2-3-0', () => {
+    const x = K.ones([2, 3, 4, 3]);
+    const y = K.spatial2dPadding(x, [[2, 2], [3, 0]]);
+    expect(y.shape).toEqual([2, 7, 7, 3]);
+
+    expectTensorsClose(
+        slice(y, [0, 0, 0, 0], [2, 2, 3, 3]), K.zeros([2, 2, 3, 3]));
+    expectTensorsClose(slice(y, [0, 2, 3, 0], [2, 3, 4, 3]), x);
   });
 });
 

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -26,13 +26,13 @@ import {Activation, ActivationLayerConfig, Dense, DenseLayerConfig, Dropout, Dro
 import {Embedding, EmbeddingLayerConfig} from './layers/embeddings';
 import {Add, Average, Concatenate, ConcatenateLayerConfig, Maximum, Minimum, Multiply} from './layers/merge';
 import {BatchNormalization, BatchNormalizationLayerConfig} from './layers/normalization';
+import {ZeroPadding2D, ZeroPadding2DLayerConfig} from './layers/padding';
 import {AvgPooling1D, AvgPooling2D, GlobalAveragePooling1D, GlobalAveragePooling2D, GlobalMaxPooling1D, GlobalMaxPooling2D, GlobalPooling2DLayerConfig, MaxPooling1D, MaxPooling2D, Pooling1DLayerConfig, Pooling2DLayerConfig} from './layers/pooling';
 import {GRU, GRUCell, GRUCellLayerConfig, GRULayerConfig, LSTM, LSTMCell, LSTMCellLayerConfig, LSTMLayerConfig, RNN, RNNCell, RNNLayerConfig, SimpleRNN, SimpleRNNCell, SimpleRNNCellLayerConfig, SimpleRNNLayerConfig, StackedRNNCells, StackedRNNCellsConfig} from './layers/recurrent';
 import {Bidirectional, BidirectionalLayerConfig, TimeDistributed, WrapperLayerConfig} from './layers/wrappers';
 import {loadModelInternal, Sequential, SequentialConfig} from './models';
 import {l1, L1Config, L1L2, L1L2Config, l2, L2Config, Regularizer} from './regularizers';
 import {SymbolicTensor} from './types';
-import { ZeroPadding2DLayerConfig, ZeroPadding2D } from './layers/padding';
 
 // tslint:enable:max-line-length
 

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -32,6 +32,7 @@ import {Bidirectional, BidirectionalLayerConfig, TimeDistributed, WrapperLayerCo
 import {loadModelInternal, Sequential, SequentialConfig} from './models';
 import {l1, L1Config, L1L2, L1L2Config, l2, L2Config, Regularizer} from './regularizers';
 import {SymbolicTensor} from './types';
+import { ZeroPadding2DLayerConfig, ZeroPadding2D } from './layers/padding';
 
 // tslint:enable:max-line-length
 
@@ -430,6 +431,19 @@ export class LayerExports {
   })
   static batchNormalization(config: BatchNormalizationLayerConfig): Layer {
     return new BatchNormalization(config);
+  }
+
+  // Padding Layers.
+
+  @doc({
+    heading: 'Layers',
+    subheading: 'Padding',
+    namespace: 'layers',
+    useDocsFrom: 'ZeroPadding2D',
+    configParamIndices: [0]
+  })
+  static zeroPadding2d(config: ZeroPadding2DLayerConfig): Layer {
+    return new ZeroPadding2D(config);
   }
 
   // Pooling Layers.

--- a/src/layers/convolutional_test.ts
+++ b/src/layers/convolutional_test.ts
@@ -18,8 +18,7 @@ import {ones, scalar, Tensor, tensor3d, tensor4d, util} from '@tensorflow/tfjs-c
 import * as K from '../backend/tfjs_backend';
 import {DataFormat, PaddingMode} from '../common';
 import {InitializerIdentifier} from '../initializers';
-import {DType} from '../types';
-import {SymbolicTensor} from '../types';
+import {DType, SymbolicTensor} from '../types';
 import {describeMathCPU, describeMathCPUAndGPU, expectTensorsClose} from '../utils/test_utils';
 
 import {Conv1D, Conv2D, Conv2DTranspose} from './convolutional';

--- a/src/layers/padding.ts
+++ b/src/layers/padding.ts
@@ -1,0 +1,178 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ * =============================================================================
+ */
+
+/**
+ * Padding Layers.
+ */
+
+// Porting Note: In Python Keras, the padding layers are in convolutional.py,
+//   but we decided to put them in a separate file (padding.ts) for clarity.
+
+// tslint:disable:max-line-length
+import {Tensor} from '@tensorflow/tfjs-core';
+
+import {imageDataFormat} from '../backend/common';
+import * as K from '../backend/tfjs_backend';
+import {DataFormat} from '../common';
+import {InputSpec, Layer, LayerConfig} from '../engine/topology';
+import {ValueError} from '../errors';
+import {ConfigDict, Shape} from '../types';
+import {ClassNameMap, getExactlyOneShape, getExactlyOneTensor} from '../utils/generic_utils';
+// tslint:enable:max-line-length
+
+export interface ZeroPadding2DLayerConfig extends LayerConfig {
+  /**
+   * Integer, or `Array` of 2 integers, or `Array` of 2 `Array`s, each of
+   * which is an `Array` of 2 integers.
+   * - If integer, the same symmetric padding is applied to width and height.
+   * - If Array` of 2 integers, interpreted as two different symmetric values
+   *   for height and width:
+   *   `[symmetricHeightPad, symmetricWidthPad]`.
+   * - If `Array` of 2 `Array`s, interpreted as:
+   *   `[[topPad, bottomPad], [leftPad, rightPad]]`.
+   */
+  padding?: number|[number, number]|[[number, number], [number, number]];
+
+  /**
+   * One of 'channelsLast' (default) and 'channelsFirst'.
+   *
+   * The ordering of the dimensions in the inputs.
+   * `channelsLast` corresponds to inputs with shape
+   * `[batch, height, width, channels]` while `channelsFirst`
+   * corresponds to inputs with shape
+   * `[batch, channels, height, width]`.
+   */
+  dataFormat?: DataFormat;
+}
+
+/**
+ * Zero-padding layer for 2D input (e.g., image).
+ *
+ * This layer can add rows and columns of zeros
+ * at the top, bottom, left and right side of an image tensor.
+ *
+ * Input shape:
+ *   4D tensor with shape:
+ *   - If `dataFormat` is `"channelsLast"`:
+ *     `[batch, rows, cols, channels]`
+ *   - If `data_format` is `"channels_first"`:
+ *     `[batch, channels, rows, cols]`.
+ *
+ * Output shape:
+ *   4D with shape:
+ *   - If `dataFormat` is `"channelsLast"`:
+ *     `[batch, paddedRows, paddedCols, channels]`
+ *    - If `dataFormat` is `"channelsFirst"`:
+ *     `[batch, channels, paddedRows, paddedCols]`.
+ */
+export class ZeroPadding2D extends Layer {
+  readonly dataFormat: DataFormat;
+  readonly padding: [[number, number], [number, number]];
+
+  constructor(config?: ZeroPadding2DLayerConfig) {
+    if (config == null) {
+      config = {};
+    }
+    super(config);
+
+    this.dataFormat =
+        config.dataFormat == null ? imageDataFormat() : config.dataFormat;
+    if (config.padding == null) {
+      this.padding = [[1, 1], [1, 1]];
+    } else if (typeof config.padding === 'number') {
+      this.padding =
+          [[config.padding, config.padding], [config.padding, config.padding]];
+    } else {
+      config.padding = config.padding as [number, number] |
+          [[number, number], [number, number]];
+      if (config.padding.length !== 2) {
+        throw new ValueError(
+            `ZeroPadding2D expects padding to be a length-2 array, but ` +
+            `received a length-${config.padding.length} array.`);
+      }
+
+      let heightPadding: [number, number];
+      let widthPadding: [number, number];
+      if (typeof config.padding[0] === 'number') {
+        heightPadding =
+            [config.padding[0] as number, config.padding[0] as number];
+        widthPadding =
+            [config.padding[1] as number, config.padding[1] as number];
+      } else {
+        config.padding = config.padding as [[number, number], [number, number]];
+
+        if (config.padding[0].length !== 2) {
+          throw new ValueError(
+              `ZeroPadding2D expects height padding to be a length-2 array, ` +
+              `but received a length-${config.padding[0].length} array.`);
+        }
+        heightPadding = config.padding[0] as [number, number];
+
+        if (config.padding[1].length !== 2) {
+          throw new ValueError(
+              `ZeroPadding2D expects width padding to be a length-2 array, ` +
+              `but received a length-${config.padding[1].length} array.`);
+        }
+        widthPadding = config.padding[1] as [number, number];
+      }
+      this.padding = [heightPadding, widthPadding];
+    }
+    this.inputSpec = [new InputSpec({ndim: 4})];
+  }
+
+  computeOutputShape(inputShape: Shape|Shape[]): Shape|Shape[] {
+    inputShape = getExactlyOneShape(inputShape);
+
+    let rows: number;
+    let cols: number;
+    if (this.dataFormat === 'channelsFirst') {
+      if (inputShape[2] != null && inputShape[2] >= 0) {
+        rows = inputShape[2] + this.padding[0][0] + this.padding[0][1];
+      } else {
+        rows = null;
+      }
+      if (inputShape[3] != null && inputShape[3] >= 0) {
+        cols = inputShape[3] + this.padding[1][0] + this.padding[1][1];
+      } else {
+        cols = null;
+      }
+      return [inputShape[0], inputShape[1], rows, cols];
+    } else {
+      if (inputShape[1] != null && inputShape[1] >= 0) {
+        rows = inputShape[1] + this.padding[0][0] + this.padding[0][1];
+      } else {
+        rows = null;
+      }
+      if (inputShape[2] != null && inputShape[2] >= 0) {
+        cols = inputShape[2] + this.padding[1][0] + this.padding[1][1];
+      } else {
+        cols = null;
+      }
+      return [inputShape[0], rows, cols, inputShape[3]];
+    }
+  }
+
+  // tslint:disable-next-line:no-any
+  call(inputs: Tensor|Tensor[], kwargs: any): Tensor|Tensor[] {
+    return K.spatial2dPadding(
+        getExactlyOneTensor(inputs), this.padding, this.dataFormat);
+  }
+
+  getConfig(): ConfigDict {
+    const config: ConfigDict = {
+      padding: this.padding,
+      dataFormat: this.dataFormat,
+    };
+    const baseConfig = super.getConfig();
+    Object.assign(config, baseConfig);
+    return config;
+  }
+}
+ClassNameMap.register('ZeroPadding2D', ZeroPadding2D);

--- a/src/layers/padding.ts
+++ b/src/layers/padding.ts
@@ -41,7 +41,7 @@ export interface ZeroPadding2DLayerConfig extends LayerConfig {
   padding?: number|[number, number]|[[number, number], [number, number]];
 
   /**
-   * One of 'channelsLast' (default) and 'channelsFirst'.
+   * One of `'channelsLast'` (default) and `'channelsFirst'`.
    *
    * The ordering of the dimensions in the inputs.
    * `channelsLast` corresponds to inputs with shape

--- a/src/layers/padding.ts
+++ b/src/layers/padding.ts
@@ -84,6 +84,8 @@ export class ZeroPadding2D extends Layer {
 
     this.dataFormat =
         config.dataFormat == null ? imageDataFormat() : config.dataFormat;
+    // TODO(cais): Maybe refactor the following logic surrounding `padding`
+    //   into a helper method.
     if (config.padding == null) {
       this.padding = [[1, 1], [1, 1]];
     } else if (typeof config.padding === 'number') {

--- a/src/layers/padding_test.ts
+++ b/src/layers/padding_test.ts
@@ -123,7 +123,7 @@ describeMathCPUAndGPU('ZeroPadding2D: Tensor', () => {
         slice(y, [0, 0, 3, 0], [2, 4, 1, 3]), zeros([2, 4, 1, 3]));
   });
 
-  it('Default padding 1-1-1-1, channelsLast', () => {
+  it('Default padding 1-1-1-1, channelFirst', () => {
     const x = ones([2, 3, 2, 2]);
     const layer = new ZeroPadding2D({dataFormat: 'channelsFirst'});
     const y = layer.apply(x) as Tensor;

--- a/src/layers/padding_test.ts
+++ b/src/layers/padding_test.ts
@@ -1,0 +1,176 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ * =============================================================================
+ */
+
+/**
+ * Unit Tests for Padding Layers.
+ */
+
+// tslint:disable:max-line-length
+import {ones, slice, Tensor, zeros} from '@tensorflow/tfjs-core';
+
+import {DataFormat} from '../common';
+import {DType, SymbolicTensor} from '../types';
+import {convertPythonicToTs, convertTsToPythonic} from '../utils/serialization_utils';
+import {describeMathCPU, describeMathCPUAndGPU, expectTensorsClose} from '../utils/test_utils';
+
+import {ZeroPadding2D, ZeroPadding2DLayerConfig} from './padding';
+// tslint:enable:max-line-length
+
+describeMathCPU('ZeroPadding2D: Symbolic', () => {
+  const dataFormats: DataFormat[] =
+      [undefined, 'channelsFirst', 'channelsLast'];
+
+  for (const dataFormat in dataFormats) {
+    it('Default padding 1-1-1-1, dataFormat=' + dataFormat, () => {
+      const x = new SymbolicTensor(DType.float32, [1, 2, 3, 4], null, [], null);
+      const layer = new ZeroPadding2D();
+      const y = layer.apply(x) as SymbolicTensor;
+      expect(y.dtype).toEqual(DType.float32);
+      if (dataFormat === 'channelsFirst') {
+        expect(y.shape).toEqual([1, 2, 5, 6]);
+      } else {
+        expect(y.shape).toEqual([1, 4, 5, 4]);
+      }
+    });
+
+    it('All symmetric padding 2, dataFormat=' + dataFormat, () => {
+      const x = new SymbolicTensor(DType.float32, [1, 2, 3, 4], null, [], null);
+      const layer = new ZeroPadding2D({padding: 2});
+      const y = layer.apply(x) as SymbolicTensor;
+      expect(y.dtype).toEqual(DType.float32);
+      if (dataFormat === 'channelsFirst') {
+        expect(y.shape).toEqual([1, 6, 7, 8]);
+      } else {
+        expect(y.shape).toEqual([1, 6, 7, 4]);
+      }
+    });
+
+    it('Symmetric padding 2-3, dataFormat=' + dataFormat, () => {
+      const x = new SymbolicTensor(DType.float32, [1, 2, 3, 4], null, [], null);
+      const layer = new ZeroPadding2D({padding: [2, 3]});
+      const y = layer.apply(x) as SymbolicTensor;
+      expect(y.dtype).toEqual(DType.float32);
+      if (dataFormat === 'channelsFirst') {
+        expect(y.shape).toEqual([1, 2, 7, 10]);
+      } else {
+        expect(y.shape).toEqual([1, 6, 9, 4]);
+      }
+    });
+
+    it('Asymmetric padding 2-3-4-5, dataFormat=' + dataFormat, () => {
+      const x = new SymbolicTensor(DType.float32, [1, 2, 3, 4], null, [], null);
+      const layer = new ZeroPadding2D({padding: [[2, 3], [4, 5]]});
+      const y = layer.apply(x) as SymbolicTensor;
+      expect(y.dtype).toEqual(DType.float32);
+      if (dataFormat === 'channelsFirst') {
+        expect(y.shape).toEqual([1, 2, 7, 13]);
+      } else {
+        expect(y.shape).toEqual([1, 7, 12, 4]);
+      }
+    });
+  }
+
+  it('Incorrect array length leads to error', () => {
+    // tslint:disable-next-line:no-any
+    expect(() => new ZeroPadding2D({padding: [2, 3, 4]} as any))
+        .toThrowError(/length-2 array/);
+  });
+
+  it('Incorrect height array length leads to error', () => {
+    // tslint:disable-next-line:no-any
+    expect(() => new ZeroPadding2D({padding: [[2, 3, 4], [5, 6]]} as any))
+        .toThrowError(/height.*length-2 array/);
+  });
+
+  it('Incorrect height array length leads to error', () => {
+    // tslint:disable-next-line:no-any
+    expect(() => new ZeroPadding2D({padding: [[1, 1], [2, 3, 4]]} as any))
+        .toThrowError(/width.*length-2 array/);
+  });
+
+  it('Serialization round trip', () => {
+    const layer = new ZeroPadding2D({padding: [2, 4]});
+    const pythonicConfig = convertTsToPythonic(layer.getConfig());
+    const tsConfig = convertPythonicToTs(pythonicConfig);
+    const layerPrime = new ZeroPadding2D(tsConfig as ZeroPadding2DLayerConfig);
+    expect(layerPrime.padding).toEqual(layer.padding);
+    expect(layerPrime.dataFormat).toEqual(layer.dataFormat);
+  });
+});
+
+describeMathCPUAndGPU('ZeroPadding2D: Tensor', () => {
+  it('Default padding 1-1-1-1, channelsLast', () => {
+    const x = ones([2, 2, 2, 3]);
+    const layer = new ZeroPadding2D();
+    const y = layer.apply(x) as Tensor;
+    expect(y.shape).toEqual([2, 4, 4, 3]);
+
+    expectTensorsClose(slice(y, [0, 1, 1, 0], [2, 2, 2, 3]), x);
+    expectTensorsClose(
+        slice(y, [0, 0, 0, 0], [2, 1, 4, 3]), zeros([2, 1, 4, 3]));
+    expectTensorsClose(
+        slice(y, [0, 3, 0, 0], [2, 1, 4, 3]), zeros([2, 1, 4, 3]));
+    expectTensorsClose(
+        slice(y, [0, 0, 0, 0], [2, 4, 1, 3]), zeros([2, 4, 1, 3]));
+    expectTensorsClose(
+        slice(y, [0, 0, 3, 0], [2, 4, 1, 3]), zeros([2, 4, 1, 3]));
+  });
+
+  it('Default padding 1-1-1-1, channelsLast', () => {
+    const x = ones([2, 3, 2, 2]);
+    const layer = new ZeroPadding2D({dataFormat: 'channelsFirst'});
+    const y = layer.apply(x) as Tensor;
+    expect(y.shape).toEqual([2, 3, 4, 4]);
+
+    expectTensorsClose(slice(y, [0, 0, 1, 1], [2, 3, 2, 2]), x);
+    expectTensorsClose(
+        slice(y, [0, 0, 0, 0], [2, 3, 1, 4]), zeros([2, 3, 1, 4]));
+    expectTensorsClose(
+        slice(y, [0, 0, 3, 0], [2, 3, 1, 4]), zeros([2, 3, 1, 4]));
+    expectTensorsClose(
+        slice(y, [0, 0, 0, 0], [2, 3, 4, 1]), zeros([2, 3, 4, 1]));
+    expectTensorsClose(
+        slice(y, [0, 0, 0, 3], [2, 3, 4, 1]), zeros([2, 3, 4, 1]));
+  });
+
+  it('Symmetric padding 2-2, channelsLast', () => {
+    const x = ones([2, 2, 2, 3]);
+    const layer = new ZeroPadding2D({padding: [2, 2]});
+    const y = layer.apply(x) as Tensor;
+    expect(y.shape).toEqual([2, 6, 6, 3]);
+
+    expectTensorsClose(slice(y, [0, 2, 2, 0], [2, 2, 2, 3]), x);
+    expectTensorsClose(
+        slice(y, [0, 0, 0, 0], [2, 2, 6, 3]), zeros([2, 2, 6, 3]));
+    expectTensorsClose(
+        slice(y, [0, 4, 0, 0], [2, 2, 6, 3]), zeros([2, 2, 6, 3]));
+    expectTensorsClose(
+        slice(y, [0, 0, 0, 0], [2, 6, 2, 3]), zeros([2, 6, 2, 3]));
+    expectTensorsClose(
+        slice(y, [0, 0, 4, 0], [2, 6, 2, 3]), zeros([2, 6, 2, 3]));
+  });
+
+  it('Asymmetric padding 2-1-2-1, channelsLast', () => {
+    const x = ones([2, 2, 2, 3]);
+    const layer = new ZeroPadding2D({padding: [[2, 1], [2, 1]]});
+    const y = layer.apply(x) as Tensor;
+    expect(y.shape).toEqual([2, 5, 5, 3]);
+
+    expectTensorsClose(slice(y, [0, 2, 2, 0], [2, 2, 2, 3]), x);
+    expectTensorsClose(
+        slice(y, [0, 0, 0, 0], [2, 2, 5, 3]), zeros([2, 2, 5, 3]));
+    expectTensorsClose(
+        slice(y, [0, 4, 0, 0], [2, 1, 5, 3]), zeros([2, 1, 5, 3]));
+    expectTensorsClose(
+        slice(y, [0, 0, 0, 0], [2, 5, 2, 3]), zeros([2, 5, 2, 3]));
+    expectTensorsClose(
+        slice(y, [0, 0, 4, 0], [2, 5, 1, 3]), zeros([2, 5, 1, 3]));
+  });
+});

--- a/src/utils/serialization_utils.ts
+++ b/src/utils/serialization_utils.ts
@@ -74,7 +74,8 @@ export function convertPythonicToTs(
         tsDict[pythonicKey] = pythonicValue;
       } else {
         const tsKey = generic_utils.toCamelCase(pythonicKey);
-        if (generic_utils.SerializableEnumRegistry.contains(pythonicKey)) {
+        if (generic_utils.SerializableEnumRegistry.contains(pythonicKey) &&
+            (typeof pythonicValue === 'string' || pythonicValue == null)) {
           const enumValue = generic_utils.SerializableEnumRegistry.lookup(
               pythonicKey, pythonicValue as string);
           if (enumValue != null) {
@@ -131,7 +132,8 @@ export function convertTsToPythonic(
         // snake-case conversion.
         pyDict[pyKey] = tsValue;
       } else {
-        if (generic_utils.SerializableEnumRegistry.contains(pyKey)) {
+        if (generic_utils.SerializableEnumRegistry.contains(pyKey) &&
+            (typeof tsValue === 'string' || tsValue == null)) {
           const enumString =
               generic_utils.SerializableEnumRegistry.reverseLookup(
                   pyKey, tsValue);


### PR DESCRIPTION
* Add ZeroPadding2D layer and the supporting backend function
  spatial2dPadding
* Fix a wrong assumption in the TypeScript-Python config object
  conversion that the key 'padding' is always for the padding mode
  enum (e.g., 'same', 'valid'). It turns out that in some layers,
  like ZeroPadding2D, the 'padding' key is for a non-enum value.

Fixes: https://github.com/tensorflow/tfjs/issues/84

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/114)
<!-- Reviewable:end -->
