### PR TITLE
Simplify the calling contract of ClassNameMap.register

### DIFF
--- a/src/constraints.ts
+++ b/src/constraints.ts
@@ -71,6 +71,7 @@ export interface MaxNormConfig {
  * 2014](http://www.cs.toronto.edu/~rsalakhu/papers/srivastava14a.pdf)
  */
 export class MaxNorm extends Constraint {
+  static readonly className = 'MaxNorm';
   private maxValue: number;
   private axis: number;
   private readonly defaultMaxValue = 2;
@@ -92,7 +93,7 @@ export class MaxNorm extends Constraint {
   }
 
   getClassName(): string {
-    return 'MaxNorm';
+    return MaxNorm.className;
   }
 
   getConfig(): ConfigDict {
@@ -123,9 +124,9 @@ export interface UnitNormConfig {
  * Constrains the weights incident to each hidden unit to have unit norm.
  */
 export class UnitNorm extends Constraint {
+  static readonly className = 'UnitNorm';
   private axis: number;
   private readonly defaultAxis = 0;
-
   constructor(config: UnitNormConfig) {
     super();
     this.axis = config.axis != null ? config.axis : this.defaultAxis;
@@ -138,7 +139,7 @@ export class UnitNorm extends Constraint {
   }
 
   getClassName(): string {
-    return 'UnitNorm';
+    return UnitNorm.className;
   }
 
   getConfig(): ConfigDict {
@@ -151,11 +152,12 @@ ClassNameMap.register(UnitNorm);
  * Constains the weight to be non-negative.
  */
 export class NonNeg extends Constraint {
+  static readonly className = 'NonNeg';
   apply(w: Tensor): Tensor {
     return K.relu(w);
   }
   getClassName(): string {
-    return 'NonNeg';
+    return NonNeg.className;
   }
 }
 ClassNameMap.register(NonNeg);
@@ -195,6 +197,7 @@ export interface MinMaxNormConfig {
 }
 
 export class MinMaxNorm extends Constraint {
+  static readonly className = 'MinMaxNorm';
   private minValue: number;
   private maxValue: number;
   private rate: number;
@@ -227,7 +230,7 @@ export class MinMaxNorm extends Constraint {
   }
 
   getClassName(): string {
-    return 'MinMaxNorm';
+    return MinMaxNorm.className;
   }
 
   getConfig(): ConfigDict {

--- a/src/constraints.ts
+++ b/src/constraints.ts
@@ -99,7 +99,7 @@ export class MaxNorm extends Constraint {
     return {maxValue: this.maxValue, axis: this.axis};
   }
 }
-ClassNameMap.register('MaxNorm', MaxNorm);
+ClassNameMap.register(MaxNorm);
 
 export interface UnitNormConfig {
   /**
@@ -145,7 +145,7 @@ export class UnitNorm extends Constraint {
     return {axis: this.axis};
   }
 }
-ClassNameMap.register('UnitNorm', UnitNorm);
+ClassNameMap.register(UnitNorm);
 
 /**
  * Constains the weight to be non-negative.
@@ -158,7 +158,7 @@ export class NonNeg extends Constraint {
     return 'NonNeg';
   }
 }
-ClassNameMap.register('NonNeg', NonNeg);
+ClassNameMap.register(NonNeg);
 
 export interface MinMaxNormConfig {
   /**
@@ -239,7 +239,7 @@ export class MinMaxNorm extends Constraint {
     };
   }
 }
-ClassNameMap.register('MinMaxNorm', MinMaxNorm);
+ClassNameMap.register(MinMaxNorm);
 
 /** @docinline */
 export type ConstraintIdentifier =

--- a/src/engine/topology.ts
+++ b/src/engine/topology.ts
@@ -1236,11 +1236,6 @@ export abstract class Layer extends Serializable {
     }
     return config;
   }
-
-  static fromConfig<T extends Serializable>(
-      cls: Constructor<T>, config: ConfigDict): T {
-    return new cls(config);
-  }
 }
 
 /**

--- a/src/engine/topology.ts
+++ b/src/engine/topology.ts
@@ -1412,7 +1412,7 @@ export class InputLayer extends Layer {
     };
   }
 }
-generic_utils.ClassNameMap.register('InputLayer', InputLayer);
+generic_utils.ClassNameMap.register(InputLayer);
 
 /**
  * Config for the Input function.

--- a/src/engine/topology.ts
+++ b/src/engine/topology.ts
@@ -19,7 +19,7 @@ import {AttributeError, NotImplementedError, RuntimeError, ValueError} from '../
 import {Initializer} from '../initializers';
 import {deserialize as deserializeLayer} from '../layers/serialization';
 import {Regularizer} from '../regularizers';
-import {ConfigDict, DType, JsonDict, LayerVariable, NamedTensorMap, RegularizerFn, Serializable, Shape, SymbolicTensor, TensorInterface} from '../types';
+import {ConfigDict, Constructor, DType, JsonDict, LayerVariable, NamedTensorMap, RegularizerFn, Serializable, Shape, SymbolicTensor, TensorInterface} from '../types';
 import * as generic_utils from '../utils/generic_utils';
 import {convertTsToPythonic} from '../utils/serialization_utils';
 // tslint:enable:max-line-length
@@ -1237,8 +1237,8 @@ export abstract class Layer extends Serializable {
     return config;
   }
 
-  static fromConfig<T>(cls: generic_utils.Constructor<T>, config: ConfigDict):
-      T {
+  static fromConfig<T extends Serializable>(
+      cls: Constructor<T>, config: ConfigDict): T {
     return new cls(config);
   }
 }
@@ -1321,6 +1321,7 @@ export interface InputLayerConfig {
  * ```
  */
 export class InputLayer extends Layer {
+  static readonly className = 'InputLayer';
   sparse: boolean;
   constructor(config: InputLayerConfig) {
     super({
@@ -1401,7 +1402,7 @@ export class InputLayer extends Layer {
   }
 
   getClassName(): string {
-    return 'InputLayer';
+    return InputLayer.className;
   }
   getConfig(): ConfigDict {
     return {
@@ -2490,8 +2491,8 @@ export abstract class Container extends Layer {
    * @returns A model instance.
    * @throws ValueError: In case of improperly formatted config dict.
    */
-  static fromConfig<T>(cls: generic_utils.Constructor<T>, config: ConfigDict):
-      T {
+  static fromConfig<T extends Serializable>(
+      cls: Constructor<T>, config: ConfigDict): T {
     // Layer instances created during
     // the graph reconstruction process
     const createdLayers: {[layerName: string]: Layer} = {};

--- a/src/engine/topology_test.ts
+++ b/src/engine/topology_test.ts
@@ -1035,7 +1035,8 @@ describeMathCPUAndGPU('Container.fromConfig', () => {
       outputLayers: [] as any[]
     };
     // tslint:enable
-    const container = Container.fromConfig(ContainerForTest, config);
+    const container =
+        Container.fromConfig(ContainerForTest, config) as Container;
     expect(container.name).toEqual('test');
   });
 
@@ -1091,7 +1092,8 @@ describeMathCPUAndGPU('Container.fromConfig', () => {
       name: 'test',
       outputLayers: [['dense_2', 0, 0]]
     };
-    const container = Container.fromConfig(ContainerForTest, config);
+    const container =
+        Container.fromConfig(ContainerForTest, config) as Container;
     expect(container.name).toEqual('test');
     const allZeros = zeros([1, 32]);
     expectTensorsClose(container.apply(allZeros) as Tensor, allZeros);

--- a/src/engine/topology_test.ts
+++ b/src/engine/topology_test.ts
@@ -22,20 +22,22 @@ import {Container, ContainerConfig, getSourceInputs, Input, InputLayer, InputSpe
 // tslint:enable
 
 class LayerForTest extends tfl.layers.Layer {
+  static className = 'LayerForTest';
   constructor(config: LayerConfig) {
     super(config);
   }
   getClassName(): string {
-    return 'Layer';
+    return LayerForTest.className;
   }
 }
 
 class ContainerForTest extends Container {
+  static className = 'ContainerForTest';
   constructor(config: ContainerConfig) {
     super(config);
   }
   getClassName(): string {
-    return 'Container';
+    return ContainerForTest.className;
   }
 }
 

--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -622,6 +622,7 @@ export interface ModelCompileConfig {
  */
 @doc({heading: 'Models', subheading: 'Classes'})
 export class Model extends Container {
+  static className = 'Model';
   optimizer: Optimizer;
   loss: string|string[]|{[outputName: string]: string}|LossOrMetricFn|
       LossOrMetricFn[]|{[outputName: string]: LossOrMetricFn};
@@ -653,7 +654,7 @@ export class Model extends Container {
   }
 
   getClassName(): string {
-    return 'Model';
+    return Model.className;
   }
 
   /**

--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -1641,4 +1641,4 @@ export class Model extends Container {
   }
 }
 
-ClassNameMap.register('Model', Model);
+ClassNameMap.register(Model);

--- a/src/initializers.ts
+++ b/src/initializers.ts
@@ -59,7 +59,6 @@ export function checkDistribution(value?: string): void {
 @doc(
     {heading: 'Initializers', subheading: 'Classes', namespace: 'initializers'})
 export abstract class Initializer extends Serializable {
-  static className = 'Override';
   public fromConfigUsesCustomObjects(): boolean {
     return false;
   }

--- a/src/initializers.ts
+++ b/src/initializers.ts
@@ -90,7 +90,7 @@ export class Zeros extends Initializer {
     return K.zeros(shape, dtype);
   }
 }
-ClassNameMap.register('Zeros', Zeros);
+ClassNameMap.register(Zeros);
 
 /**
  * Initializer that generates tensors initialized to 1.
@@ -103,7 +103,7 @@ export class Ones extends Initializer {
     return K.ones(shape, dtype);
   }
 }
-ClassNameMap.register('Ones', Ones);
+ClassNameMap.register(Ones);
 
 export interface ConstantConfig {
   /** The value for each element in the variable. */
@@ -135,7 +135,7 @@ export class Constant extends Initializer {
     };
   }
 }
-ClassNameMap.register('Constant', Constant);
+ClassNameMap.register(Constant);
 
 export interface RandomUniformConfig {
   /** Lower bound of the range of random values to generate. */
@@ -179,7 +179,7 @@ export class RandomUniform extends Initializer {
     return {minval: this.minval, maxval: this.maxval, seed: this.seed};
   }
 }
-ClassNameMap.register('RandomUniform', RandomUniform);
+ClassNameMap.register(RandomUniform);
 
 export interface RandomNormalConfig {
   /** Mean of the random values to generate. */
@@ -219,7 +219,7 @@ export class RandomNormal extends Initializer {
     return {mean: this.mean, stddev: this.stddev, seed: this.seed};
   }
 }
-ClassNameMap.register('RandomNormal', RandomNormal);
+ClassNameMap.register(RandomNormal);
 
 export interface TruncatedNormalConfig {
   /** Mean of the random values to generate. */
@@ -264,7 +264,7 @@ export class TruncatedNormal extends Initializer {
     return {mean: this.mean, stddev: this.stddev, seed: this.seed};
   }
 }
-ClassNameMap.register('TruncatedNormal', TruncatedNormal);
+ClassNameMap.register(TruncatedNormal);
 
 export interface IdentityConfig {
   /**
@@ -299,7 +299,7 @@ export class Identity extends Initializer {
     return {gain: this.gain.get()};
   }
 }
-ClassNameMap.register('Identity', Identity);
+ClassNameMap.register(Identity);
 
 /**
  * Computes the number of input and output units for a weight shape.
@@ -421,7 +421,7 @@ export class VarianceScaling extends Initializer {
     };
   }
 }
-ClassNameMap.register('VarianceScaling', VarianceScaling);
+ClassNameMap.register(VarianceScaling);
 
 export interface SeedOnlyInitializerConfig {
   /** Random number generator seed. */
@@ -456,7 +456,7 @@ export class GlorotUniform extends VarianceScaling {
     });
   }
 }
-ClassNameMap.register('GlorotUniform', GlorotUniform);
+ClassNameMap.register(GlorotUniform);
 
 /**
  * Glorot normal initializer, also called Xavier normal initializer.
@@ -486,7 +486,7 @@ export class GlorotNormal extends VarianceScaling {
     });
   }
 }
-ClassNameMap.register('GlorotNormal', GlorotNormal);
+ClassNameMap.register(GlorotNormal);
 
 /**
  * He normal initializer.
@@ -504,7 +504,7 @@ export class HeNormal extends VarianceScaling {
         {scale: 2.0, mode: 'fanIn', distribution: 'normal', seed: config.seed});
   }
 }
-ClassNameMap.register('HeNormal', HeNormal);
+ClassNameMap.register(HeNormal);
 
 /**
  * LeCun normal initializer.
@@ -523,7 +523,7 @@ export class LeCunNormal extends VarianceScaling {
         {scale: 1.0, mode: 'fanIn', distribution: 'normal', seed: config.seed});
   }
 }
-ClassNameMap.register('LeCunNormal', LeCunNormal);
+ClassNameMap.register(LeCunNormal);
 
 export interface OrthogonalConfig extends SeedOnlyInitializerConfig {
   /**
@@ -583,7 +583,7 @@ export class Orthogonal extends Initializer {
     };
   }
 }
-ClassNameMap.register('Orthogonal', Orthogonal);
+ClassNameMap.register(Orthogonal);
 
 /** @docinline */
 export type InitializerIdentifier = 'constant'|'glorotNormal'|'glorotUniform'|

--- a/src/initializers_test.ts
+++ b/src/initializers_test.ts
@@ -17,7 +17,7 @@ import {Tensor2D, tensor2d} from '@tensorflow/tfjs-core';
 
 import * as K from './backend/tfjs_backend';
 import * as tfl from './index';
-import {checkDistribution, checkFanMode, getInitializer, serializeInitializer, VALID_DISTRIBUTION_VALUES, VALID_FAN_MODE_VALUES} from './initializers';
+import {checkDistribution, checkFanMode, getInitializer, serializeInitializer, VALID_DISTRIBUTION_VALUES, VALID_FAN_MODE_VALUES, VarianceScaling} from './initializers';
 import {DType} from './types';
 import {ConfigDict} from './types';
 import * as math_utils from './utils/math_utils';
@@ -197,6 +197,7 @@ describeMathCPU('HeNormal initializer', () => {
     expect(weights.shape).toEqual(shape);
     expect(weights.dtype).toEqual(DType.float32);
     expectTensorsValuesInRange(weights, -2 * stddev, 2 * stddev);
+    expect(init.getClassName()).toEqual(VarianceScaling.className);
   });
 
   it('default, upper case', () => {
@@ -217,6 +218,7 @@ describeMathCPU('LecunNormal initializer', () => {
     expect(weights.shape).toEqual(shape);
     expect(weights.dtype).toEqual(DType.float32);
     expectTensorsValuesInRange(weights, -2 * stddev, 2 * stddev);
+    expect(init.getClassName()).toEqual(VarianceScaling.className);
   });
 
   it('default, upper case', () => {
@@ -282,6 +284,7 @@ describeMathCPU('Glorot uniform initializer', () => {
           .toBeLessThan(limit);
       expect(math_utils.min(weights.dataSync() as Float32Array))
           .toBeGreaterThan(-limit);
+      expect(init.getClassName()).toEqual(VarianceScaling.className);
     });
 
     it('2D ' + initializer, () => {
@@ -324,6 +327,7 @@ describeMathCPU('Glorot normal initializer', () => {
       const variance2 = math_utils.variance(weights.dataSync() as Float32Array);
 
       expect(variance2).toBeLessThan(variance1);
+      expect(init.getClassName()).toEqual(VarianceScaling.className);
     });
 
     it('2D ' + initializer, () => {

--- a/src/layers/advanced_activations.ts
+++ b/src/layers/advanced_activations.ts
@@ -78,7 +78,7 @@ export class LeakyReLU extends Layer {
     return config;
   }
 }
-generic_utils.ClassNameMap.register('LeakyReLU', LeakyReLU);
+generic_utils.ClassNameMap.register(LeakyReLU);
 
 // TODO(cais): Implement PReLU
 
@@ -148,7 +148,7 @@ export class ELU extends Layer {
     return config;
   }
 }
-generic_utils.ClassNameMap.register('ELU', ELU);
+generic_utils.ClassNameMap.register(ELU);
 
 export interface ThresholdedReLULayerConfig extends LayerConfig {
   /**
@@ -212,7 +212,7 @@ export class ThresholdedReLU extends Layer {
     return config;
   }
 }
-generic_utils.ClassNameMap.register('ThresholdedReLU', ThresholdedReLU);
+generic_utils.ClassNameMap.register(ThresholdedReLU);
 
 export interface SoftmaxLayerConfig extends LayerConfig {
   /**
@@ -267,4 +267,4 @@ export class Softmax extends Layer {
     return config;
   }
 }
-generic_utils.ClassNameMap.register('Softmax', Softmax);
+generic_utils.ClassNameMap.register(Softmax);

--- a/src/layers/advanced_activations.ts
+++ b/src/layers/advanced_activations.ts
@@ -44,6 +44,7 @@ export interface LeakyReLULayerConfig extends LayerConfig {
  *   Same shape as the input.
  */
 export class LeakyReLU extends Layer {
+  static className = 'LeakyReLU';
   readonly alpha: number;
 
   readonly DEFAULT_ALPHA = 0.3;
@@ -68,7 +69,7 @@ export class LeakyReLU extends Layer {
   }
 
   getClassName(): string {
-    return 'LeakyReLU';
+    return LeakyReLU.className;
   }
 
   getConfig(): ConfigDict {
@@ -108,6 +109,7 @@ export interface ELULayerConfig extends LayerConfig {
  * (ELUs)](https://arxiv.org/abs/1511.07289v1)
  */
 export class ELU extends Layer {
+  static className = 'ELU';
   readonly alpha: number;
 
   readonly DEFAULT_ALPHA = 1.0;
@@ -138,7 +140,7 @@ export class ELU extends Layer {
   }
 
   getClassName(): string {
-    return 'ELU';
+    return ELU.className;
   }
 
   getConfig(): ConfigDict {
@@ -176,6 +178,7 @@ export interface ThresholdedReLULayerConfig extends LayerConfig {
  * Features](http://arxiv.org/abs/1402.3337)
  */
 export class ThresholdedReLU extends Layer {
+  static className = 'ThresholdedReLU';
   readonly theta: number;
   private readonly thetaTensor: Tensor;
 
@@ -202,7 +205,7 @@ export class ThresholdedReLU extends Layer {
   }
 
   getClassName(): string {
-    return 'ThresholdedReLU';
+    return ThresholdedReLU.className;
   }
 
   getConfig(): ConfigDict {
@@ -233,6 +236,7 @@ export interface SoftmaxLayerConfig extends LayerConfig {
  *   Same shape as the input.
  */
 export class Softmax extends Layer {
+  static className = 'Softmax';
   readonly axis: number;
 
   readonly DEFAULT_AXIS = 1.0;
@@ -257,7 +261,7 @@ export class Softmax extends Layer {
   }
 
   getClassName(): string {
-    return 'Softmax';
+    return Softmax.className;
   }
 
   getConfig(): ConfigDict {

--- a/src/layers/convolutional.ts
+++ b/src/layers/convolutional.ts
@@ -327,12 +327,13 @@ export abstract class Conv extends Layer {
  * in `dataFormat='channelsLast'`.
  */
 export class Conv2D extends Conv {
+  static className = 'Conv2D';
   constructor(config: ConvLayerConfig) {
     super(2, config);
   }
 
   getClassName(): string {
-    return 'Conv2D';
+    return Conv2D.className;
   }
 
   getConfig(): ConfigDict {
@@ -376,6 +377,7 @@ generic_utils.ClassNameMap.register(Conv2D);
  * Networks](http://www.matthewzeiler.com/pubs/cvpr2010/cvpr2010.pdf)
  */
 export class Conv2DTranspose extends Conv2D {
+  static className = 'Conv2DTranspose';
   inputSpec: InputSpec[];
 
   constructor(config: ConvLayerConfig) {
@@ -390,7 +392,7 @@ export class Conv2DTranspose extends Conv2D {
   }
 
   getClassName(): string {
-    return 'Conv2DTranspose';
+    return Conv2DTranspose.className;
   }
 
 
@@ -757,11 +759,12 @@ export class SeparableConv extends Conv {
  *     `rows` and `cols` values might have changed due to padding.
  */
 export class SeparableConv2D extends SeparableConv {
+  static className = 'SeparableConv2D';
   constructor(config?: SeparableConvLayerConfig) {
     super(2, config);
   }
   getClassName(): string {
-    return 'SeparableConv2D';
+    return SeparableConv2D.className;
   }
 }
 generic_utils.ClassNameMap.register(SeparableConv2D);
@@ -785,13 +788,14 @@ generic_utils.ClassNameMap.register(SeparableConv2D);
  * - `[null, 128]` for variable-length sequences of 128-dimensional vectors.
  */
 export class Conv1D extends Conv {
+  static className = 'Conv1D';
   constructor(config: ConvLayerConfig) {
     super(1, config);
     this.inputSpec = [{ndim: 3}];
   }
 
   getClassName(): string {
-    return 'Conv1D';
+    return Conv1D.className;
   }
 
   getConfig(): ConfigDict {

--- a/src/layers/convolutional.ts
+++ b/src/layers/convolutional.ts
@@ -341,7 +341,7 @@ export class Conv2D extends Conv {
     return config;
   }
 }
-generic_utils.ClassNameMap.register('Conv2D', Conv2D);
+generic_utils.ClassNameMap.register(Conv2D);
 
 /**
  * Transposed convolutional layer (sometimes called Deconvolution).
@@ -525,7 +525,7 @@ export class Conv2DTranspose extends Conv2D {
     return config;
   }
 }
-generic_utils.ClassNameMap.register('Conv2DTranspose', Conv2DTranspose);
+generic_utils.ClassNameMap.register(Conv2DTranspose);
 
 
 export interface SeparableConvLayerConfig extends ConvLayerConfig {
@@ -764,7 +764,7 @@ export class SeparableConv2D extends SeparableConv {
     return 'SeparableConv2D';
   }
 }
-generic_utils.ClassNameMap.register('SeparableConv2D', SeparableConv2D);
+generic_utils.ClassNameMap.register(SeparableConv2D);
 
 /**
  * 1D convolution layer (e.g., temporal convolution).
@@ -801,4 +801,4 @@ export class Conv1D extends Conv {
     return config;
   }
 }
-generic_utils.ClassNameMap.register('Conv1D', Conv1D);
+generic_utils.ClassNameMap.register(Conv1D);

--- a/src/layers/convolutional_depthwise.ts
+++ b/src/layers/convolutional_depthwise.ts
@@ -72,6 +72,7 @@ export interface DepthwiseConv2DLayerConfig extends ConvLayerConfig {
  * are generated per input channel in the depthwise step.
  */
 export class DepthwiseConv2D extends Conv2D {
+  static className = 'DepthwiseConv2D';
   private readonly depthMultiplier: number;
   private readonly depthwiseInitializer: Initializer;
   private readonly depthwiseConstraint: Constraint;
@@ -89,7 +90,7 @@ export class DepthwiseConv2D extends Conv2D {
     this.depthwiseRegularizer = getRegularizer(config.depthwiseRegularizer);
   }
   getClassName(): string {
-    return 'DepthwiseConv2D';
+    return DepthwiseConv2D.className;
   }
 
   build(inputShape: Shape|Shape[]): void {

--- a/src/layers/convolutional_depthwise.ts
+++ b/src/layers/convolutional_depthwise.ts
@@ -161,4 +161,4 @@ export class DepthwiseConv2D extends Conv2D {
     }
   }
 }
-generic_utils.ClassNameMap.register('DepthwiseConv2D', DepthwiseConv2D);
+generic_utils.ClassNameMap.register(DepthwiseConv2D);

--- a/src/layers/core.ts
+++ b/src/layers/core.ts
@@ -126,7 +126,7 @@ export class Dropout extends Layer {
     return config;
   }
 }
-generic_utils.ClassNameMap.register('Dropout', Dropout);
+generic_utils.ClassNameMap.register(Dropout);
 
 export interface DenseLayerConfig extends LayerConfig {
   /** Positive integer, dimensionality of the output space. */
@@ -319,7 +319,7 @@ export class Dense extends Layer {
     return config;
   }
 }
-generic_utils.ClassNameMap.register('Dense', Dense);
+generic_utils.ClassNameMap.register(Dense);
 
 /**
  * Flattens the input. Does not affect the batch size.
@@ -368,7 +368,7 @@ export class Flatten extends Layer {
     return K.batchFlatten(generic_utils.getExactlyOneTensor(inputs));
   }
 }
-generic_utils.ClassNameMap.register('Flatten', Flatten);
+generic_utils.ClassNameMap.register(Flatten);
 
 export interface ActivationLayerConfig extends LayerConfig {
   /**
@@ -400,7 +400,7 @@ export class Activation extends Layer {
     return this.activation(input);
   }
 }
-generic_utils.ClassNameMap.register('Activation', Activation);
+generic_utils.ClassNameMap.register(Activation);
 
 export interface ReshapeLayerConfig extends LayerConfig {
   /** The target shape. Does not include the batch axis. */
@@ -450,7 +450,7 @@ export class RepeatVector extends Layer {
     return config;
   }
 }
-generic_utils.ClassNameMap.register('RepeatVector', RepeatVector);
+generic_utils.ClassNameMap.register(RepeatVector);
 
 
 /**
@@ -562,4 +562,4 @@ export class Reshape extends Layer {
     return K.reshape(input, outputShape);
   }
 }
-generic_utils.ClassNameMap.register('Reshape', Reshape);
+generic_utils.ClassNameMap.register(Reshape);

--- a/src/layers/core.ts
+++ b/src/layers/core.ts
@@ -56,6 +56,7 @@ export interface DropoutLayerConfig extends LayerConfig {
  * each update during training time, which helps prevent overfitting.
  */
 export class Dropout extends Layer {
+  static className = 'Dropout';
   private readonly rate: number;
   private readonly rateScalar: Scalar;
   private readonly noiseShape: number[];
@@ -112,7 +113,7 @@ export class Dropout extends Layer {
   }
 
   getClassName(): string {
-    return 'Dropout';
+    return Dropout.className;
   }
 
   getConfig(): ConfigDict {
@@ -210,6 +211,7 @@ export interface DenseLayerConfig extends LayerConfig {
  * flattened prior to the initial dot product with the kernel.
  */
 export class Dense extends Layer {
+  static className = 'Dense';
   private units: number;
   // Default activation: Linear (none).
   private activation: ActivationFn = null;
@@ -298,7 +300,7 @@ export class Dense extends Layer {
   }
 
   getClassName(): string {
-    return 'Dense';
+    return Dense.className;
   }
 
   getConfig(): ConfigDict {
@@ -339,6 +341,7 @@ generic_utils.ClassNameMap.register(Dense);
  * ```
  */
 export class Flatten extends Layer {
+  static className = 'Flatten';
   constructor(config?: LayerConfig) {
     super(config || {});
     this.inputSpec = [{minNDim: 3}];
@@ -359,7 +362,7 @@ export class Flatten extends Layer {
   }
 
   getClassName(): string {
-    return 'Flatten';
+    return Flatten.className;
   }
 
   // tslint:disable-next-line:no-any
@@ -381,6 +384,7 @@ export interface ActivationLayerConfig extends LayerConfig {
  * Applies an activation function to an output.
  */
 export class Activation extends Layer {
+  static className = 'Activation';
   activation: ActivationFn;
 
   constructor(config: ActivationLayerConfig) {
@@ -390,7 +394,7 @@ export class Activation extends Layer {
   }
 
   getClassName(): string {
-    return 'Activation';
+    return Activation.className;
   }
 
   // tslint:disable-next-line:no-any
@@ -419,6 +423,7 @@ export interface RepeatVectorLayerConfig extends LayerConfig {
  */
 // TODO(cais): Add example.
 export class RepeatVector extends Layer {
+  static className = 'RepeatVector';
   readonly n: number;
 
   constructor(config: RepeatVectorLayerConfig) {
@@ -438,7 +443,7 @@ export class RepeatVector extends Layer {
   }
 
   getClassName(): string {
-    return 'RepeatVector';
+    return RepeatVector.className;
   }
 
   getConfig(): ConfigDict {
@@ -467,6 +472,7 @@ generic_utils.ClassNameMap.register(RepeatVector);
  *    targetShape[targetShape.length - 1]].
  */
 export class Reshape extends Layer {
+  static className = 'Reshape';
   private targetShape: Shape;
 
   constructor(config: ReshapeLayerConfig) {
@@ -548,7 +554,7 @@ export class Reshape extends Layer {
   }
 
   getClassName(): string {
-    return 'Reshape';
+    return Reshape.className;
   }
 
 

--- a/src/layers/embeddings.ts
+++ b/src/layers/embeddings.ts
@@ -206,4 +206,4 @@ export class Embedding extends Layer {
   }
 }
 
-generic_utils.ClassNameMap.register('Embedding', Embedding);
+generic_utils.ClassNameMap.register(Embedding);

--- a/src/layers/embeddings.ts
+++ b/src/layers/embeddings.ts
@@ -84,6 +84,7 @@ export interface EmbeddingLayerConfig extends LayerConfig {
  * outputDim]`.
  */
 export class Embedding extends Layer {
+  static className = 'Embedding';
   private inputDim: number;
   private outputDim: number;
   private embeddingsInitializer: Initializer;
@@ -186,7 +187,7 @@ export class Embedding extends Layer {
   }
 
   getClassName(): string {
-    return 'Embedding';
+    return Embedding.className;
   }
 
   getConfig(): ConfigDict {

--- a/src/layers/merge.ts
+++ b/src/layers/merge.ts
@@ -266,7 +266,7 @@ export class Add extends Merge {
     return output;
   }
 }
-generic_utils.ClassNameMap.register('Add', Add);
+generic_utils.ClassNameMap.register(Add);
 
 /**
  * Calculate the element-wise sum of inputs, which all have the same shape.
@@ -359,7 +359,7 @@ export class Multiply extends Merge {
     return output;
   }
 }
-generic_utils.ClassNameMap.register('Multiply', Multiply);
+generic_utils.ClassNameMap.register(Multiply);
 
 /**
  * Calculate the element-wise product of inputs, which all have the same shape.
@@ -451,7 +451,7 @@ export class Average extends Merge {
     return K.scalarTimesArray(K.getScalar(1 / inputs.length), output);
   }
 }
-generic_utils.ClassNameMap.register('Average', Average);
+generic_utils.ClassNameMap.register(Average);
 
 /**
  * Calculate the element-wise arithmetic mean of inputs, which all have the same
@@ -544,7 +544,7 @@ export class Maximum extends Merge {
     return output;
   }
 }
-generic_utils.ClassNameMap.register('Maximum', Maximum);
+generic_utils.ClassNameMap.register(Maximum);
 
 /**
  * Calculate the element-wise maximum of inputs, which all have the same shape.
@@ -636,7 +636,7 @@ export class Minimum extends Merge {
     return output;
   }
 }
-generic_utils.ClassNameMap.register('Minimum', Minimum);
+generic_utils.ClassNameMap.register(Minimum);
 
 /**
  * Calculate the element-wise minimum of inputs, which all have the same shape.
@@ -809,7 +809,7 @@ export class Concatenate extends Merge {
   // TODO(cais): Implement computeMask();
   // TODO(cais): Add getConfig();
 }
-generic_utils.ClassNameMap.register('Concatenate', Concatenate);
+generic_utils.ClassNameMap.register(Concatenate);
 
 /**
  * Concatenate an `Array` of inputs.

--- a/src/layers/merge.ts
+++ b/src/layers/merge.ts
@@ -26,16 +26,12 @@ import * as mathUtils from '../utils/math_utils';
  *
  * Used to implement `Sum`, `Average`, `Concatenate`, etc.
  */
-export class Merge extends Layer {
+export abstract class Merge extends Layer {
   protected reshapeRequired: boolean;
 
   constructor(config?: LayerConfig) {
     super(config || {});
     this.supportsMasking = true;
-  }
-
-  getClassName(): string {
-    return 'Merge';
   }
 
   /**
@@ -250,12 +246,13 @@ export class Merge extends Layer {
  * ```
  */
 export class Add extends Merge {
+  static className = 'Add';
   constructor(config?: LayerConfig) {
     super(config as LayerConfig);
   }
 
   getClassName(): string {
-    return 'Add';
+    return Add.className;
   }
 
   protected mergeFunction(inputs: Tensor[]): Tensor {
@@ -343,12 +340,13 @@ export function add(config?: SymbolicTensor[]|Tensor[]|LayerConfig): Layer|
  * // dimension.
  */
 export class Multiply extends Merge {
+  static className = 'Multiply';
   constructor(config?: LayerConfig) {
     super(config);
   }
 
   getClassName(): string {
-    return 'Multiply';
+    return Multiply.className;
   }
 
   protected mergeFunction(inputs: Tensor[]): Tensor {
@@ -435,12 +433,13 @@ export function multiply(config?: SymbolicTensor[]|Tensor[]|LayerConfig): Layer|
  * ```
  */
 export class Average extends Merge {
+  static className = 'Average';
   constructor(config?: LayerConfig) {
     super(config);
   }
 
   getClassName(): string {
-    return 'Average';
+    return Average.className;
   }
 
   protected mergeFunction(inputs: Tensor[]): Tensor {
@@ -528,12 +527,13 @@ export function average(config?: SymbolicTensor[]|Tensor[]|LayerConfig): Layer|
  * ```
  */
 export class Maximum extends Merge {
+  static className = 'Maximum';
   constructor(config?: LayerConfig) {
     super(config);
   }
 
   getClassName(): string {
-    return 'Maximum';
+    return Maximum.className;
   }
 
   protected mergeFunction(inputs: Tensor[]): Tensor {
@@ -620,12 +620,13 @@ export function maximum(config?: SymbolicTensor[]|Tensor[]|LayerConfig): Layer|
  * ```
  */
 export class Minimum extends Merge {
+  static className = 'Minimum';
   constructor(config?: LayerConfig) {
     super(config);
   }
 
   getClassName(): string {
-    return 'Minimum';
+    return Minimum.className;
   }
 
   protected mergeFunction(inputs: Tensor[]): Tensor {
@@ -721,6 +722,7 @@ export interface ConcatenateLayerConfig extends LayerConfig {
  * ```
  */
 export class Concatenate extends Merge {
+  static className = 'Concatenate';
   readonly DEFAULT_AXIS = -1;
   private readonly axis: number;
 
@@ -735,7 +737,7 @@ export class Concatenate extends Merge {
   }
 
   getClassName(): string {
-    return 'Concatenate';
+    return Concatenate.className;
   }
 
   build(inputShape: Shape|Shape[]): void {

--- a/src/layers/normalization.ts
+++ b/src/layers/normalization.ts
@@ -130,6 +130,7 @@ export interface BatchNormalizationLayerConfig extends LayerConfig {
  * Internal Covariate Shift](https://arxiv.org/abs/1502.03167)
  */
 export class BatchNormalization extends Layer {
+  static className = 'BatchNormalization';
   private readonly axis: number;
   private readonly momentum: number;
   private readonly epsilon: number;
@@ -247,7 +248,7 @@ export class BatchNormalization extends Layer {
   }
 
   getClassName(): string {
-    return 'BatchNormalization';
+    return BatchNormalization.className;
   }
 
   getConfig(): ConfigDict {

--- a/src/layers/normalization.ts
+++ b/src/layers/normalization.ts
@@ -272,4 +272,4 @@ export class BatchNormalization extends Layer {
     return config;
   }
 }
-generic_utils.ClassNameMap.register('BatchNormalization', BatchNormalization);
+generic_utils.ClassNameMap.register(BatchNormalization);

--- a/src/layers/padding.ts
+++ b/src/layers/padding.ts
@@ -73,6 +73,7 @@ export interface ZeroPadding2DLayerConfig extends LayerConfig {
  *     `[batch, channels, paddedRows, paddedCols]`.
  */
 export class ZeroPadding2D extends Layer {
+  static className = 'ZeroPadding2D';
   readonly dataFormat: DataFormat;
   readonly padding: [[number, number], [number, number]];
 
@@ -168,7 +169,7 @@ export class ZeroPadding2D extends Layer {
   }
 
   getClassName(): string {
-    return 'ZeroPadding2D';
+    return ZeroPadding2D.className;
   }
 
   getConfig(): ConfigDict {

--- a/src/layers/padding.ts
+++ b/src/layers/padding.ts
@@ -181,4 +181,4 @@ export class ZeroPadding2D extends Layer {
     return config;
   }
 }
-ClassNameMap.register('ZeroPadding2D', ZeroPadding2D);
+ClassNameMap.register(ZeroPadding2D);

--- a/src/layers/pooling.ts
+++ b/src/layers/pooling.ts
@@ -125,7 +125,7 @@ export class MaxPooling1D extends Pooling1D {
     return K.pool2d(inputs, poolSize, strides, padding, dataFormat, 'max');
   }
 }
-generic_utils.ClassNameMap.register('MaxPooling1D', MaxPooling1D);
+generic_utils.ClassNameMap.register(MaxPooling1D);
 
 /**
  * Average pooling operation for spatial data.
@@ -153,7 +153,7 @@ export class AveragePooling1D extends Pooling1D {
     return K.pool2d(inputs, poolSize, strides, padding, dataFormat, 'avg');
   }
 }
-generic_utils.ClassNameMap.register('AveragePooling1D', AveragePooling1D);
+generic_utils.ClassNameMap.register(AveragePooling1D);
 
 export interface Pooling2DLayerConfig extends LayerConfig {
   /**
@@ -285,7 +285,7 @@ export class MaxPooling2D extends Pooling2D {
     return K.pool2d(inputs, poolSize, strides, padding, dataFormat, 'max');
   }
 }
-generic_utils.ClassNameMap.register('MaxPooling2D', MaxPooling2D);
+generic_utils.ClassNameMap.register(MaxPooling2D);
 
 /**
  * Average pooling operation for spatial data.
@@ -325,7 +325,7 @@ export class AveragePooling2D extends Pooling2D {
     return K.pool2d(inputs, poolSize, strides, padding, dataFormat, 'avg');
   }
 }
-generic_utils.ClassNameMap.register('AveragePooling2D', AveragePooling2D);
+generic_utils.ClassNameMap.register(AveragePooling2D);
 
 /**
  * Abstract class for different global pooling 1D layers.
@@ -368,8 +368,7 @@ export class GlobalAveragePooling1D extends GlobalPooling1D {
     return K.mean(input, 1);
   }
 }
-generic_utils.ClassNameMap.register(
-    'GlobalAveragePooling1D', GlobalAveragePooling1D);
+generic_utils.ClassNameMap.register(GlobalAveragePooling1D);
 
 /**
  * Global max pooling operation for temporal data.
@@ -393,7 +392,7 @@ export class GlobalMaxPooling1D extends GlobalPooling1D {
     return K.max(input, 1);
   }
 }
-generic_utils.ClassNameMap.register('GlobalMaxPooling1D', GlobalMaxPooling1D);
+generic_utils.ClassNameMap.register(GlobalMaxPooling1D);
 
 export interface GlobalPooling2DLayerConfig extends LayerConfig {
   /**
@@ -468,8 +467,7 @@ export class GlobalAveragePooling2D extends GlobalPooling2D {
     return 'GlobalAveragePooling2D';
   }
 }
-generic_utils.ClassNameMap.register(
-    'GlobalAveragePooling2D', GlobalAveragePooling2D);
+generic_utils.ClassNameMap.register(GlobalAveragePooling2D);
 
 /**
  * Global max pooling operation for spatial data.
@@ -497,4 +495,4 @@ export class GlobalMaxPooling2D extends GlobalPooling2D {
     return 'GlobalMaxPooling2D';
   }
 }
-generic_utils.ClassNameMap.register('GlobalMaxPooling2D', GlobalMaxPooling2D);
+generic_utils.ClassNameMap.register(GlobalMaxPooling2D);

--- a/src/layers/pooling.ts
+++ b/src/layers/pooling.ts
@@ -383,7 +383,7 @@ generic_utils.ClassNameMap.register(GlobalAveragePooling1D);
  * Output Shape:2D tensor with shape: `[batchSize, features]`.
  */
 export class GlobalMaxPooling1D extends GlobalPooling1D {
-  static className = 'GlobalMaxPooling1D'
+  static className = 'GlobalMaxPooling1D';
   constructor(config: LayerConfig) {
     super(config);
   }

--- a/src/layers/pooling.ts
+++ b/src/layers/pooling.ts
@@ -109,12 +109,13 @@ export abstract class Pooling1D extends Layer {
  * Output shape: `[batchSize, pooledLength, channels]`
  */
 export class MaxPooling1D extends Pooling1D {
+  static className = 'MaxPooling1D';
   constructor(config: Pooling1DLayerConfig) {
     super(config);
   }
 
   getClassName(): string {
-    return 'MaxPooling1D';
+    return MaxPooling1D.className;
   }
 
   protected poolingFunction(
@@ -137,12 +138,13 @@ generic_utils.ClassNameMap.register(MaxPooling1D);
  * `tf.avgPool1d` is an alias.
  */
 export class AveragePooling1D extends Pooling1D {
+  static className = 'AveragePooling1D';
   constructor(config: Pooling1DLayerConfig) {
     super(config);
   }
 
   getClassName(): string {
-    return 'AveragePooling1D';
+    return AveragePooling1D.className;
   }
 
   protected poolingFunction(
@@ -269,12 +271,13 @@ export abstract class Pooling2D extends Layer {
  *       `[batchSize, channels, pooleRows, pooledCols]`
  */
 export class MaxPooling2D extends Pooling2D {
+  static className = 'MaxPooling2D';
   constructor(config: Pooling2DLayerConfig) {
     super(config);
   }
 
   getClassName(): string {
-    return 'MaxPooling2D';
+    return MaxPooling2D.className;
   }
 
   protected poolingFunction(
@@ -309,12 +312,13 @@ generic_utils.ClassNameMap.register(MaxPooling2D);
  * `tf.avgPool2d` is an alias.
  */
 export class AveragePooling2D extends Pooling2D {
+  static className = 'AveragePooing2D';
   constructor(config: Pooling2DLayerConfig) {
     super(config);
   }
 
   getClassName(): string {
-    return 'AveragePooling2D';
+    return AveragePooling2D.className;
   }
 
   protected poolingFunction(
@@ -354,12 +358,13 @@ export abstract class GlobalPooling1D extends Layer {
  * Output Shape:2D tensor with shape: `[batchSize, features]`.
  */
 export class GlobalAveragePooling1D extends GlobalPooling1D {
+  static className = 'GlobalAveragePooling1D';
   constructor(config: LayerConfig) {
     super(config);
   }
 
   getClassName(): string {
-    return 'GlobalAveragePooling1D';
+    return GlobalAveragePooling1D.className;
   }
 
   // tslint:disable-next-line:no-any
@@ -378,12 +383,13 @@ generic_utils.ClassNameMap.register(GlobalAveragePooling1D);
  * Output Shape:2D tensor with shape: `[batchSize, features]`.
  */
 export class GlobalMaxPooling1D extends GlobalPooling1D {
+  static className = 'GlobalMaxPooling1D'
   constructor(config: LayerConfig) {
     super(config);
   }
 
   getClassName(): string {
-    return 'GlobalMaxPooling1D';
+    return GlobalMaxPooling1D.className;
   }
 
   // tslint:disable-next-line:no-any
@@ -454,6 +460,7 @@ export abstract class GlobalPooling2D extends Layer {
  *   2D tensor with shape: `[batchSize, channels]`.
  */
 export class GlobalAveragePooling2D extends GlobalPooling2D {
+  static className = 'GlobalAveragePooling2D';
   // tslint:disable-next-line:no-any
   call(inputs: Tensor|Tensor[], kwargs: any): Tensor|Tensor[] {
     const input = generic_utils.getExactlyOneTensor(inputs);
@@ -464,7 +471,7 @@ export class GlobalAveragePooling2D extends GlobalPooling2D {
     }
   }
   getClassName(): string {
-    return 'GlobalAveragePooling2D';
+    return GlobalAveragePooling2D.className;
   }
 }
 generic_utils.ClassNameMap.register(GlobalAveragePooling2D);
@@ -482,6 +489,7 @@ generic_utils.ClassNameMap.register(GlobalAveragePooling2D);
  *   2D tensor with shape: `[batchSize, channels]`.
  */
 export class GlobalMaxPooling2D extends GlobalPooling2D {
+  static className = 'GlobalMaxPooling2D';
   // tslint:disable-next-line:no-any
   call(inputs: Tensor|Tensor[], kwargs: any): Tensor|Tensor[] {
     const input = generic_utils.getExactlyOneTensor(inputs);
@@ -492,7 +500,7 @@ export class GlobalMaxPooling2D extends GlobalPooling2D {
     }
   }
   getClassName(): string {
-    return 'GlobalMaxPooling2D';
+    return GlobalMaxPooling2D.className;
   }
 }
 generic_utils.ClassNameMap.register(GlobalMaxPooling2D);

--- a/src/layers/recurrent.ts
+++ b/src/layers/recurrent.ts
@@ -645,7 +645,7 @@ export class RNN extends Layer {
     return config;
   }
 }
-generic_utils.ClassNameMap.register('RNN', RNN);
+generic_utils.ClassNameMap.register(RNN);
 
 /**
  * An RNNCell layer.
@@ -933,7 +933,7 @@ export class SimpleRNNCell extends RNNCell {
     return config;
   }
 }
-generic_utils.ClassNameMap.register('SimpleRNNCell', SimpleRNNCell);
+generic_utils.ClassNameMap.register(SimpleRNNCell);
 
 export interface SimpleRNNLayerConfig extends BaseRNNLayerConfig {
   /**
@@ -1139,7 +1139,7 @@ export class SimpleRNN extends RNN {
     return config;
   }
 }
-generic_utils.ClassNameMap.register('SimpleRNN', SimpleRNN);
+generic_utils.ClassNameMap.register(SimpleRNN);
 
 // Porting Note: Since this is a superset of SimpleRNNLayerConfig, we extend
 //   that interface instead of repeating the fields.
@@ -1430,7 +1430,7 @@ export class GRUCell extends RNNCell {
     return config;
   }
 }
-generic_utils.ClassNameMap.register('GRUCell', GRUCell);
+generic_utils.ClassNameMap.register(GRUCell);
 
 // Porting Note: Since this is a superset of SimpleRNNLayerConfig, we inherit
 //   from that interface instead of repeating the fields here.
@@ -1587,7 +1587,7 @@ export class GRU extends RNN {
     return new cls(config);
   }
 }
-generic_utils.ClassNameMap.register('GRU', GRU);
+generic_utils.ClassNameMap.register(GRU);
 
 // Porting Note: Since this is a superset of SimpleRNNLayerConfig, we extend
 //   that interface instead of repeating the fields.
@@ -1917,7 +1917,7 @@ export class LSTMCell extends RNNCell {
     return config;
   }
 }
-generic_utils.ClassNameMap.register('LSTMCell', LSTMCell);
+generic_utils.ClassNameMap.register(LSTMCell);
 
 // Porting Note: Since this is a superset of SimpleRNNLayerConfig, we inherit
 //   from that interface instead of repeating the fields here.
@@ -2086,7 +2086,7 @@ export class LSTM extends RNN {
     return new cls(config);
   }
 }
-generic_utils.ClassNameMap.register('LSTM', LSTM);
+generic_utils.ClassNameMap.register(LSTM);
 
 export interface StackedRNNCellsConfig extends LayerConfig {
   /**
@@ -2272,4 +2272,4 @@ export class StackedRNNCells extends RNNCell {
 
   // TODO(cais): Maybe implemnt `losses` and `getLossesFor`.
 }
-generic_utils.ClassNameMap.register('StackedRNNCells', StackedRNNCells);
+generic_utils.ClassNameMap.register(StackedRNNCells);

--- a/src/layers/recurrent.ts
+++ b/src/layers/recurrent.ts
@@ -23,8 +23,8 @@ import {Layer, LayerConfig} from '../engine/topology';
 import {AttributeError, NotImplementedError, ValueError} from '../errors';
 import {getInitializer, Initializer, InitializerIdentifier, Ones, serializeInitializer} from '../initializers';
 import {getRegularizer, Regularizer, RegularizerIdentifier, serializeRegularizer} from '../regularizers';
-import {DType, Shape, SymbolicTensor} from '../types';
-import {ConfigDict, LayerVariable} from '../types';
+import {DType, Serializable, Shape, SymbolicTensor} from '../types';
+import {ConfigDict, Constructor, LayerVariable} from '../types';
 import * as generic_utils from '../utils/generic_utils';
 import * as math_utils from '../utils/math_utils';
 
@@ -178,6 +178,7 @@ export interface RNNLayerConfig extends BaseRNNLayerConfig {
  *   (not changing over time), a.k.a an attention mechanism.
  */
 export class RNN extends Layer {
+  static className = 'RNN';
   public readonly cell: RNNCell;
   public readonly returnSequences: boolean;
   public readonly returnState: boolean;
@@ -621,7 +622,7 @@ export class RNN extends Layer {
   }
 
   getClassName(): string {
-    return 'RNN';
+    return RNN.className;
   }
 
   getConfig(): ConfigDict {
@@ -784,6 +785,7 @@ export interface SimpleRNNCellLayerConfig extends LayerConfig {
  * `tf.layers.simpleRNN`.
  */
 export class SimpleRNNCell extends RNNCell {
+  static className = 'SimpleRNNCell';
   readonly units: number;
   readonly activation: ActivationFn;
   readonly useBias: boolean;
@@ -907,7 +909,7 @@ export class SimpleRNNCell extends RNNCell {
   }
 
   getClassName(): string {
-    return 'SimpleRNNCell';
+    return SimpleRNNCell.className;
   }
 
   getConfig(): ConfigDict {
@@ -1038,6 +1040,7 @@ export interface SimpleRNNLayerConfig extends BaseRNNLayerConfig {
  * ```
  */
 export class SimpleRNN extends RNN {
+  static className = 'SimpleRNN';
   constructor(config: SimpleRNNLayerConfig) {
     config.cell = new SimpleRNNCell(config);
     super(config as RNNLayerConfig);
@@ -1113,7 +1116,7 @@ export class SimpleRNN extends RNN {
   }
 
   getClassName(): string {
-    return 'SimpleRNN';
+    return SimpleRNN.className;
   }
 
   getConfig(): ConfigDict {
@@ -1210,6 +1213,7 @@ export interface GRUCellLayerConfig extends SimpleRNNCellLayerConfig {
  * `tf.layers.gru`.
  */
 export class GRUCell extends RNNCell {
+  static className = 'GRUCell';
   readonly units: number;
   readonly activation: ActivationFn;
   readonly recurrentActivation: ActivationFn;
@@ -1403,7 +1407,7 @@ export class GRUCell extends RNNCell {
   }
 
   getClassName(): string {
-    return 'GRUCell';
+    return GRUCell.className;
   }
 
   getConfig(): ConfigDict {
@@ -1470,6 +1474,7 @@ export interface GRULayerConfig extends SimpleRNNLayerConfig {
  * // 3rd dimension is the `GRUCell`'s number of units.
  */
 export class GRU extends RNN {
+  static className = 'GRU';
   constructor(config: GRULayerConfig) {
     if (config.implementation === 0) {
       console.warn(
@@ -1552,7 +1557,7 @@ export class GRU extends RNN {
   }
 
   getClassName(): string {
-    return 'GRU';
+    return GRU.className;
   }
 
   getConfig(): ConfigDict {
@@ -1579,8 +1584,8 @@ export class GRU extends RNN {
     return config;
   }
 
-  static fromConfig<T>(cls: generic_utils.Constructor<T>, config: ConfigDict):
-      T {
+  static fromConfig<T extends Serializable>(
+      cls: Constructor<T>, config: ConfigDict): T {
     if (config['implmentation'] === 0) {
       config['implementation'] = 1;
     }
@@ -1667,6 +1672,7 @@ export interface LSTMCellLayerConfig extends SimpleRNNCellLayerConfig {
  * `tf.layers.lstm`.
  */
 export class LSTMCell extends RNNCell {
+  static className = 'LSTMCell';
   readonly units: number;
   readonly activation: ActivationFn;
   readonly recurrentActivation: ActivationFn;
@@ -1889,7 +1895,7 @@ export class LSTMCell extends RNNCell {
   }
 
   getClassName(): string {
-    return 'LSTMCell';
+    return LSTMCell.className;
   }
 
   getConfig(): ConfigDict {
@@ -1964,6 +1970,7 @@ export interface LSTMLayerConfig extends SimpleRNNLayerConfig {
  * // 3rd dimension is the `LSTMCell`'s number of units.
  */
 export class LSTM extends RNN {
+  static className = 'LSTM';
   constructor(config: LSTMLayerConfig) {
     if (config.implementation as number === 0) {
       console.warn(
@@ -2050,7 +2057,7 @@ export class LSTM extends RNN {
   }
 
   getClassName(): string {
-    return 'LSTM';
+    return LSTM.className;
   }
 
   getConfig(): ConfigDict {
@@ -2078,8 +2085,8 @@ export class LSTM extends RNN {
     return config;
   }
 
-  static fromConfig<T>(cls: generic_utils.Constructor<T>, config: ConfigDict):
-      T {
+  static fromConfig<T extends Serializable>(
+      cls: Constructor<T>, config: ConfigDict): T {
     if (config['implmentation'] === 0) {
       config['implementation'] = 1;
     }
@@ -2101,6 +2108,7 @@ export interface StackedRNNCellsConfig extends LayerConfig {
  * Used to implement efficient stacked RNNs.
  */
 export class StackedRNNCells extends RNNCell {
+  static className = 'StackedRNNCells';
   protected cells: RNNCell[];
 
   constructor(config: StackedRNNCellsConfig) {
@@ -2186,7 +2194,7 @@ export class StackedRNNCells extends RNNCell {
   }
 
   getClassName(): string {
-    return 'StackedRNNCells';
+    return StackedRNNCells.className;
   }
 
   getConfig(): ConfigDict {
@@ -2203,8 +2211,8 @@ export class StackedRNNCells extends RNNCell {
     return config;
   }
 
-  static fromConfig<T>(
-      cls: generic_utils.Constructor<T>, config: ConfigDict,
+  static fromConfig<T extends Serializable>(
+      cls: Constructor<T>, config: ConfigDict,
       customObjects = {} as ConfigDict): T {
     const cells: RNNCell[] = [];
     for (const cellConfig of (config['cells'] as ConfigDict[])) {

--- a/src/layers/wrappers.ts
+++ b/src/layers/wrappers.ts
@@ -235,7 +235,7 @@ export class TimeDistributed extends Wrapper {
     return 'TimeDistributed';
   }
 }
-generic_utils.ClassNameMap.register('TimeDistributed', TimeDistributed);
+generic_utils.ClassNameMap.register(TimeDistributed);
 
 export enum BidirectionalMergeMode {
   SUM,
@@ -474,4 +474,4 @@ export class Bidirectional extends Wrapper {
   // TODO(cais): Implement constraints().
   // TODO(cais): Implement getConfig().
 }
-generic_utils.ClassNameMap.register('Bidirectional', Bidirectional);
+generic_utils.ClassNameMap.register(Bidirectional);

--- a/src/layers/wrappers.ts
+++ b/src/layers/wrappers.ts
@@ -18,8 +18,8 @@ import {Tensor} from '@tensorflow/tfjs-core';
 import * as K from '../backend/tfjs_backend';
 import {Layer, LayerConfig} from '../engine/topology';
 import {NotImplementedError, ValueError} from '../errors';
-import {Shape, TensorInterface} from '../types';
-import {ConfigDict, LayerVariable, RegularizerFn, RnnStepFunction, SymbolicTensor} from '../types';
+import {Serializable, Shape, TensorInterface} from '../types';
+import {ConfigDict, Constructor, LayerVariable, RegularizerFn, RnnStepFunction, SymbolicTensor} from '../types';
 import * as generic_utils from '../utils/generic_utils';
 
 import {RNN} from './recurrent';
@@ -125,8 +125,8 @@ export abstract class Wrapper extends Layer {
     return config;
   }
 
-  static fromConfig<T>(
-      cls: generic_utils.Constructor<T>, config: ConfigDict,
+  static fromConfig<T extends Serializable>(
+      cls: Constructor<T>, config: ConfigDict,
       customObjects = {} as ConfigDict): T {
     const layerConfig = config['layer'] as ConfigDict;
     const layer = deserialize(layerConfig, customObjects) as Layer;
@@ -182,6 +182,7 @@ export abstract class Wrapper extends Layer {
  * ```
  */
 export class TimeDistributed extends Wrapper {
+  static className = 'TimeDistributed';
   constructor(config: WrapperLayerConfig) {
     super(config);
     this.supportsMasking = true;
@@ -232,7 +233,7 @@ export class TimeDistributed extends Wrapper {
     return y;
   }
   getClassName(): string {
-    return 'TimeDistributed';
+    return TimeDistributed.className;
   }
 }
 generic_utils.ClassNameMap.register(TimeDistributed);
@@ -265,6 +266,7 @@ export interface BidirectionalLayerConfig extends WrapperLayerConfig {
 }
 
 export class Bidirectional extends Wrapper {
+  static className = 'Bidirectional';
   private forwardLayer: RNN;
   private backwardLayer: RNN;
   private mergeMode: BidirectionalMergeMode;
@@ -468,7 +470,7 @@ export class Bidirectional extends Wrapper {
         this.backwardLayer.nonTrainableWeights);
   }
   getClassName(): string {
-    return 'Bidirectional';
+    return Bidirectional.className;
   }
 
   // TODO(cais): Implement constraints().

--- a/src/models.ts
+++ b/src/models.ts
@@ -19,8 +19,8 @@ import {getSourceInputs, Input, Layer, Node} from './engine/topology';
 import {Model, ModelCompileConfig, ModelEvaluateConfig, ModelFitConfig, ModelPredictConfig} from './engine/training';
 import {RuntimeError, ValueError} from './errors';
 import {deserialize} from './layers/serialization';
-import {NamedTensorMap, Shape} from './types';
-import {ConfigDict, ConfigDictArray, JsonDict, SymbolicTensor} from './types';
+import {NamedTensorMap, Serializable, Shape} from './types';
+import {ConfigDict, ConfigDictArray, Constructor, JsonDict, SymbolicTensor} from './types';
 import * as generic_utils from './utils/generic_utils';
 import {convertPythonicToTs} from './utils/serialization_utils';
 // tslint:enable:max-line-length
@@ -166,6 +166,7 @@ export interface SequentialConfig {
  */
 @doc({heading: 'Models', subheading: 'Classes'})
 export class Sequential extends Model {
+  static className = 'Sequential';
   private model: Model;
   private _updatable: boolean;
   constructor(config?: SequentialConfig) {
@@ -187,7 +188,7 @@ export class Sequential extends Model {
     }
   }
   getClassName(): string {
-    return 'Sequential';
+    return Sequential.className;
   }
   /**
    * Adds a layer instance on top of the layer stack.
@@ -517,8 +518,8 @@ export class Sequential extends Model {
   }
 
   /* See parent class for JsDoc */
-  static fromConfig<T>(cls: generic_utils.Constructor<T>, config: ConfigDict):
-      T {
+  static fromConfig<T extends Serializable>(
+      cls: Constructor<T>, config: ConfigDict): T {
     const model = new cls({});
     if (!(model instanceof Sequential)) {
       throw new ValueError(

--- a/src/models.ts
+++ b/src/models.ts
@@ -555,4 +555,4 @@ export class Sequential extends Model {
     return config;
   }
 }
-generic_utils.ClassNameMap.register('Sequential', Sequential);
+generic_utils.ClassNameMap.register(Sequential);

--- a/src/regularizers.ts
+++ b/src/regularizers.ts
@@ -14,8 +14,7 @@
 import {doc, Scalar, Tensor, zeros} from '@tensorflow/tfjs-core';
 
 import * as K from './backend/tfjs_backend';
-import {ConfigDict, ConfigDictValue, Serializable} from './types';
-import * as generic_utils from './utils/generic_utils';
+import {ConfigDict, ConfigDictValue, Constructor, Serializable} from './types';
 import {ClassNameMap, deserializeKerasObject, serializeKerasObject} from './utils/generic_utils';
 // tslint:enable:max-line-length
 
@@ -51,6 +50,7 @@ export interface L2Config {
  */
 @doc({heading: 'Regularizers', namespace: 'regularizers'})
 export class L1L2 extends Regularizer {
+  static className = 'L1L2';
   private readonly l1: Scalar;
   private readonly l2: Scalar;
   private readonly hasL1: boolean;
@@ -83,14 +83,14 @@ export class L1L2 extends Regularizer {
     return regularization.asScalar();
   }
   getClassName(): string {
-    return 'L1L2';
+    return L1L2.className;
   }
   getConfig(): ConfigDict {
     return {'l1': this.l1.dataSync()[0], 'l2': this.l2.dataSync()[0]};
   }
-  static fromConfig(cls: generic_utils.Constructor<L1L2>, config: ConfigDict):
-      L1L2 {
-    return new L1L2({l1: config.l1 as number, l2: config.l2 as number});
+  static fromConfig<T extends Serializable>(
+      cls: Constructor<T>, config: ConfigDict): T {
+    return new cls({l1: config.l1 as number, l2: config.l2 as number});
   }
 }
 ClassNameMap.register(L1L2);

--- a/src/regularizers.ts
+++ b/src/regularizers.ts
@@ -93,7 +93,7 @@ export class L1L2 extends Regularizer {
     return new L1L2({l1: config.l1 as number, l2: config.l2 as number});
   }
 }
-ClassNameMap.register('L1L2', L1L2);
+ClassNameMap.register(L1L2);
 
 /**
  * Regularizer for L1 regularization.

--- a/src/types.ts
+++ b/src/types.ts
@@ -321,7 +321,10 @@ export type NamedTensorMap = {
 };
 
 /**
- * Type to represent class constructors.
+ * Type to represent the class-type of Serializable objects.
+ *
+ * Ie the class prototype with access to the constructor and any
+ * static members/methods.  Instance methods are not listed here.
  *
  * Source for this idea: https://stackoverflow.com/a/43607255
  */
@@ -360,7 +363,7 @@ export abstract class Serializable {
   /**
    * Creates an instance of T from a ConfigDict.
    *
-   * This works for most descendans of serializable.  A few need to
+   * This works for most descendants of serializable.  A few need to
    * provide special handling.
    * @param cls A Constructor for the class to instantiate.
    * @param config The Configuration for the object.

--- a/src/types.ts
+++ b/src/types.ts
@@ -325,8 +325,8 @@ export type NamedTensorMap = {
  *
  * Source for this idea: https://stackoverflow.com/a/43607255
  */
-// tslint:disable-next-line:no-any
 export type Constructor<T extends Serializable> = {
+  // tslint:disable-next-line:no-any
   new (...args: any[]): T; className: string; fromConfig: FromConfigMethod<T>;
 };
 export type FromConfigMethod<T extends Serializable> =

--- a/src/types.ts
+++ b/src/types.ts
@@ -321,6 +321,18 @@ export type NamedTensorMap = {
 };
 
 /**
+ * Type to represent class constructors.
+ *
+ * Source for this idea: https://stackoverflow.com/a/43607255
+ */
+// tslint:disable-next-line:no-any
+export type Constructor<T extends Serializable> = {
+  new (...args: any[]): T; className: string; fromConfig: FromConfigMethod<T>;
+};
+export type FromConfigMethod<T extends Serializable> =
+    (cls: Constructor<T>, config: JsonDict) => T;
+
+/**
  * Serializable defines the serialization contract.
  *
  * TFJS requires serializable classes to return their className when asked
@@ -344,4 +356,17 @@ export abstract class Serializable {
    * Return all the non-weight state needed to serialize this object.
    */
   abstract getConfig(): ConfigDict;
+
+  /**
+   * Creates an instance of T from a ConfigDict.
+   *
+   * This works for most descendans of serializable.  A few need to
+   * provide special handling.
+   * @param cls A Constructor for the class to instantiate.
+   * @param config The Configuration for the object.
+   */
+  static fromConfig<T extends Serializable>(
+      cls: Constructor<T>, config: ConfigDict): T {
+    return new cls(config);
+  }
 }

--- a/src/utils/generic_utils.ts
+++ b/src/utils/generic_utils.ts
@@ -14,7 +14,7 @@
 import {Tensor} from '@tensorflow/tfjs-core';
 
 import {AssertionError, AttributeError, IndexError, ValueError} from '../errors';
-import {ConfigDict, ConfigDictValue, Constructor, DType, FromConfigMethod, JsonDict, Serializable, Shape} from '../types';
+import {ConfigDict, ConfigDictValue, Constructor, DType, FromConfigMethod, Serializable, Shape} from '../types';
 
 
 

--- a/src/utils/generic_utils.ts
+++ b/src/utils/generic_utils.ts
@@ -14,7 +14,7 @@
 import {Tensor} from '@tensorflow/tfjs-core';
 
 import {AssertionError, AttributeError, IndexError, ValueError} from '../errors';
-import {ConfigDict, ConfigDictValue, DType, JsonDict, Serializable, Shape} from '../types';
+import {ConfigDict, ConfigDictValue, Constructor, DType, FromConfigMethod, JsonDict, Serializable, Shape} from '../types';
 
 
 
@@ -109,15 +109,6 @@ export function count<T>(array: T[], refernce: T) {
   return counter;
 }
 
-/**
- * Type to represent class constructors.
- *
- * Source for this idea: https://stackoverflow.com/a/43607255
- */
-// tslint:disable-next-line:no-any
-export type Constructor<T> = new (...args: any[]) => T;
-export type FromConfigMethod<T> = (config: JsonDict) => T;
-
 export class ClassNameMap {
   private static instance: ClassNameMap;
   pythonClassNameMap: {
@@ -136,11 +127,9 @@ export class ClassNameMap {
     return ClassNameMap.instance;
   }
 
+  // tslint:disable-next-line:no-any
   static register<T extends Serializable>(cls: Constructor<T>) {
-    const className = new cls({}).getClassName();
-    this.getMap().pythonClassNameMap[className] =
-        // tslint:disable-next-line:no-any
-        [cls, (cls as any).fromConfig];
+    this.getMap().pythonClassNameMap[cls.className] = [cls, cls.fromConfig];
   }
 }
 

--- a/src/utils/generic_utils.ts
+++ b/src/utils/generic_utils.ts
@@ -127,7 +127,6 @@ export class ClassNameMap {
     return ClassNameMap.instance;
   }
 
-  // tslint:disable-next-line:no-any
   static register<T extends Serializable>(cls: Constructor<T>) {
     this.getMap().pythonClassNameMap[cls.className] = [cls, cls.fromConfig];
   }

--- a/src/utils/generic_utils.ts
+++ b/src/utils/generic_utils.ts
@@ -14,7 +14,8 @@
 import {Tensor} from '@tensorflow/tfjs-core';
 
 import {AssertionError, AttributeError, IndexError, ValueError} from '../errors';
-import {ConfigDict, ConfigDictValue, DType, Serializable, Shape} from '../types';
+import {ConfigDict, ConfigDictValue, DType, JsonDict, Serializable, Shape} from '../types';
+
 
 
 // tslint:enable
@@ -115,11 +116,14 @@ export function count<T>(array: T[], refernce: T) {
  */
 // tslint:disable-next-line:no-any
 export type Constructor<T> = new (...args: any[]) => T;
+export type FromConfigMethod<T> = (config: JsonDict) => T;
 
 export class ClassNameMap {
   private static instance: ClassNameMap;
-  // tslint:disable-next-line:no-any
-  pythonClassNameMap: {[className: string]: any};
+  pythonClassNameMap: {
+    [className: string]:
+        [Constructor<Serializable>, FromConfigMethod<Serializable>]
+  };
 
   private constructor() {
     this.pythonClassNameMap = {};
@@ -132,7 +136,8 @@ export class ClassNameMap {
     return ClassNameMap.instance;
   }
 
-  static register<T>(className: string, cls: Constructor<T>) {
+  static register<T extends Serializable>(cls: Constructor<T>) {
+    const className = new cls({}).getClassName();
     this.getMap().pythonClassNameMap[className] =
         // tslint:disable-next-line:no-any
         [cls, (cls as any).fromConfig];


### PR DESCRIPTION
WIP: This does not yet work.  This approach gets rid of the first argument to .register, and attempts to use the required getClassName method from all Serializables.  However we have to instantiate the Serializable during the registration (which feels odd), AND we can't construct all Serializables w/o additional information (not all can be constructed with an empty config object).

Do any of you see a workaround, that's not worse than what we had before this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/146)
<!-- Reviewable:end -->
