### PR TITLE
Add some print-outs to a code snippet

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -484,6 +484,7 @@ export class Sequential extends Model {
    *   batchSize: 4,
    *   epochs: 3
    * });
+   * console.log(history.history.loss);
    * ```
    *
    * @param x `Tensor` of training data, or an array of `Tensor`s if the model


### PR DESCRIPTION
The code snippet for Sequential.fit() did not have any
printed messages previously, which was confusing.

This PR fixes that.