### PR TITLE
Fixes to documentation of Conv2D layers

### DIFF
--- a/src/layers/convolutional.ts
+++ b/src/layers/convolutional.ts
@@ -30,21 +30,14 @@ import * as generic_utils from '../utils/generic_utils';
 // tslint:enable:max-line-length
 
 /**
- * LayerConfig for convolutional layers.
- * Applies to convolution of all ranks (e.g, Conv1D, Conv2D).
+ * Base LayerConfig for depthwise and non-depthwise convolutional layers.
  */
-export interface ConvLayerConfig extends LayerConfig {
+export interface BaseConvLayerConfig extends LayerConfig {
   /**
    * The dimensions of the convolution window. If kernelSize is a number, the
    * convolutional window will be square.
    */
   kernelSize: number|number[];
-
-  /**
-   * The dimensionality of the output space (i.e. the number of filters in the
-   * convolution).
-   */
-  filters?: number;
 
   /**
    * The strides of the convolution in each dimension. If strides is a number,
@@ -91,7 +84,7 @@ export interface ConvLayerConfig extends LayerConfig {
   activation?: string;
 
   /**
-   * Whether the layer uses a bias vector. Defaults to false.
+   * Whether the layer uses a bias vector. Defaults to `true`.
    */
   useBias?: boolean;
 
@@ -129,6 +122,18 @@ export interface ConvLayerConfig extends LayerConfig {
    * Regularizer function applied to the activation.
    */
   activityRegularizer?: RegularizerIdentifier|Regularizer;
+}
+
+/**
+ * LayerConfig for non-depthwise convolutional layers.
+ * Applies to non-depthwise convolution of all ranks (e.g, Conv1D, Conv2D).
+ */
+export interface ConvLayerConfig extends BaseConvLayerConfig {
+  /**
+   * The dimensionality of the output space (i.e. the number of filters in the
+   * convolution).
+   */
+  filters: number;
 }
 
 /**

--- a/src/layers/convolutional_depthwise.ts
+++ b/src/layers/convolutional_depthwise.ts
@@ -26,10 +26,11 @@ import {convOutputLength} from '../utils/conv_utils';
 import * as generic_utils from '../utils/generic_utils';
 import {getExactlyOneShape, getExactlyOneTensor} from '../utils/generic_utils';
 
-import {Conv2D, ConvLayerConfig} from './convolutional';
+import {BaseConvLayerConfig, Conv2D, ConvLayerConfig} from './convolutional';
+
 // tslint:enable:max-line-length
 
-export interface DepthwiseConv2DLayerConfig extends ConvLayerConfig {
+export interface DepthwiseConv2DLayerConfig extends BaseConvLayerConfig {
   /**
    * An integer or Array of 2 integers, specifying the width and height of the
    * 2D convolution window. Can be a single integer to specify the same value
@@ -81,7 +82,7 @@ export class DepthwiseConv2D extends Conv2D {
   private depthwiseKernel: LayerVariable = null;
 
   constructor(config: DepthwiseConv2DLayerConfig) {
-    super(config);
+    super(config as ConvLayerConfig);
     this.depthMultiplier =
         config.depthMultiplier == null ? 1 : config.depthMultiplier;
     this.depthwiseInitializer = getInitializer(


### PR DESCRIPTION
1. For Conv1D and Conv2D layers, filters is not an optional field.
   It is required. The reason why it listed as optional in the
   documentation before was that the `filters` field of ConvLayerConfig
   was made optional in order to accomodate Depthwise conv layers,
   whose config interfaces inherited from the config interfaces of
   Conv1D and Conv2D layers.
   This is fixed by creating a base config interface BaseConvLayerConfig
   without the `filters` field. Conv1D and Conv2D layers now have
   a config interface (ConvLayerConfig) that extends BaseConvLayerConfig
   and add the required `filters` field.
2. For Conv1D and Conv2D, the default value of `useBias` was incorrectly
   as listed `false`. It is corrected to `true`.

DOC Clarify that the default value of `useBias` is `true` for
convolutional layers.
DOC Clarify that `filters` is a required field for non-depthwise
convolutional layers.

Fixes https://github.com/tensorflow/tfjs/issues/267

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/162)
<!-- Reviewable:end -->
