### PR TITLE
Fix a bug in custom-loss support

### DIFF
--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -325,8 +325,8 @@ export function sliceArraysByIndices(
   } else {
     // TODO(cais): indices should be oa pre-constructed Tensor1D to avoid
     //   tensor1d() calls.
-    return K.gather(arrays,
-        indices.dtype === 'int32' ? indices : indices.toInt());
+    return K.gather(
+        arrays, indices.dtype === 'int32' ? indices : indices.toInt());
   }
 }
 
@@ -595,7 +595,8 @@ export interface ModelCompileConfig {
    * The loss value that will be minimized by the model will then be the sum
    * of all individual losses.
    */
-  loss: string|string[]|{[outputName: string]: string};
+  loss: string|string[]|{[outputName: string]: string}|LossOrMetricFn|
+      LossOrMetricFn[]|{[outputName: string]: LossOrMetricFn};
 
   /**
    * List of metrics to be evaluated by the model during training and testing.
@@ -622,7 +623,8 @@ export interface ModelCompileConfig {
 @doc({heading: 'Models', subheading: 'Classes'})
 export class Model extends Container {
   optimizer: Optimizer;
-  loss: string|string[]|{[outputName: string]: string};
+  loss: string|string[]|{[outputName: string]: string}|LossOrMetricFn|
+      LossOrMetricFn[]|{[outputName: string]: LossOrMetricFn};
   lossFunctions: LossOrMetricFn[];
 
   // TODO(cais): These private variables should probably not have the string
@@ -680,7 +682,8 @@ export class Model extends Container {
 
     // Prepare loss functions.
     let lossFunctions: LossOrMetricFn[] = [];
-    if (!Array.isArray(config.loss) && typeof config.loss !== 'string') {
+    if (!Array.isArray(config.loss) && typeof config.loss !== 'string' &&
+        typeof config.loss !== 'function') {
       config.loss = config.loss as {[outputName: string]: string};
       for (const name in config.loss) {
         if (this.outputNames.indexOf(name) === -1) {
@@ -705,7 +708,8 @@ export class Model extends Container {
             `model output. The model has ${this.outputs.length} output(s), ` +
             `but you passed loss=${config.loss}.`);
       }
-      lossFunctions = config.loss.map(l => losses.get(l));
+      const theLosses = config.loss as Array<string|LossOrMetricFn>;
+      lossFunctions = theLosses.map(l => losses.get(l));
     } else {
       const lossFunction = losses.get(config.loss);
       this.outputs.map(layer => {

--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -589,7 +589,7 @@ export interface ModelCompileConfig {
   optimizer: string|Optimizer;
 
   /**
-   * String (name of objective function) or objective function.
+   * Object function(s) or name(s) of object function(s).
    * If the model has multiple outputs, you can use a different loss
    * on each output by passing a dictionary or an Array of losses.
    * The loss value that will be minimized by the model will then be the sum

--- a/src/engine/training_test.ts
+++ b/src/engine/training_test.ts
@@ -13,7 +13,8 @@
  */
 
 // tslint:disable:max-line-length
-import {Scalar, scalar, SGDOptimizer, Tensor, tensor1d, tensor2d, tensor3d, zeros} from '@tensorflow/tfjs-core';
+import {abs, mean, Scalar, scalar, SGDOptimizer, Tensor, tensor1d, tensor2d, tensor3d, zeros} from '@tensorflow/tfjs-core';
+import {expectArraysClose} from '@tensorflow/tfjs-core/dist/test_util';
 
 import * as K from '../backend/tfjs_backend';
 import {CustomCallback, CustomCallbackConfig, Logs} from '../callbacks';
@@ -411,6 +412,53 @@ describeMathCPUAndGPU('Model.fit', () => {
              done.fail(err.stack);
            });
      });
+
+  it('training with custom loss', async done => {
+    // Use the following Python code snippet to get reference values
+    // for assertion:
+    //
+    // ```python
+    // import keras
+    // import keras.backend as K;
+    // import numpy as np
+    //
+    // def abs_diff_loss(x, y):
+    //   return K.mean(K.abs(x - y))
+    //
+    // input1 = keras.Input(shape=[4])
+    // layer = keras.layers.Dense(
+    //     units=1, use_bias=False, kernel_initializer='ones')
+    // output = layer(input1)
+    // model = keras.Model(input1, output)
+    // model.compile(optimizer='SGD', loss=abs_diff_loss)
+    // inputs = np.ones([5, 4])
+    // targets = np.ones([5])
+    // history = model.fit(
+    //     inputs, targets, batch_size=5, epochs=2,
+    //     validation_split=0.2)
+    // print(history.history)
+    // ```
+
+    createDenseModelAndData();
+
+    const absDiffLoss = (x: Tensor, y: Tensor) => mean(abs(x.sub(y)));
+
+    model.compile({optimizer: 'SGD', loss: absDiffLoss});
+    // Use batchSize === numSamples to get exactly one batch.
+    model
+        .fit(
+            inputs, targets,
+            {batchSize: numSamples, epochs: 2, validationSplit: 0.2})
+        .then(history => {
+          expectArraysClose(history.history['loss'] as number[], [3, 2.96]);
+          expectArraysClose(
+              history.history['val_loss'] as number[], [2.96, 2.92]);
+          done();
+        })
+        .catch(err => {
+          done.fail(err.stack);
+        });
+  });
 
   it('Using only x and y input arguments', async done => {
     createDenseModelAndData();

--- a/src/engine/training_test.ts
+++ b/src/engine/training_test.ts
@@ -13,8 +13,7 @@
  */
 
 // tslint:disable:max-line-length
-import {abs, mean, Scalar, scalar, SGDOptimizer, Tensor, tensor1d, tensor2d, tensor3d, zeros} from '@tensorflow/tfjs-core';
-import {expectArraysClose} from '@tensorflow/tfjs-core/dist/test_util';
+import {abs, mean, Scalar, scalar, SGDOptimizer, Tensor, tensor1d, tensor2d, tensor3d, test_util, zeros} from '@tensorflow/tfjs-core';
 
 import * as K from '../backend/tfjs_backend';
 import {CustomCallback, CustomCallbackConfig, Logs} from '../callbacks';
@@ -450,8 +449,9 @@ describeMathCPUAndGPU('Model.fit', () => {
             inputs, targets,
             {batchSize: numSamples, epochs: 2, validationSplit: 0.2})
         .then(history => {
-          expectArraysClose(history.history['loss'] as number[], [3, 2.96]);
-          expectArraysClose(
+          test_util.expectArraysClose(
+              history.history['loss'] as number[], [3, 2.96]);
+          test_util.expectArraysClose(
               history.history['val_loss'] as number[], [2.96, 2.92]);
           done();
         })

--- a/src/losses.ts
+++ b/src/losses.ts
@@ -137,7 +137,7 @@ export const cosine = cosineProximity;
 
 // Porting note: This diverges from the PyKeras implementation and may need to
 // change based on (de)serialization requirements.
-export function get(identifier: string): LossOrMetricFn {
+export function get(identifierOrFn: string|LossOrMetricFn): LossOrMetricFn {
   const lossesMap: {[functionName: string]: LossOrMetricFn} = {
     meanSquaredError,
     meanAbsoluteError,
@@ -154,8 +154,12 @@ export function get(identifier: string): LossOrMetricFn {
     poisson,
     cosineProximity
   };
-  if (identifier in lossesMap) {
-    return lossesMap[identifier];
+  if (typeof identifierOrFn === 'string') {
+    if (identifierOrFn in lossesMap) {
+      return lossesMap[identifierOrFn];
+    }
+    throw new ValueError(`Unknown loss ${identifierOrFn}`);
+  } else {
+    return identifierOrFn;
   }
-  throw new ValueError(`Unknown loss ${identifier}`);
 }

--- a/src/losses_test.ts
+++ b/src/losses_test.ts
@@ -12,7 +12,7 @@
  * Unit tests for activations.ts.
  */
 
-import {scalar, tensor1d, tensor2d, zeros} from '@tensorflow/tfjs-core';
+import {scalar, Tensor, tensor1d, tensor2d, zeros} from '@tensorflow/tfjs-core';
 
 import * as K from './backend/tfjs_backend';
 import * as losses from './losses';
@@ -247,4 +247,9 @@ describe('losses get', () => {
       losses.get(lossName);
     });
   }
+
+  it(`get custom loss works`, () => {
+    const customLoss = (x: Tensor, y: Tensor) => scalar(42.0);
+    expect(losses.get(customLoss)).toEqual(customLoss);
+  });
 });


### PR DESCRIPTION
* losses.get() now does the correct thing when a custom loss function is
  passed in

Fixes: https://github.com/tensorflow/tfjs/issues/198

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/131)
<!-- Reviewable:end -->
