### PR TITLE
Add Model.save(); Let loadModel() support IOHandlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "devDependencies": {
-    "@tensorflow/tfjs-core": "0.8.5",
+    "@tensorflow/tfjs-core": "0.9.0",
     "@types/jasmine": "~2.5.53",
     "browserify": "~16.1.0",
     "clang-format": "~1.2.2",
@@ -42,6 +42,6 @@
     "lint": "tslint -p . --type-check -t verbose"
   },
   "peerDependencies": {
-    "@tensorflow/tfjs-core": "0.8.5"
+    "@tensorflow/tfjs-core": "0.9.0"
   }
 }

--- a/src/engine/topology.ts
+++ b/src/engine/topology.ts
@@ -985,9 +985,13 @@ export abstract class Layer extends Serializable {
 
   /**
    * Returns the current values of the weights of the layer.
+   *
+   * @param trainableOnly Whether to get the values of only trainable weights.
+   * @returns Weight values as an `Array` of `Tensor`s.
    */
-  getWeights(): Tensor[] {
-    return K.batchGetValue(this.weights);
+  getWeights(trainableOnly = false): Tensor[] {
+    return trainableOnly ? K.batchGetValue(this.trainableWeights) :
+                           K.batchGetValue(this.weights);
   }
 
   /**

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -13,7 +13,7 @@
  */
 
 // tslint:disable:max-line-length
-import {doc, Tensor} from '@tensorflow/tfjs-core';
+import {doc, io, Tensor} from '@tensorflow/tfjs-core';
 
 import {Constraint, MaxNorm, MaxNormConfig, MinMaxNorm, MinMaxNormConfig, NonNeg, UnitNorm, UnitNormConfig} from './constraints';
 import {ContainerConfig, Input, InputConfig, InputLayer, InputLayerConfig, Layer, LayerConfig} from './engine/topology';
@@ -155,8 +155,8 @@ export class ModelExports {
     subheading: 'Loading',
     useDocsFrom: 'loadModelInternal'
   })
-  static loadModel(modelConfigPath: string): Promise<Model> {
-    return loadModelInternal(modelConfigPath);
+  static loadModel(pathOrIOHandler: string|io.IOHandler): Promise<Model> {
+    return loadModelInternal(pathOrIOHandler);
   }
 
   @doc({

--- a/src/model_save_test.ts
+++ b/src/model_save_test.ts
@@ -1,0 +1,108 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ * =============================================================================
+ */
+
+import {io} from '@tensorflow/tfjs-core';
+
+import {Dense} from './layers/core';
+import {Sequential} from './models';
+import {describeMathCPUAndGPU} from './utils/test_utils';
+
+describeMathCPUAndGPU('Model.save', () => {
+  class IOHandlerForTest implements io.IOHandler {
+    savedArtifacts: io.ModelArtifacts;
+
+    constructor() {}
+
+    async save(modelArtifacts: io.ModelArtifacts): Promise<io.SaveResult> {
+      this.savedArtifacts = modelArtifacts;
+      return {modelArtifactsInfo: null};
+    }
+  }
+
+  class EmptyIOHanlder implements io.IOHandler {
+    constructor() {}
+  }
+
+  it('Saving all weights succeeds', async done => {
+    const model = new Sequential();
+    model.add(new Dense({units: 3, inputShape: [5]}));
+    const handler = new IOHandlerForTest();
+
+    model.save(handler)
+        .then(saveResult => {
+          expect(handler.savedArtifacts.modelTopology)
+              .toEqual(model.toJSON(null, false));
+          expect(handler.savedArtifacts.weightSpecs.length).toEqual(2);
+          expect(handler.savedArtifacts.weightSpecs[0].name.indexOf('/kernel'))
+              .toBeGreaterThan(0);
+          expect(handler.savedArtifacts.weightSpecs[0].shape).toEqual([5, 3]);
+          expect(handler.savedArtifacts.weightSpecs[0].dtype)
+              .toEqual('float32');
+          expect(handler.savedArtifacts.weightSpecs[1].name.indexOf('/bias'))
+              .toBeGreaterThan(0);
+          expect(handler.savedArtifacts.weightSpecs[1].shape).toEqual([3]);
+          expect(handler.savedArtifacts.weightSpecs[1].dtype)
+              .toEqual('float32');
+          done();
+        })
+        .catch(err => {
+          console.error(err.stack);
+        });
+  });
+
+  it('Saving only trainable weights succeeds', async done => {
+    const model = new Sequential();
+    model.add(new Dense({units: 3, inputShape: [5], trainable: false}));
+    model.add(new Dense({units: 2}));
+    const handler = new IOHandlerForTest();
+
+    model.save(handler, {trainableOnly: true})
+        .then(saveResult => {
+          expect(handler.savedArtifacts.modelTopology)
+              .toEqual(model.toJSON(null, false));
+          // Verify that only the trainable weights (i.e., weights from the
+          // 2nd, trainable Dense layer) are saved.
+          expect(handler.savedArtifacts.weightSpecs.length).toEqual(2);
+          expect(handler.savedArtifacts.weightSpecs[0].name.indexOf('/kernel'))
+              .toBeGreaterThan(0);
+          expect(handler.savedArtifacts.weightSpecs[0].shape).toEqual([3, 2]);
+          expect(handler.savedArtifacts.weightSpecs[0].dtype)
+              .toEqual('float32');
+          expect(handler.savedArtifacts.weightSpecs[1].name.indexOf('/bias'))
+              .toBeGreaterThan(0);
+          expect(handler.savedArtifacts.weightSpecs[1].shape).toEqual([2]);
+          expect(handler.savedArtifacts.weightSpecs[1].dtype)
+              .toEqual('float32');
+          done();
+        })
+        .catch(err => {
+          console.error(err.stack);
+        });
+  });
+
+  it('Saving to a handler without save method fails', async done => {
+    const model = new Sequential();
+    model.add(new Dense({units: 3, inputShape: [5]}));
+    const handler = new EmptyIOHanlder();
+    model.save(handler)
+        .then(saveResult => {
+          fail(
+              'Saving with an IOHandler without `save` succeeded ' +
+              'unexpectedly.');
+        })
+        .catch(err => {
+          expect(err.message)
+              .toEqual(
+                  'Model.save() cannot proceed because the IOHandler ' +
+                  'provided does not have the `save` attribute defined.');
+          done();
+        });
+  });
+});

--- a/src/models_test.ts
+++ b/src/models_test.ts
@@ -9,14 +9,14 @@
  */
 
 // tslint:disable:max-line-length
-import {io, ones, Scalar, scalar, Tensor, zeros} from '@tensorflow/tfjs-core';
+import {io, ones, Scalar, scalar, Tensor, tensor1d, tensor2d, zeros} from '@tensorflow/tfjs-core';
 
 import * as K from './backend/tfjs_backend';
 import {Model} from './engine/training';
 import * as tfl from './index';
 import {Reshape} from './layers/core';
 import {deserialize} from './layers/serialization';
-import {ModelAndWeightsConfig, modelFromJSON} from './models';
+import {loadModelInternal, ModelAndWeightsConfig, modelFromJSON} from './models';
 import {ConfigDict, JsonDict} from './types';
 import {convertPythonicToTs} from './utils/serialization_utils';
 import {describeMathCPU, describeMathCPUAndGPU, expectTensorsClose} from './utils/test_utils';
@@ -161,7 +161,7 @@ describeMathCPU('model_from_json', () => {
   });
 });
 
-describeMathCPU('loadModel', () => {
+describeMathCPU('loadModel from URL', () => {
   const setupFakeWeightFiles =
       (fileBufferMap:
            {[filename: string]: Float32Array|Int32Array|ArrayBuffer}) => {
@@ -324,6 +324,133 @@ describeMathCPU('loadModel', () => {
         deserialize(convertPythonicToTs(json1) as ConfigDict) as Model;
     const json2 = model2.toJSON(null, false);
     expect(json2).toEqual(json1);
+  });
+});
+
+describeMathCPU('loadModel from IOHandler', () => {
+  // The model topology JSON can be obtained with the following Python Keras
+  // code:
+  //
+  // ```python
+  // import keras
+  // model = keras.Sequential([
+  //     keras.layers.Dense(1, input_shape=[4], activation='sigmoid')
+  // ])
+  // print(model.to_json())
+  // ```
+  const modelTopology: {} = {
+    'class_name': 'Sequential',
+    'keras_version': '2.1.4',
+    'config': [{
+      'class_name': 'Dense',
+      'config': {
+        'kernel_initializer': {
+          'class_name': 'VarianceScaling',
+          'config': {
+            'distribution': 'uniform',
+            'scale': 1.0,
+            'seed': null,
+            'mode': 'fan_avg'
+          }
+        },
+        'name': 'dense_1',
+        'kernel_constraint': null,
+        'bias_regularizer': null,
+        'bias_constraint': null,
+        'dtype': 'float32',
+        'activation': 'sigmoid',
+        'trainable': true,
+        'kernel_regularizer': null,
+        'bias_initializer': {'class_name': 'Zeros', 'config': {}},
+        'units': 1,
+        'batch_input_shape': [null, 4],
+        'use_bias': true,
+        'activity_regularizer': null
+      }
+    }],
+    'backend': 'tensorflow'
+  };
+  const weightSpecs: io.WeightsManifestEntry[] = [
+    {
+      name: 'dense_1/kernel',
+      shape: [4, 1],
+      dtype: 'float32',
+    },
+    {
+      name: 'dense_1/bias',
+      shape: [1],
+      dtype: 'float32',
+    }
+  ];
+  const weightData = new Float32Array([1.1, 2.2, 3.3, 4.4, 5.5]).buffer;
+
+  // A dummy IOHandler that returns hard-coded model artifiacts when its `load`
+  // method is called.
+  class IOHandlerForTest implements io.IOHandler {
+    private readonly includeWeights: boolean;
+
+    constructor(includeWeights = true) {
+      this.includeWeights = includeWeights;
+    }
+
+    async load(): Promise<io.ModelArtifacts> {
+      return this.includeWeights ? {modelTopology, weightSpecs, weightData} :
+                                   {modelTopology};
+    }
+  }
+
+  // A dummy IOHandler that doesn't have the `load` method implemented and is
+  // expected to cause `loadModel` or `loadModelInternal` to fail.
+  class IOHandlerWithoutLoad implements io.IOHandler {
+    constructor() {}
+  }
+
+  it('load topology and weights', async done => {
+    loadModelInternal(new IOHandlerForTest(true))
+        .then(model => {
+          expect(model.layers.length).toEqual(1);
+          expect(model.inputs.length).toEqual(1);
+          expect(model.inputs[0].shape).toEqual([null, 4]);
+          expect(model.outputs.length).toEqual(1);
+          expect(model.outputs[0].shape).toEqual([null, 1]);
+          const weightValues = model.getWeights();
+          expect(weightValues.length).toEqual(2);
+          expectTensorsClose(
+              weightValues[0], tensor2d([1.1, 2.2, 3.3, 4.4], [4, 1]));
+          expectTensorsClose(weightValues[1], tensor1d([5.5]));
+          done();
+        })
+        .catch(err => {
+          done.fail(err.stack);
+        });
+  });
+
+  it('load topology only', async done => {
+    loadModelInternal(new IOHandlerForTest(false))
+        .then(model => {
+          expect(model.layers.length).toEqual(1);
+          expect(model.inputs.length).toEqual(1);
+          expect(model.inputs[0].shape).toEqual([null, 4]);
+          expect(model.outputs.length).toEqual(1);
+          expect(model.outputs[0].shape).toEqual([null, 1]);
+          done();
+        })
+        .catch(err => {
+          done.fail(err.stack);
+        });
+  });
+
+  it('IOHandler without load method causes error', async done => {
+    loadModelInternal(new IOHandlerWithoutLoad())
+        .then(model => {
+          done.fail(
+              'Loading with an IOHandler without load method succeeded ' +
+              'unexpectedly.');
+        })
+        .catch(err => {
+          expect(err.message).toMatch(/does not have .*load.* method/);
+          done();
+        });
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@tensorflow/tfjs-core@0.8.5":
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.8.5.tgz#8b0d5e99094eae47806a98a76bc3cadf8b7efd4d"
+"@tensorflow/tfjs-core@0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.9.0.tgz#7e4b37e0c444c95abc8579d0a22b4f7d59c4248b"
   dependencies:
     seedrandom "~2.4.3"
 


### PR DESCRIPTION
* Model.save() uses IOHandler.save() to save model as artifacts.
* Model.load() uses IOHandler.load() to get artifacts and construct
  a Model object.
* Using dummy implementations of IOHandler in unit tests.

Also in this change:
* Increase tfjs-core dependency version to 0.9.0.

Towards: https://github.com/tensorflow/tfjs/issues/13