### PR TITLE
Model.fit(): Change default epochs to 1

### DIFF
--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -1172,7 +1172,7 @@ export class Model extends Container {
       batchSize = 32;
     }
     if (epochs == null) {
-      epochs = 100;
+      epochs = 1;
     }
     if (shuffle == null) {
       shuffle = true;

--- a/src/engine/training_test.ts
+++ b/src/engine/training_test.ts
@@ -462,7 +462,7 @@ describeMathCPUAndGPU('Model.fit', () => {
     createDenseModelAndData();
 
     model.compile({optimizer: 'SGD', loss: 'meanSquaredError'});
-    model.fit(inputs, targets)
+    model.fit(inputs, targets, {epochs: 100})
         .then(history => {
           expect(history.epoch.length).toEqual(100);
           // 100 is the default number of epochs.


### PR DESCRIPTION
to be consistent with Python Keras.
Previously the default value was 100.

BREAKING