### PR TITLE
Fix duplicate weight names in Conv2DTranspose layer

### DIFF
--- a/integration_tests/benchmarks/build-benchmarks.sh
+++ b/integration_tests/benchmarks/build-benchmarks.sh
@@ -44,10 +44,12 @@ python "${DEMO_DIR}/python/benchmarks.py" "${DATA_ROOT}"
 
 echo Building local TensorFlow.js Layers NPM package...
 cd ../..
-yarn build-npm
+yarn build
+yarn link
 
 cd ${DEMO_DIR}
 yarn
+yarn link "@tensorflow/tfjs-layers"
 yarn build
 
 echo

--- a/integration_tests/benchmarks/package.json
+++ b/integration_tests/benchmarks/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@tensorflow/tfjs-core": "0.0.2",
-    "@tensorflow/tfjs-layers": "file:../../tensorflow-tfjs-layers-0.1.2.tgz",
+    "@tensorflow/tfjs-layers": "0.2.0",
     "vega-embed": "~3.0.0"
   },
   "scripts": {

--- a/integration_tests/benchmarks/yarn.lock
+++ b/integration_tests/benchmarks/yarn.lock
@@ -9,9 +9,9 @@
     seedrandom "~2.4.3"
     utf8 "~2.1.2"
 
-"@tensorflow/tfjs-layers@file:../../tensorflow-tfjs-layers-0.1.2.tgz":
-  version "0.1.2"
-  resolved "file:../../tensorflow-tfjs-layers-0.1.2.tgz#eb3e1fa2ca5cf569863f69b682534790a0a8505b"
+"@tensorflow/tfjs-layers@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-0.2.0.tgz#87114fe7e680b5cb87ca05f0119a21d2578f6b7f"
   dependencies:
     underscore "~1.8.3"
 

--- a/src/engine/topology.ts
+++ b/src/engine/topology.ts
@@ -363,6 +363,8 @@ export class Layer {
   private _built: boolean;
   private _callHook: CallHook = null;
 
+  private _addedWeightNames: string[] = [];
+
   readonly id: number;
 
   // Porting Notes: PyKeras does not have this property in this base Layer
@@ -1030,6 +1032,13 @@ export class Layer {
       name: string, shape: Shape, dtype?: DType, initializer?: Initializer,
       regularizer?: Regularizer, trainable?: boolean,
       constraint?: Constraint): LayerVariable {
+    // Reject duplicate weight names.
+    if (this._addedWeightNames.indexOf(name) !== -1) {
+      throw new ValueError(
+          `Duplicate weight name ${name} for layer ${this.name}`);
+    }
+    this._addedWeightNames.push(name);
+
     if (dtype == null) {
       dtype = K.floatx();
     }

--- a/src/layers/convolutional.ts
+++ b/src/layers/convolutional.ts
@@ -397,7 +397,7 @@ export class Conv2DTranspose extends Conv2D {
         this.kernelRegularizer, true, this.kernelConstraint);
     if (this.useBias) {
       this.bias = this.addWeight(
-          'kernel', [this.filters], DType.float32, this.biasInitializer,
+          'bias', [this.filters], DType.float32, this.biasInitializer,
           this.biasRegularizer, true, this.biasConstraint);
     }
 

--- a/src/layers/convolutional_test.ts
+++ b/src/layers/convolutional_test.ts
@@ -234,6 +234,16 @@ describeMathCPU('Conv2DTranspose: Symbolic', () => {
       }
     }
   }
+
+  it('Correct weight names', () => {
+    const x = new SymbolicTensor(DType.float32, [1, 2, 3, 4], null, [], null);
+    const layer = new Conv2DTranspose({filters: 2, kernelSize: [3, 3]});
+    layer.apply(x);  // Let the layer build first.
+
+    expect(layer.weights.length).toEqual(2);
+    expect(layer.weights[0].name.indexOf('/kernel')).toBeGreaterThan(0);
+    expect(layer.weights[1].name.indexOf('/bias')).toBeGreaterThan(0);
+  });
 });
 
 describeMathCPUAndGPU('Conv2DTranspose: Tensor', () => {


### PR DESCRIPTION
* The bias weight was incorrectly named as 'kernel', probably a
  copy-paste error.
* Add a sanity check for this kind of mistakes.
* Add unit test.

Also in this PR:

* Improve the way benchmarks are linked to the tfjs-layers package
  by using `yarn link`.

Fixes: https://github.com/tensorflow/tfjs/issues/99