### PR TITLE
Export Shape type alias: tf.Shape

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export {Callback, CallbackList, CustomCallback, CustomCallbackConfig, Logs} from
 export {Model, ModelCompileConfig, ModelEvaluateConfig, ModelFitConfig, ModelPredictConfig} from './engine/training';
 export {GRUCellLayerConfig, GRULayerConfig, LSTMCellLayerConfig, LSTMLayerConfig, RNN, RNNLayerConfig, SimpleRNNCellLayerConfig, SimpleRNNLayerConfig} from './layers/recurrent';
 export {ModelAndWeightsConfig, Sequential, SequentialConfig} from './models';
-export {SymbolicTensor} from './types';
+export {Shape, SymbolicTensor} from './types';
 export {version as version_layers} from './version';
 
 export {backend};


### PR DESCRIPTION
This would be useful to users even tho it's such a simple type alias.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/142)
<!-- Reviewable:end -->
