### PR TITLE
Remove the need to override getClassName()

### DIFF
--- a/src/constraints.ts
+++ b/src/constraints.ts
@@ -92,10 +92,6 @@ export class MaxNorm extends Constraint {
         K.divide(desired, K.scalarPlusArray(K.getScalar(K.epsilon()), norms)));
   }
 
-  getClassName(): string {
-    return MaxNorm.className;
-  }
-
   getConfig(): ConfigDict {
     return {maxValue: this.maxValue, axis: this.axis};
   }
@@ -138,10 +134,6 @@ export class UnitNorm extends Constraint {
         K.scalarPlusArray(K.getScalar(K.epsilon()), calcL2Norms(w, this.axis)));
   }
 
-  getClassName(): string {
-    return UnitNorm.className;
-  }
-
   getConfig(): ConfigDict {
     return {axis: this.axis};
   }
@@ -155,9 +147,6 @@ export class NonNeg extends Constraint {
   static readonly className = 'NonNeg';
   apply(w: Tensor): Tensor {
     return K.relu(w);
-  }
-  getClassName(): string {
-    return NonNeg.className;
   }
 }
 ClassNameMap.register(NonNeg);
@@ -227,10 +216,6 @@ export class MinMaxNorm extends Constraint {
     return K.multiply(
         w,
         K.divide(desired, K.scalarPlusArray(K.getScalar(K.epsilon()), norms)));
-  }
-
-  getClassName(): string {
-    return MinMaxNorm.className;
   }
 
   getConfig(): ConfigDict {

--- a/src/engine/topology.ts
+++ b/src/engine/topology.ts
@@ -1396,9 +1396,6 @@ export class InputLayer extends Layer {
         `InputLayer's apply() method. InputLayer name: ${this.name}`);
   }
 
-  getClassName(): string {
-    return InputLayer.className;
-  }
   getConfig(): ConfigDict {
     return {
       batchInputShape: this.batchInputShape,

--- a/src/engine/topology_test.ts
+++ b/src/engine/topology_test.ts
@@ -26,18 +26,12 @@ class LayerForTest extends tfl.layers.Layer {
   constructor(config: LayerConfig) {
     super(config);
   }
-  getClassName(): string {
-    return LayerForTest.className;
-  }
 }
 
 class ContainerForTest extends Container {
   static className = 'ContainerForTest';
   constructor(config: ContainerConfig) {
     super(config);
-  }
-  getClassName(): string {
-    return ContainerForTest.className;
   }
 }
 
@@ -315,6 +309,7 @@ describeMathCPU('Layer', () => {
 
     it('Layer with duplicate weight names throws error', () => {
       class LayerForTest extends tfl.layers.Layer {
+        static className = 'LayerForTest';
         constructor(config: LayerConfig) {
           super(config);
           this.addWeight(
@@ -323,9 +318,6 @@ describeMathCPU('Layer', () => {
           this.addWeight(
               'foo', [2, 3], DType.float32,
               initializers.getInitializer('zeros'));
-        }
-        getClassName(): string {
-          return 'Layer';
         }
       }
       expect(() => new LayerForTest({}))

--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -653,10 +653,6 @@ export class Model extends Container {
     super(config);
   }
 
-  getClassName(): string {
-    return Model.className;
-  }
-
   /**
    * Configures and prepares the model for training and evaluation.  Compiling
    * outfits the model with an optimizer, loss, and/or metrics.  Calling `fit`

--- a/src/initializers.ts
+++ b/src/initializers.ts
@@ -80,9 +80,7 @@ export abstract class Initializer extends Serializable {
  */
 export class Zeros extends Initializer {
   static className = 'Zeros';
-  getClassName(): string {
-    return Zeros.className;
-  }
+
   apply(shape: Shape, dtype?: DType): Tensor {
     return K.zeros(shape, dtype);
   }
@@ -94,9 +92,7 @@ ClassNameMap.register(Zeros);
  */
 export class Ones extends Initializer {
   static className = 'Ones';
-  getClassName(): string {
-    return Ones.className;
-  }
+
   apply(shape: Shape, dtype?: DType): Tensor {
     return K.ones(shape, dtype);
   }
@@ -121,10 +117,6 @@ export class Constant extends Initializer {
 
   apply(shape: Shape, dtype?: DType): Tensor {
     return K.scalarTimesArray(scalar(this.value), K.ones(shape, dtype));
-  }
-
-  getClassName(): string {
-    return Constant.className;
   }
 
   getConfig(): ConfigDict {
@@ -170,10 +162,6 @@ export class RandomUniform extends Initializer {
     return K.randomUniform(shape, this.minval, this.maxval, dtype, this.seed);
   }
 
-  getClassName(): string {
-    return RandomUniform.className;
-  }
-
   getConfig(): ConfigDict {
     return {minval: this.minval, maxval: this.maxval, seed: this.seed};
   }
@@ -212,9 +200,6 @@ export class RandomNormal extends Initializer {
     return K.randomNormal(shape, this.mean, this.stddev, dtype, this.seed);
   }
 
-  getClassName(): string {
-    return RandomNormal.className;
-  }
   getConfig(): ConfigDict {
     return {mean: this.mean, stddev: this.stddev, seed: this.seed};
   }
@@ -258,10 +243,6 @@ export class TruncatedNormal extends Initializer {
     return K.truncatedNormal(shape, this.mean, this.stddev, dtype, this.seed);
   }
 
-  getClassName(): string {
-    return TruncatedNormal.className;
-  }
-
   getConfig(): ConfigDict {
     return {mean: this.mean, stddev: this.stddev, seed: this.seed};
   }
@@ -295,9 +276,7 @@ export class Identity extends Initializer {
       return K.scalarTimesArray(this.gain, K.eye(shape[0]));
     }
   }
-  getClassName(): string {
-    return Identity.className;
-  }
+
   getConfig(): ConfigDict {
     return {gain: this.gain.get()};
   }
@@ -412,9 +391,6 @@ export class VarianceScaling extends Initializer {
       return K.randomUniform(shape, -limit, limit, dtype, this.seed);
     }
   }
-  getClassName(): string {
-    return VarianceScaling.className;
-  }
 
   getConfig(): ConfigDict {
     return {
@@ -459,6 +435,13 @@ export class GlorotUniform extends VarianceScaling {
       seed: config == null ? null : config.seed
     });
   }
+
+  getClassName(): string {
+    // In Python Keras, GlorotUniform is not a class, but a helper method
+    // that creates a VarianceScaling object. Use 'VarianceScaling' as
+    // class name to be compatible with that.
+    return VarianceScaling.className;
+  }
 }
 
 /**
@@ -488,6 +471,13 @@ export class GlorotNormal extends VarianceScaling {
       seed: config == null ? null : config.seed
     });
   }
+
+  getClassName(): string {
+    // In Python Keras, GlorotUniform is not a class, but a helper method
+    // that creates a VarianceScaling object. Use 'VarianceScaling' as
+    // class name to be compatible with that.
+    return VarianceScaling.className;
+  }
 }
 
 /**
@@ -508,6 +498,13 @@ export class HeNormal extends VarianceScaling {
       distribution: 'normal',
       seed: config == null ? null : config.seed
     });
+  }
+
+  getClassName(): string {
+    // In Python Keras, GlorotUniform is not a class, but a helper method
+    // that creates a VarianceScaling object. Use 'VarianceScaling' as
+    // class name to be compatible with that.
+    return VarianceScaling.className;
   }
 }
 
@@ -530,6 +527,13 @@ export class LeCunNormal extends VarianceScaling {
       distribution: 'normal',
       seed: config == null ? null : config.seed
     });
+  }
+
+  getClassName(): string {
+    // In Python Keras, GlorotUniform is not a class, but a helper method
+    // that creates a VarianceScaling object. Use 'VarianceScaling' as
+    // class name to be compatible with that.
+    return VarianceScaling.className;
   }
 }
 
@@ -579,10 +583,6 @@ export class Orthogonal extends Initializer {
       q = q.transpose();
     }
     return K.scalarTimesArray(K.getScalar(this.gain), q);
-  }
-
-  getClassName(): string {
-    return Orthogonal.className;
   }
 
   getConfig(): ConfigDict {

--- a/src/initializers.ts
+++ b/src/initializers.ts
@@ -473,7 +473,7 @@ export class GlorotNormal extends VarianceScaling {
   }
 
   getClassName(): string {
-    // In Python Keras, GlorotUniform is not a class, but a helper method
+    // In Python Keras, GlorotNormal is not a class, but a helper method
     // that creates a VarianceScaling object. Use 'VarianceScaling' as
     // class name to be compatible with that.
     return VarianceScaling.className;
@@ -501,7 +501,7 @@ export class HeNormal extends VarianceScaling {
   }
 
   getClassName(): string {
-    // In Python Keras, GlorotUniform is not a class, but a helper method
+    // In Python Keras, HeNormal is not a class, but a helper method
     // that creates a VarianceScaling object. Use 'VarianceScaling' as
     // class name to be compatible with that.
     return VarianceScaling.className;
@@ -530,7 +530,7 @@ export class LeCunNormal extends VarianceScaling {
   }
 
   getClassName(): string {
-    // In Python Keras, GlorotUniform is not a class, but a helper method
+    // In Python Keras, LeCunNormal is not a class, but a helper method
     // that creates a VarianceScaling object. Use 'VarianceScaling' as
     // class name to be compatible with that.
     return VarianceScaling.className;

--- a/src/layers/advanced_activations.ts
+++ b/src/layers/advanced_activations.ts
@@ -68,10 +68,6 @@ export class LeakyReLU extends Layer {
     return inputShape;
   }
 
-  getClassName(): string {
-    return LeakyReLU.className;
-  }
-
   getConfig(): ConfigDict {
     const config: ConfigDict = {alpha: this.alpha};
     const baseConfig = super.getConfig();
@@ -139,10 +135,6 @@ export class ELU extends Layer {
     return inputShape;
   }
 
-  getClassName(): string {
-    return ELU.className;
-  }
-
   getConfig(): ConfigDict {
     const config: ConfigDict = {alpha: this.alpha};
     const baseConfig = super.getConfig();
@@ -204,10 +196,6 @@ export class ThresholdedReLU extends Layer {
     return inputShape;
   }
 
-  getClassName(): string {
-    return ThresholdedReLU.className;
-  }
-
   getConfig(): ConfigDict {
     const config: ConfigDict = {theta: this.theta};
     const baseConfig = super.getConfig();
@@ -258,10 +246,6 @@ export class Softmax extends Layer {
 
   computeOutputShape(inputShape: Shape|Shape[]): Shape|Shape[] {
     return inputShape;
-  }
-
-  getClassName(): string {
-    return Softmax.className;
   }
 
   getConfig(): ConfigDict {

--- a/src/layers/convolutional.ts
+++ b/src/layers/convolutional.ts
@@ -332,10 +332,6 @@ export class Conv2D extends Conv {
     super(2, config);
   }
 
-  getClassName(): string {
-    return Conv2D.className;
-  }
-
   getConfig(): ConfigDict {
     const config = super.getConfig();
     delete config['rank'];
@@ -390,11 +386,6 @@ export class Conv2DTranspose extends Conv2D {
           `and 'valid', but received padding mode ${this.padding}`);
     }
   }
-
-  getClassName(): string {
-    return Conv2DTranspose.className;
-  }
-
 
   build(inputShape: Shape|Shape[]): void {
     inputShape = generic_utils.getExactlyOneShape(inputShape);
@@ -573,6 +564,8 @@ export interface SeparableConvLayerConfig extends ConvLayerConfig {
 
 
 export class SeparableConv extends Conv {
+  static className = 'SeparableConv';
+
   readonly depthMultiplier: number;
 
   protected readonly depthwiseInitializer?: Initializer;
@@ -705,10 +698,6 @@ export class SeparableConv extends Conv {
     return output;
   }
 
-  getClassName(): string {
-    return 'SeparableConv';
-  }
-
   getConfig(): ConfigDict {
     const config = super.getConfig();
     delete config['rank'];
@@ -763,9 +752,6 @@ export class SeparableConv2D extends SeparableConv {
   constructor(config?: SeparableConvLayerConfig) {
     super(2, config);
   }
-  getClassName(): string {
-    return SeparableConv2D.className;
-  }
 }
 generic_utils.ClassNameMap.register(SeparableConv2D);
 
@@ -792,10 +778,6 @@ export class Conv1D extends Conv {
   constructor(config: ConvLayerConfig) {
     super(1, config);
     this.inputSpec = [{ndim: 3}];
-  }
-
-  getClassName(): string {
-    return Conv1D.className;
   }
 
   getConfig(): ConfigDict {

--- a/src/layers/convolutional_depthwise.ts
+++ b/src/layers/convolutional_depthwise.ts
@@ -89,9 +89,6 @@ export class DepthwiseConv2D extends Conv2D {
     this.depthwiseConstraint = getConstraint(config.depthwiseConstraint);
     this.depthwiseRegularizer = getRegularizer(config.depthwiseRegularizer);
   }
-  getClassName(): string {
-    return DepthwiseConv2D.className;
-  }
 
   build(inputShape: Shape|Shape[]): void {
     inputShape = getExactlyOneShape(inputShape);

--- a/src/layers/core.ts
+++ b/src/layers/core.ts
@@ -112,10 +112,6 @@ export class Dropout extends Layer {
     return inputs;
   }
 
-  getClassName(): string {
-    return Dropout.className;
-  }
-
   getConfig(): ConfigDict {
     const config = {
       rate: this.rate,
@@ -299,10 +295,6 @@ export class Dense extends Layer {
     return output;
   }
 
-  getClassName(): string {
-    return Dense.className;
-  }
-
   getConfig(): ConfigDict {
     const config: ConfigDict = {
       units: this.units,
@@ -361,10 +353,6 @@ export class Flatten extends Layer {
     return [inputShape[0], math_utils.arrayProd(inputShape, 1)];
   }
 
-  getClassName(): string {
-    return Flatten.className;
-  }
-
   // tslint:disable-next-line:no-any
   call(inputs: Tensor|Tensor[], kwargs: any): Tensor|Tensor[] {
     this.invokeCallHook(inputs, kwargs);
@@ -391,10 +379,6 @@ export class Activation extends Layer {
     super(config);
     this.supportsMasking = true;
     this.activation = getActivation(config.activation);
-  }
-
-  getClassName(): string {
-    return Activation.className;
   }
 
   // tslint:disable-next-line:no-any
@@ -440,10 +424,6 @@ export class RepeatVector extends Layer {
   call(inputs: Tensor|Tensor[], kwargs: any): Tensor|Tensor[] {
     inputs = getExactlyOneTensor(inputs);
     return K.repeat(inputs, this.n);
-  }
-
-  getClassName(): string {
-    return RepeatVector.className;
   }
 
   getConfig(): ConfigDict {
@@ -552,11 +532,6 @@ export class Reshape extends Layer {
           this.fixUnknownDimension(inputShape.slice(1), this.targetShape));
     }
   }
-
-  getClassName(): string {
-    return Reshape.className;
-  }
-
 
   // tslint:disable-next-line:no-any
   call(inputs: Tensor|Tensor[], kwargs: any): Tensor|Tensor[] {

--- a/src/layers/embeddings.ts
+++ b/src/layers/embeddings.ts
@@ -186,10 +186,6 @@ export class Embedding extends Layer {
         output, getExactlyOneShape(this.computeOutputShape(input.shape)));
   }
 
-  getClassName(): string {
-    return Embedding.className;
-  }
-
   getConfig(): ConfigDict {
     const config = {
       inputDim: this.inputDim,

--- a/src/layers/merge.ts
+++ b/src/layers/merge.ts
@@ -251,10 +251,6 @@ export class Add extends Merge {
     super(config as LayerConfig);
   }
 
-  getClassName(): string {
-    return Add.className;
-  }
-
   protected mergeFunction(inputs: Tensor[]): Tensor {
     let output = K.zeros(inputs[0].shape);
     for (const input of inputs) {
@@ -345,10 +341,6 @@ export class Multiply extends Merge {
     super(config);
   }
 
-  getClassName(): string {
-    return Multiply.className;
-  }
-
   protected mergeFunction(inputs: Tensor[]): Tensor {
     let output = K.ones(inputs[0].shape);
     for (const input of inputs) {
@@ -436,10 +428,6 @@ export class Average extends Merge {
   static className = 'Average';
   constructor(config?: LayerConfig) {
     super(config);
-  }
-
-  getClassName(): string {
-    return Average.className;
   }
 
   protected mergeFunction(inputs: Tensor[]): Tensor {
@@ -532,10 +520,6 @@ export class Maximum extends Merge {
     super(config);
   }
 
-  getClassName(): string {
-    return Maximum.className;
-  }
-
   protected mergeFunction(inputs: Tensor[]): Tensor {
     let output = inputs[0];
     for (let i = 1; i < inputs.length; ++i) {
@@ -623,10 +607,6 @@ export class Minimum extends Merge {
   static className = 'Minimum';
   constructor(config?: LayerConfig) {
     super(config);
-  }
-
-  getClassName(): string {
-    return Minimum.className;
   }
 
   protected mergeFunction(inputs: Tensor[]): Tensor {
@@ -734,10 +714,6 @@ export class Concatenate extends Merge {
     this.axis = config.axis == null ? this.DEFAULT_AXIS : config.axis;
     this.supportsMasking = true;
     this.reshapeRequired = false;
-  }
-
-  getClassName(): string {
-    return Concatenate.className;
   }
 
   build(inputShape: Shape|Shape[]): void {

--- a/src/layers/normalization.ts
+++ b/src/layers/normalization.ts
@@ -278,10 +278,6 @@ export class BatchNormalization extends Layer {
     });
   }
 
-  getClassName(): string {
-    return BatchNormalization.className;
-  }
-
   getConfig(): ConfigDict {
     const config: ConfigDict = {
       axis: this.axis,

--- a/src/layers/padding.ts
+++ b/src/layers/padding.ts
@@ -168,10 +168,6 @@ export class ZeroPadding2D extends Layer {
         getExactlyOneTensor(inputs), this.padding, this.dataFormat);
   }
 
-  getClassName(): string {
-    return ZeroPadding2D.className;
-  }
-
   getConfig(): ConfigDict {
     const config: ConfigDict = {
       padding: this.padding,

--- a/src/layers/pooling.ts
+++ b/src/layers/pooling.ts
@@ -114,10 +114,6 @@ export class MaxPooling1D extends Pooling1D {
     super(config);
   }
 
-  getClassName(): string {
-    return MaxPooling1D.className;
-  }
-
   protected poolingFunction(
       inputs: Tensor, poolSize: [number, number], strides: [number, number],
       padding: PaddingMode, dataFormat: DataFormat): Tensor {
@@ -141,10 +137,6 @@ export class AveragePooling1D extends Pooling1D {
   static className = 'AveragePooling1D';
   constructor(config: Pooling1DLayerConfig) {
     super(config);
-  }
-
-  getClassName(): string {
-    return AveragePooling1D.className;
   }
 
   protected poolingFunction(
@@ -276,10 +268,6 @@ export class MaxPooling2D extends Pooling2D {
     super(config);
   }
 
-  getClassName(): string {
-    return MaxPooling2D.className;
-  }
-
   protected poolingFunction(
       inputs: Tensor, poolSize: [number, number], strides: [number, number],
       padding: PaddingMode, dataFormat: DataFormat): Tensor {
@@ -315,10 +303,6 @@ export class AveragePooling2D extends Pooling2D {
   static className = 'AveragePooing2D';
   constructor(config: Pooling2DLayerConfig) {
     super(config);
-  }
-
-  getClassName(): string {
-    return AveragePooling2D.className;
   }
 
   protected poolingFunction(
@@ -363,10 +347,6 @@ export class GlobalAveragePooling1D extends GlobalPooling1D {
     super(config);
   }
 
-  getClassName(): string {
-    return GlobalAveragePooling1D.className;
-  }
-
   // tslint:disable-next-line:no-any
   call(inputs: Tensor|Tensor[], kwargs: any): Tensor|Tensor[] {
     const input = generic_utils.getExactlyOneTensor(inputs);
@@ -386,10 +366,6 @@ export class GlobalMaxPooling1D extends GlobalPooling1D {
   static className = 'GlobalMaxPooling1D';
   constructor(config: LayerConfig) {
     super(config);
-  }
-
-  getClassName(): string {
-    return GlobalMaxPooling1D.className;
   }
 
   // tslint:disable-next-line:no-any
@@ -470,9 +446,6 @@ export class GlobalAveragePooling2D extends GlobalPooling2D {
       return K.mean(input, [2, 3]);
     }
   }
-  getClassName(): string {
-    return GlobalAveragePooling2D.className;
-  }
 }
 generic_utils.ClassNameMap.register(GlobalAveragePooling2D);
 
@@ -498,9 +471,6 @@ export class GlobalMaxPooling2D extends GlobalPooling2D {
     } else {
       return K.max(input, [2, 3]);
     }
-  }
-  getClassName(): string {
-    return GlobalMaxPooling2D.className;
   }
 }
 generic_utils.ClassNameMap.register(GlobalMaxPooling2D);

--- a/src/layers/recurrent.ts
+++ b/src/layers/recurrent.ts
@@ -621,10 +621,6 @@ export class RNN extends Layer {
     return this.cell.nonTrainableWeights;
   }
 
-  getClassName(): string {
-    return RNN.className;
-  }
-
   getConfig(): ConfigDict {
     const config: ConfigDict = {
       returnSequences: this.returnSequences,
@@ -908,10 +904,6 @@ export class SimpleRNNCell extends RNNCell {
     return [output, output];
   }
 
-  getClassName(): string {
-    return SimpleRNNCell.className;
-  }
-
   getConfig(): ConfigDict {
     const config: ConfigDict = {
       units: this.units,
@@ -1113,10 +1105,6 @@ export class SimpleRNN extends RNN {
 
   get recurrentDropout(): number {
     return (this.cell as SimpleRNNCell).recurrentDropout;
-  }
-
-  getClassName(): string {
-    return SimpleRNN.className;
   }
 
   getConfig(): ConfigDict {
@@ -1406,10 +1394,6 @@ export class GRUCell extends RNNCell {
     return [h, h];
   }
 
-  getClassName(): string {
-    return GRUCell.className;
-  }
-
   getConfig(): ConfigDict {
     const config: ConfigDict = {
       units: this.units,
@@ -1554,10 +1538,6 @@ export class GRU extends RNN {
 
   get implementation(): number {
     return (this.cell as GRUCell).implementation;
-  }
-
-  getClassName(): string {
-    return GRU.className;
   }
 
   getConfig(): ConfigDict {
@@ -1764,6 +1744,8 @@ export class LSTMCell extends RNNCell {
         const capturedBiasInit = this.biasInitializer;
         const capturedUnits = this.units;
         biasInitializer = new (class CustomInit extends Initializer {
+          static className = 'CustomInit';
+
           apply(shape: Shape, dtype?: DType): Tensor {
             // TODO(cais): More informative variable names?
             const bI = capturedBiasInit.apply([capturedUnits]);
@@ -1771,9 +1753,6 @@ export class LSTMCell extends RNNCell {
             const bCAndH = capturedBiasInit.apply([capturedUnits * 2]);
             return K.concatAlongFirstAxis(
                 K.concatAlongFirstAxis(bI, bF), bCAndH);
-          }
-          getClassName(): string {
-            return 'CustomInit';
           }
         })();
       } else {
@@ -1892,10 +1871,6 @@ export class LSTMCell extends RNNCell {
     const h = K.multiply(o, this.activation(c));
     // TODO(cais): Add use_learning_phase flag properly.
     return [h, h, c];
-  }
-
-  getClassName(): string {
-    return LSTMCell.className;
   }
 
   getConfig(): ConfigDict {
@@ -2056,10 +2031,6 @@ export class LSTM extends RNN {
     return (this.cell as LSTMCell).implementation;
   }
 
-  getClassName(): string {
-    return LSTM.className;
-  }
-
   getConfig(): ConfigDict {
     const config: ConfigDict = {
       units: this.units,
@@ -2191,10 +2162,6 @@ export class StackedRNNCells extends RNNCell {
       inputShape = [inputShape[0], outputDim];
     }
     this.built = true;
-  }
-
-  getClassName(): string {
-    return StackedRNNCells.className;
   }
 
   getConfig(): ConfigDict {

--- a/src/layers/recurrent_test.ts
+++ b/src/layers/recurrent_test.ts
@@ -35,6 +35,7 @@ import {RNN, RNNCell} from './recurrent';
  *   output.
  */
 class RNNCellForTest extends RNNCell {
+  static className = 'RNNCellForTest';
   constructor(stateSizes: number|number[]) {
     super({});
     this.stateSize = stateSizes;
@@ -49,9 +50,6 @@ class RNNCellForTest extends RNNCell {
     const newStates = states.map(state => K.scalarPlusArray(mean, state));
     const output = K.neg(newStates[0]);
     return [output].concat(newStates);
-  }
-  getClassName(): string {
-    return 'RNNCellForTest';
   }
 }
 

--- a/src/layers/wrappers.ts
+++ b/src/layers/wrappers.ts
@@ -232,9 +232,6 @@ export class TimeDistributed extends Wrapper {
     // TODO(cais): Add useLearningPhase.
     return y;
   }
-  getClassName(): string {
-    return TimeDistributed.className;
-  }
 }
 generic_utils.ClassNameMap.register(TimeDistributed);
 
@@ -468,9 +465,6 @@ export class Bidirectional extends Wrapper {
   get nonTrainableWeights(): LayerVariable[] {
     return this.forwardLayer.nonTrainableWeights.concat(
         this.backwardLayer.nonTrainableWeights);
-  }
-  getClassName(): string {
-    return Bidirectional.className;
   }
 
   // TODO(cais): Implement constraints().

--- a/src/models.ts
+++ b/src/models.ts
@@ -187,9 +187,7 @@ export class Sequential extends Model {
       }
     }
   }
-  getClassName(): string {
-    return Sequential.className;
-  }
+
   /**
    * Adds a layer instance on top of the layer stack.
    *

--- a/src/regularizers.ts
+++ b/src/regularizers.ts
@@ -51,6 +51,7 @@ export interface L2Config {
 @doc({heading: 'Regularizers', namespace: 'regularizers'})
 export class L1L2 extends Regularizer {
   static className = 'L1L2';
+
   private readonly l1: Scalar;
   private readonly l2: Scalar;
   private readonly hasL1: boolean;
@@ -66,6 +67,7 @@ export class L1L2 extends Regularizer {
     this.l1 = K.getScalar(l1);
     this.l2 = K.getScalar(l2);
   }
+
   /**
    * Porting note: Renamed from __call__.
    * @param x Variable of which to calculate the regularization score.
@@ -82,12 +84,11 @@ export class L1L2 extends Regularizer {
     }
     return regularization.asScalar();
   }
-  getClassName(): string {
-    return L1L2.className;
-  }
+
   getConfig(): ConfigDict {
     return {'l1': this.l1.dataSync()[0], 'l2': this.l2.dataSync()[0]};
   }
+
   static fromConfig<T extends Serializable>(
       cls: Constructor<T>, config: ConfigDict): T {
     return new cls({l1: config.l1 as number, l2: config.l2 as number});

--- a/src/types.ts
+++ b/src/types.ts
@@ -353,7 +353,9 @@ export abstract class Serializable {
    * implementation details between different languages led to different
    * class hierarchies and a non-leaf node is used for serialization purposes.
    */
-  abstract getClassName(): string;
+  getClassName(): string {
+    return (this.constructor as Constructor<Serializable>).className;
+  }
 
   /**
    * Return all the non-weight state needed to serialize this object.


### PR DESCRIPTION
in Serializable subclasses.

by making the `Serializable.getClassName()` a concrete (non-abstract) method.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/153)
<!-- Reviewable:end -->
