### PR TITLE
Issues Template: Remove label issues from template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,6 +1,5 @@
-GitHub issues for this repository are tracked in the [tfjs union
-repository](https://github.com/tensorflow/tfjs/issues).
+To get help from the community, check out our [Google group](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs).
 
-Please file your issue there, following the guidance in [that issue
-template](https://github.com/tensorflow/tfjs/blob/master/ISSUE_TEMPLATE.md).
-Include a 'layers' tag to indicate that the issue is with tfjs-layers.
+GitHub issues for this repository are tracked in the [tfjs union repository](https://github.com/tensorflow/tfjs/issues).
+
+Please file your issue there, following the guidance in [that issue template](https://github.com/tensorflow/tfjs/blob/master/ISSUE_TEMPLATE.md).


### PR DESCRIPTION
This PR removes line regarding adding labels to issues since contributors are not allowed to do so. Also, adds Google Group's link and fixes the formatting of the template.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/124)
<!-- Reviewable:end -->
