### PR TITLE
Initial sweep at pruning the -layers backend.

### DIFF
--- a/src/activations.ts
+++ b/src/activations.ts
@@ -9,6 +9,7 @@
  */
 
 // Layer activation functions
+import * as tfc from '@tensorflow/tfjs-core';
 import {scalar, serialization, Tensor} from '@tensorflow/tfjs-core';
 
 import * as K from './backend/tfjs_backend';
@@ -74,13 +75,13 @@ export function elu(x: Tensor, alpha = 1): Tensor {
  * @returns Tensor with the same shape and dtype as `x`.
  */
 export function selu(x: Tensor): Tensor {
-  return K.selu(x);
+  return tfc.selu(x);
 }
 
 
 // Rectified linear unit
 export function relu(x: Tensor): Tensor {
-  return K.relu(x);
+  return tfc.relu(x);
 }
 
 /**
@@ -90,7 +91,7 @@ export function relu(x: Tensor): Tensor {
 // A better pattern would be to reuse a single constant 6, created after the
 // backend math has been instantiated.
 export function relu6(x: Tensor): Tensor {
-  return K.minimum(scalar(6.0), K.relu(x));
+  return tfc.minimum(scalar(6.0), tfc.relu(x));
 }
 
 //* Linear activation (no-op) */
@@ -102,7 +103,7 @@ export function linear(x: Tensor): Tensor {
  * Sigmoid activation function.
  */
 export function sigmoid(x: Tensor): Tensor {
-  return K.sigmoid(x);
+  return tfc.sigmoid(x);
 }
 
 /**
@@ -132,7 +133,7 @@ export function softsign(x: Tensor): Tensor {
  * @returns Output of the hyperbolic tangent function.
  */
 export function tanh(x: Tensor): Tensor {
-  return K.tanh(x);
+  return tfc.tanh(x);
 }
 
 /**

--- a/src/backend/tfjs_backend.ts
+++ b/src/backend/tfjs_backend.ts
@@ -54,14 +54,6 @@ export function getBackend(): 'cpu'|'webgl' {
   return backend;
 }
 
-/**
- * Alias for deeplearn math keep: do not dispose a tensor's value.
- * @param x
- */
-export function keep(x: Tensor): Tensor {
-  return tfc.keep(x);
-}
-
 const scalarCache: {[typeKey: string]: {[key: number]: Scalar}} = {
   float32: {},
   int32: {}
@@ -199,29 +191,7 @@ export function reshape(x: Tensor, shape: Shape): Tensor {
   return x.reshape(shape);
 }
 
-/**
- * Generalized transpose of a tensor.
- * @param x The input tensor to tranpose.
- * @param perm Optional permutation array. If == null, will be set to
- *   `[n - 1, n - 2, ..., 0]`, n being `ndim(x)`, hence reducing to the usual
- *   transpose for matricies (`Tensor2D`s).
- * @returns The resultant tensor of the tranpose.
- */
-export function transpose(x: Tensor, perm?: number[]): Tensor {
-  return tfc.transpose(x, perm);
-}
-
-export const permuteDimensions = transpose;
-
-/**
- * Reverse a tensor along the specified axis or axes.
- * @param x Tensor to reverse.
- * @param axes Integer or an `Array` of integers. Axis or axes to reverse.
- * @returns The result of the reverse operation.
- */
-export function reverse(x: Tensor, axes: number|number[]): Tensor {
-  return tfc.reverse(x, axes);
-}
+export const permuteDimensions = tfc.transpose;
 
 /**
  * Adds a 1-sized dimension at index "axis".
@@ -833,24 +803,6 @@ export function eyeVariable(
 }
 
 /**
- * Negates a tensor.
- * @param x Tensor to negate.
- */
-export function neg(x: Tensor): Tensor {
-  return tfc.neg(x);
-}
-
-/**
- * Add two tensors, element-wise, with support for broadcasting.
- * @param x First tensor to add.
- * @param y Second tensor to add.
- * @returns Result of the addition.
- */
-export function add(x: Tensor, y: Tensor): Tensor {
-  return tfc.add(x, y);
-}
-
-/**
  * Subtract two tensors, element-wise, with support for broadcasting.
  * @param x First tensor to subtract element-wise.
  * @param y Second tensor to subtract element-wise.
@@ -1099,9 +1051,9 @@ export function sign(x: Tensor): Tensor {
   const zerosLikeX = coreZerosLike(x);
   const onesLikeX = coreOnesLike(x);
   return where(
-      equal(x, zerosLikeX), zerosLikeX,
+      tfc.equal(x, zerosLikeX), zerosLikeX,
       where(
-          greater(x, coreZerosLike(x)), onesLikeX,
+          tfc.greater(x, coreZerosLike(x)), onesLikeX,
           scalarTimesArray(getScalar(-1), onesLikeX)));
 }
 
@@ -1263,107 +1215,12 @@ export function gather(
 }
 
 /**
- * Maximum value in a tensor.
- * @param x Input Tensor
- * @param axis The axis or a set of axes to find maximum values.
- *  *  If axis is undefined, return the maximum value across all axes.
- * @param keepDims Whether to keep the dimensions or not.
- *   If `keepDims` is `false`, the rank of the tensor is reduced
- *   by 1 for each entry in `axis`. If `keepDims` is `True`,
- *   the reduced dimensions are retained with length 1.
- *
- * @return: A tensor with maximum values of `x`.
- */
-export function max(
-    x: Tensor, axis?: number|number[], keepDims?: boolean): Scalar|Tensor {
-  return tfc.max(x, axis, keepDims);
-}
-
-/**
- * Minimum value in a tensor.
- * @param x Input Tensor
- * @param axis The axis or the `Array` of axes to find minimum values over.
- *  If axis is undefined, return the minimum value across all axes.
- * @param keepDims Whether to keep the dimensions or not.
- *   If `keepDims` is `false`, the rank of the tensor is reduced
- *   by 1 for each entry in `axis`. If `keepDims` is `True`,
- *   the reduced dimensions are retained with length 1.
- * @return: A tensor with minimum values of `x`.
- */
-export function min(
-    x: Tensor, axis?: number|number[], keepDims?: boolean): Scalar|Tensor {
-  return tfc.min(x, axis, keepDims);
-}
-
-/**
- * Element-wise minimum of two tensors.
- * @param x Input Tensor
- * @param y Input Tensor with shape and type compatible with `x`.
- * @return: Tensor with the minimum values between `x` and `y`.
- */
-export function minimum(x: Tensor, y: Tensor): Tensor {
-  return tfc.minimum(x, y);
-}
-/**
- * Sum value in a tensor.
- * @param x Input Tensor
- * @param axis The axis or the `Array` of axes to sum over.
- *  If axis is undefined, return the sum of all values across all axes.
- * @param keepDims Whether to keep the dimensions or not.
- *   If `keepDims` is `false`, the rank of the tensor is reduced
- *   by 1 for each entry in `axis`. If `keepDims` is `True`,
- *   the reduced dimensions are retained with length 1.
- * @return: A tensor with the sum values of `x`.
- */
-export function sum(
-    x: Tensor, axis?: number|number[], keepDims?: boolean): Tensor {
-  return tfc.sum(x, axis, keepDims);
-}
-
-/**
- * Element-wise absolute value.
- * @param x Input tensor.
- * @return element-wise |x|.
- */
-export function abs(x: Tensor): Tensor {
-  return tfc.abs(x);
-}
-
-/**
  * Element-wise square.
  * @param x Input tensor.
  * @return element-wise x^2
  */
 export function square(x: Tensor): Tensor {
   return tfc.mulStrict(x, x);
-}
-
-/**
- * Element-wise sqrt.
- * @param x Input tensor.
- * @return element-wise sqrt(x)
- */
-export function sqrt(x: Tensor): Tensor {
-  return tfc.sqrt(x);
-}
-
-/**
- * Element-wise exp.
- * @param x Input tensor.
- * @return element-wise exp(x)
- */
-export function exp(x: Tensor): Tensor {
-  return tfc.exp(x);
-}
-
-/**
- * Element-wise logarithm.
- *
- * @param x Input tensor.
- * @returns Element-wise log(x).
- */
-export function log(x: Tensor): Tensor {
-  return tfc.log(x);
 }
 
 /**
@@ -1399,63 +1256,6 @@ export function pow(x: Tensor, a: Tensor|number): Tensor {
  */
 export function clip(x: Tensor, minValue: number, maxValue: number): Tensor {
   return tfc.clipByValue(x, minValue, maxValue);
-}
-
-/**
- * Element-wise equality between two tensors.
- * @param x
- * @param y
- * @returns A tensor of the same shape as `x`, consisting of `0`(s) and `1`(s).
- */
-export function equal(x: Tensor, y: Tensor): Tensor {
-  return tfc.equal(x, y);
-}
-
-/**
- * Element-wise truth value of (x > y).
- * @param x
- * @param y
- * @returns A tensor of the same shape as `x`, consisting of `0`(s) and `1`(s).
- */
-export function greater(x: Tensor, y: Tensor): Tensor {
-  return tfc.greater(x, y);
-}
-
-/**
- * Element-wise truth value of (x >= y).
- * @param x
- * @param y
- * @returns A tensor of the same shape as `x`, consisting of `0`(s) and `1`(s).
- */
-export function greaterEqual(x: Tensor, y: Tensor): Tensor {
-  return tfc.greaterEqual(x, y);
-}
-
-/**
- * Element-wise maximum of two tensors.
- */
-export function maximum(x: Tensor, y: Tensor): Tensor {
-  return tfc.maximum(x, y);
-}
-
-/**
- * Element-wise sin.
- *
- * @param x Input Tensor or Variable.
- * @returns Element-wise sin(x).
- */
-export function sin(x: Tensor): Tensor {
-  return tfc.sin(x);
-}
-
-/**
- * Element-wise cos.
- *
- * @param x Input Tensor or Variable.
- * @returns Element-wise cos(x).
- */
-export function cos(x: Tensor): Tensor {
-  return tfc.cos(x);
 }
 
 /* Normalization operations. */
@@ -1595,28 +1395,6 @@ export function elu(x: Tensor, alpha = 1): Tensor {
 }
 
 /**
- * Scaled Exponential linear unit (SELU).
- * Stable and Attracting Fixed Point (0, 1) for Normalized Weights.
- * see: https://arxiv.org/abs/1706.02515
- *
- * @param x A tensor or variable to compute the activation function for.
- * @return Output of the SELU operation.
- */
-export function selu(x: Tensor): Tensor {
-  return tfc.selu(x);
-}
-
-/**
- * Rectified linear unit (ReLU).
- * @param x Input Tensor.
- * @return ReLU output.
- */
-export function relu(x: Tensor): Tensor {
-  // TODO(cais): Add params alpha and max_value.
-  return tfc.relu(x);
-}
-
-/**
  * Softplus of a tensor.
  *
  * Defined as log(exp(x) + 1), element-wise.
@@ -1638,16 +1416,6 @@ export function softplus(x: Tensor): Tensor {
  */
 export function softsign(x: Tensor): Tensor {
   return tfc.div(x, tfc.add(getScalar(1), tfc.abs(x)));
-}
-
-/**
- * Element-wise hyperbolic tan.
- *
- * @param x Input Tensor or Variable.
- * @returns Element-wise tanh(x).
- */
-export function tanh(x: Tensor): Tensor {
-  return tfc.tanh(x);
 }
 
 /**
@@ -1673,7 +1441,7 @@ export function dropout(
     throw new NotImplementedError('seed is not implemented for dropout yet.');
   }
   let multiplier = tfc.step(tfc.add(
-      neg(level) as Scalar, randomUniform(x.shape, 0, 1, DType.float32)));
+      tfc.neg(level) as Scalar, randomUniform(x.shape, 0, 1, DType.float32)));
   // Scale the kept elements, so the expected sum is unchanged.
   multiplier = tfc.mul(
       divide(getScalar(1), subtract(getScalar(1), level)) as Scalar,
@@ -1687,9 +1455,9 @@ export function dropout(
  * @param axis Axis along which to perform normalization.
  */
 export function l2Normalize(x: Tensor, axis?: number): Tensor {
-  const squareSum = sum(square(x), axis, true);
+  const squareSum = tfc.sum(square(x), axis, true);
   const epsilonTensor = scalarTimesArray(scalar(epsilon()), tfc.onesLike(x));
-  const norm = sqrt(maximum(squareSum, epsilonTensor));
+  const norm = tfc.sqrt(tfc.maximum(squareSum, epsilonTensor));
   return divide(x, norm);
 }
 
@@ -1752,7 +1520,7 @@ export function conv1dWithBias(
   // TODO(cais): Support CAUSAL padding mode.
 
   if (dataFormat === 'channelsFirst') {
-    x = transpose(x, [0, 2, 1]);  // NCW -> NWC.
+    x = tfc.transpose(x, [0, 2, 1]);  // NCW -> NWC.
   }
   if (padding === 'causal') {
     throw new NotImplementedError(
@@ -2004,7 +1772,7 @@ export function categoricalCrossentropy(
     output = softmax(output);
   } else {
     // scale preds so that the class probabilities of each sample sum to 1.
-    const outputSum = sum(output, shape(output).length - 1, true);
+    const outputSum = tfc.sum(output, shape(output).length - 1, true);
     output = divide(output, outputSum);
   }
   output = clip(output, epsilon(), 1 - epsilon());
@@ -2043,7 +1811,7 @@ export function binaryCrossentropy(
   let y: Tensor;
   if (!fromLogits) {
     y = clip(output, epsilon(), 1 - epsilon());
-    y = log(divide(y, subtract(tfc.onesLike(y), y)));
+    y = tfc.log(divide(y, subtract(tfc.onesLike(y), y)));
   } else {
     y = output;
   }
@@ -2079,13 +1847,6 @@ export function sigmoidCrossEntropyWithLogits(
       tfc.log(tfc.add(getScalar(1), tfc.exp(tfc.neg(tfc.abs(output)))));
   const result = tfc.add(tfc.sub(maxOutput, outputXTarget), sigmoidOutput);
   return result;
-}
-
-/**
- * Element-wise sigmoid.
- */
-export function sigmoid(x: Tensor): Tensor {
-  return tfc.sigmoid(x);
 }
 
 /**
@@ -2170,7 +1931,7 @@ export function rnn(
   // Transpose to time-major, i.e., from [batch, time, ...] to [time, batch,
   // ...].
   const axes = [1, 0].concat(math_utils.range(2, ndim));
-  inputs = transpose(inputs, axes);
+  inputs = tfc.transpose(inputs, axes);
 
   if (mask != null) {
     throw new NotImplementedError(
@@ -2192,7 +1953,7 @@ export function rnn(
   }
 
   if (goBackwards) {
-    inputs = reverse(inputs, 0);
+    inputs = tfc.reverse(inputs, 0);
   }
 
   // Porting Note: PyKeras with TensorFlow backend uses a symbolic loop
@@ -2228,7 +1989,7 @@ export function rnn(
 
   return [
     lastOutput,
-    transpose(
+    tfc.transpose(
         outputs, [1, 0].concat(math_utils.range(2, outputs.shape.length))),
     states
   ];

--- a/src/callbacks.ts
+++ b/src/callbacks.ts
@@ -10,7 +10,7 @@
 
 /* Original source: keras/callbacks.py */
 
-import {Scalar, Tensor, tidy} from '@tensorflow/tfjs-core';
+import {keep, Scalar, Tensor, tidy} from '@tensorflow/tfjs-core';
 
 import * as K from './backend/tfjs_backend';
 import {Model} from './engine/training';
@@ -257,7 +257,7 @@ export class BaseLogger extends Callback {
               K.scalarPlusArray(
                   this.totals[key] as Scalar,
                   K.multiply(value, K.getScalar(batchSize))) as Scalar;
-          K.keep(this.totals[key] as Scalar);
+          keep(this.totals[key] as Scalar);
         });
       }
     }
@@ -277,7 +277,7 @@ export class BaseLogger extends Callback {
                 K.scalarTimesArray(
                     K.divide(K.getScalar(1), K.getScalar(this.seen)) as Scalar,
                     this.totals[key] as Scalar) as Scalar;
-            K.keep(logs[key] as Scalar);
+            keep(logs[key] as Scalar);
           });
         }
       }

--- a/src/constraints.ts
+++ b/src/constraints.ts
@@ -11,6 +11,7 @@
 /* Original source: keras/contraints.py */
 
 // tslint:disable:max-line-length
+import * as tfc from '@tensorflow/tfjs-core';
 import {doc, serialization, Tensor} from '@tensorflow/tfjs-core';
 
 import * as K from './backend/tfjs_backend';
@@ -21,7 +22,7 @@ import {deserializeKerasObject, serializeKerasObject} from './utils/generic_util
  * Helper function used by many of the Constraints to find the L2Norms.
  */
 function calcL2Norms(w: Tensor, axis: number): Tensor {
-  return K.sqrt(K.sum(K.square(w), axis, true));
+  return tfc.sqrt(tfc.sum(K.square(w), axis, true));
 }
 
 /**
@@ -145,7 +146,7 @@ serialization.SerializationMap.register(UnitNorm);
 export class NonNeg extends Constraint {
   static readonly className = 'NonNeg';
   apply(w: Tensor): Tensor {
-    return K.relu(w);
+    return tfc.relu(w);
   }
 }
 serialization.SerializationMap.register(NonNeg);
@@ -207,7 +208,7 @@ export class MinMaxNorm extends Constraint {
 
   apply(w: Tensor): Tensor {
     const norms = calcL2Norms(w, this.axis);
-    const desired = K.add(
+    const desired = tfc.add(
         K.scalarTimesArray(
             K.getScalar(this.rate),
             K.clip(norms, this.minValue, this.maxValue)),

--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -1272,7 +1272,7 @@ export class Model extends Container {
               const label = outLabels[i];
               const out = outs[i];
               batchLogs[label] = out;
-              K.keep(out);
+              tfc.keep(out);
               // TODO(cais): Use scope() to avoid ownership.
             }
 
@@ -1286,7 +1286,7 @@ export class Model extends Container {
                 for (let i = 0; i < outLabels.length; ++i) {
                   const label = outLabels[i];
                   const out = valOuts[i];
-                  K.keep(out);
+                  tfc.keep(out);
                   // TODO(cais): Use scope() to avoid ownership.
                   epochLogs['val_' + label] = out;
                 }
@@ -1355,7 +1355,7 @@ export class Model extends Container {
         for (let i = 0; i < batchOuts.length; ++i) {
           const batchOut = batchOuts[i];
           outs[i] =
-              K.add(
+              tfc.add(
                   outs[i],
                   K.scalarTimesArray(
                       K.getScalar(batchEnd - batchStart), batchOut)) as Scalar;
@@ -1407,7 +1407,7 @@ export class Model extends Container {
           if (i === 0) {
             totalLoss = loss;
           } else {
-            totalLoss = K.add(totalLoss, loss) as Scalar;
+            totalLoss = tfc.add(totalLoss, loss) as Scalar;
           }
           valOutputs.push(totalLoss);
         }
@@ -1579,7 +1579,7 @@ export class Model extends Container {
           if (i === 0) {
             totalLoss = loss;
           } else {
-            totalLoss = K.add(totalLoss, loss);
+            totalLoss = tfc.add(totalLoss, loss);
           }
         }
 
@@ -1593,7 +1593,7 @@ export class Model extends Container {
           const meanMetric =
               K.mean(metric(targets[outputIndex], outputs[outputIndex])) as
               Scalar;
-          K.keep(meanMetric);
+          tfc.keep(meanMetric);
           // TODO(cais): Use a scope() instead, to avoid ownership.
           metricsValues.push(meanMetric);
         }
@@ -1602,7 +1602,7 @@ export class Model extends Container {
 
         // Add regularizer penalties.
         this.calculateLosses().forEach(regularizerLoss => {
-          totalLoss = K.add(totalLoss, regularizerLoss);
+          totalLoss = tfc.add(totalLoss, regularizerLoss);
         });
 
         return totalLoss as Scalar;

--- a/src/layers/convolutional.ts
+++ b/src/layers/convolutional.ts
@@ -13,7 +13,7 @@
  */
 
 // tslint:disable:max-line-length
-import {conv2dTranspose, separableConv2d, serialization, Tensor, Tensor4D, tidy} from '@tensorflow/tfjs-core';
+import {conv2dTranspose, separableConv2d, serialization, Tensor, Tensor4D, tidy, transpose} from '@tensorflow/tfjs-core';
 
 import {ActivationFn, getActivation, serializeActivation} from '../activations';
 import * as K from '../backend/tfjs_backend';
@@ -465,13 +465,13 @@ export class Conv2DTranspose extends Conv2D {
           [batchSize, outHeight, outWidth, this.filters];
 
       if (this.dataFormat !== 'channelsLast') {
-        input = K.transpose(input, [0, 2, 3, 1]);
+        input = transpose(input, [0, 2, 3, 1]);
       }
       let outputs = conv2dTranspose(
           input as Tensor4D, this.kernel.read() as Tensor4D, outputShape,
           this.strides as [number, number], this.padding as 'same' | 'valid');
       if (this.dataFormat !== 'channelsLast') {
-        outputs = K.transpose(outputs, [0, 3, 1, 2]) as Tensor4D;
+        outputs = transpose(outputs, [0, 3, 1, 2]) as Tensor4D;
       }
 
       if (this.bias != null) {
@@ -677,7 +677,7 @@ export class SeparableConv extends Conv {
           '1D separable convolution is not implemented yet.');
     } else if (this.rank === 2) {
       if (this.dataFormat === 'channelsFirst') {
-        inputs = K.transpose(inputs, [0, 2, 3, 1]);  // NCHW -> NHWC.
+        inputs = transpose(inputs, [0, 2, 3, 1]);  // NCHW -> NHWC.
       }
 
       output = separableConv2d(
@@ -695,7 +695,7 @@ export class SeparableConv extends Conv {
     }
 
     if (this.dataFormat === 'channelsFirst') {
-      output = K.transpose(output, [0, 3, 1, 2]);  // NHWC -> NCHW.
+      output = transpose(output, [0, 3, 1, 2]);  // NHWC -> NCHW.
     }
     return output;
   }

--- a/src/layers/convolutional_depthwise_test.ts
+++ b/src/layers/convolutional_depthwise_test.ts
@@ -13,9 +13,8 @@
  */
 
 // tslint:disable:max-line-length
-import {Tensor, tensor4d} from '@tensorflow/tfjs-core';
+import {Tensor, tensor4d, transpose} from '@tensorflow/tfjs-core';
 
-import * as K from '../backend/tfjs_backend';
 import {DataFormat, PaddingMode} from '../common';
 import * as tfl from '../index';
 import {InitializerIdentifier} from '../initializers';
@@ -129,7 +128,7 @@ describeMathCPUAndGPU('DepthwiseConv2D-Tensor:', () => {
 
   it('channelsLast', () => {
     // Convert input to channelsLast.
-    const x = K.transpose(tensor4d(x4by4Data, [1, 1, 4, 4]), [0, 2, 3, 1]);
+    const x = transpose(tensor4d(x4by4Data, [1, 1, 4, 4]), [0, 2, 3, 1]);
     const conv2dLayer = tfl.layers.depthwiseConv2d({
       depthMultiplier: 2,
       kernelSize: [2, 2],

--- a/src/layers/convolutional_test.ts
+++ b/src/layers/convolutional_test.ts
@@ -13,9 +13,8 @@
  */
 
 // tslint:disable:max-line-length
-import {ones, scalar, Tensor, tensor3d, Tensor4D, tensor4d, util} from '@tensorflow/tfjs-core';
+import {ones, scalar, Tensor, tensor3d, Tensor4D, tensor4d, transpose, util} from '@tensorflow/tfjs-core';
 
-import * as K from '../backend/tfjs_backend';
 import {DataFormat, PaddingMode} from '../common';
 import * as tfl from '../index';
 import {InitializerIdentifier} from '../initializers';
@@ -144,7 +143,7 @@ describeMathCPUAndGPU('Conv2D Layer: Tensor', () => {
 
   it('CHANNEL_LAST', () => {
     // Convert input to CHANNEL_LAST.
-    const x = K.transpose(tensor4d(x4by4Data, [1, 1, 4, 4]), [0, 2, 3, 1]);
+    const x = transpose(tensor4d(x4by4Data, [1, 1, 4, 4]), [0, 2, 3, 1]);
     const conv2dLayer = tfl.layers.conv2d({
       filters: 1,
       kernelSize: [2, 2],
@@ -588,7 +587,7 @@ describeMathGPU('SeparableConv2D Layer: Tensor', () => {
             it(testTitle, () => {
               let x = tensor4d(x5by5Data, [1, 5, 5, 1]);
               if (dataFormat === 'channelsFirst') {
-                x = K.transpose(x, [0, 3, 1, 2]) as Tensor4D;  // NHWC -> NCHW.
+                x = transpose(x, [0, 3, 1, 2]) as Tensor4D;  // NHWC -> NCHW.
               }
 
               const conv2dLayer = tfl.layers.separableConv2d({
@@ -627,7 +626,7 @@ describeMathGPU('SeparableConv2D Layer: Tensor', () => {
                   tensor4d(yExpectedData, [1, 3, 3, 1]) :
                   tensor4d(yExpectedData, [1, 4, 4, 1]);
               if (dataFormat === 'channelsFirst') {
-                yExpected = K.transpose(yExpected, [0, 3, 1, 2]) as
+                yExpected = transpose(yExpected, [0, 3, 1, 2]) as
                     Tensor4D;  // NHWC -> NCHW.
               }
               expectTensorsClose(y, yExpected);

--- a/src/layers/merge.ts
+++ b/src/layers/merge.ts
@@ -12,6 +12,7 @@
  * TensorFlow.js Layers: Merge Layers.
  */
 
+import * as tfc from '@tensorflow/tfjs-core';
 import {serialization, Tensor, util} from '@tensorflow/tfjs-core';
 
 import * as K from '../backend/tfjs_backend';
@@ -253,7 +254,7 @@ export class Add extends Merge {
   protected mergeFunction(inputs: Tensor[]): Tensor {
     let output = K.zeros(inputs[0].shape);
     for (const input of inputs) {
-      output = K.add(output, input);
+      output = tfc.add(output, input);
     }
     return output;
   }
@@ -432,7 +433,7 @@ export class Average extends Merge {
   protected mergeFunction(inputs: Tensor[]): Tensor {
     let output = K.zeros(inputs[0].shape);
     for (const input of inputs) {
-      output = K.add(output, input);
+      output = tfc.add(output, input);
     }
     return K.scalarTimesArray(K.getScalar(1 / inputs.length), output);
   }
@@ -522,7 +523,7 @@ export class Maximum extends Merge {
   protected mergeFunction(inputs: Tensor[]): Tensor {
     let output = inputs[0];
     for (let i = 1; i < inputs.length; ++i) {
-      output = K.maximum(output, inputs[i]);
+      output = tfc.maximum(output, inputs[i]);
     }
     return output;
   }
@@ -611,7 +612,7 @@ export class Minimum extends Merge {
   protected mergeFunction(inputs: Tensor[]): Tensor {
     let output = inputs[0];
     for (let i = 1; i < inputs.length; ++i) {
-      output = K.minimum(output, inputs[i]);
+      output = tfc.minimum(output, inputs[i]);
     }
     return output;
   }

--- a/src/layers/pooling.ts
+++ b/src/layers/pooling.ts
@@ -13,7 +13,7 @@
  */
 
 // tslint:disable:max-line-length
-import {serialization, Tensor} from '@tensorflow/tfjs-core';
+import {max, serialization, Tensor} from '@tensorflow/tfjs-core';
 
 import * as K from '../backend/tfjs_backend';
 import {checkDataFormat, checkPaddingMode, DataFormat, PaddingMode} from '../common';
@@ -367,7 +367,7 @@ export class GlobalMaxPooling1D extends GlobalPooling1D {
 
   call(inputs: Tensor|Tensor[], kwargs: Kwargs): Tensor|Tensor[] {
     const input = generic_utils.getExactlyOneTensor(inputs);
-    return K.max(input, 1);
+    return max(input, 1);
   }
 }
 serialization.SerializationMap.register(GlobalMaxPooling1D);
@@ -460,9 +460,9 @@ export class GlobalMaxPooling2D extends GlobalPooling2D {
   call(inputs: Tensor|Tensor[], kwargs: Kwargs): Tensor|Tensor[] {
     const input = generic_utils.getExactlyOneTensor(inputs);
     if (this.dataFormat === 'channelsLast') {
-      return K.max(input, [1, 2]);
+      return max(input, [1, 2]);
     } else {
-      return K.max(input, [2, 3]);
+      return max(input, [2, 3]);
     }
   }
 }

--- a/src/layers/recurrent.ts
+++ b/src/layers/recurrent.ts
@@ -12,9 +12,9 @@
  * TensorFlow.js Layers: Recurrent Neural Network Layers.
  */
 
+// tslint:disable:max-line-length
 import {add, doc, neg, serialization, sum, Tensor, util} from '@tensorflow/tfjs-core';
 
-// tslint:disable:max-line-length
 import {ActivationFn, ActivationIdentifier, getActivation, serializeActivation} from '../activations';
 import * as K from '../backend/tfjs_backend';
 import {Constraint, ConstraintIdentifier, getConstraint, serializeConstraint} from '../constraints';

--- a/src/layers/recurrent.ts
+++ b/src/layers/recurrent.ts
@@ -12,7 +12,7 @@
  * TensorFlow.js Layers: Recurrent Neural Network Layers.
  */
 
-import {doc, serialization, Tensor, util} from '@tensorflow/tfjs-core';
+import {add, doc, neg, serialization, sum, Tensor, util} from '@tensorflow/tfjs-core';
 
 // tslint:disable:max-line-length
 import {ActivationFn, ActivationIdentifier, getActivation, serializeActivation} from '../activations';
@@ -590,7 +590,7 @@ export class RNN extends Layer {
     // [Samples, timeSteps, inputDim].
     let initialState = K.zeros(inputs.shape);
     // [Samples].
-    initialState = K.sum(initialState, [1, 2]);
+    initialState = sum(initialState, [1, 2]);
     initialState = K.expandDims(initialState);  // [Samples, 1].
 
     if (Array.isArray(this.cell.stateSize)) {
@@ -892,7 +892,7 @@ export class SimpleRNNCell extends RNNCell {
     if (this.bias != null) {
       h = K.biasAdd(h, this.bias.read());
     }
-    let output = K.add(h, K.dot(prevOutput, this.recurrentKernel.read()));
+    let output = add(h, K.dot(prevOutput, this.recurrentKernel.read()));
     if (this.activation != null) {
       output = this.activation(output);
     }
@@ -1348,12 +1348,10 @@ export class GRUCell extends RNNCell {
       const hTMinus1Z = hTMinus1;
       const hTMinus1R = hTMinus1;
       const hTMinus1H = hTMinus1;
-      z = this.recurrentActivation(
-          K.add(xZ, K.dot(hTMinus1Z, recurrentKernelZ)));
-      r = this.recurrentActivation(
-          K.add(xR, K.dot(hTMinus1R, recurrentKernelR)));
+      z = this.recurrentActivation(add(xZ, K.dot(hTMinus1Z, recurrentKernelZ)));
+      r = this.recurrentActivation(add(xR, K.dot(hTMinus1R, recurrentKernelR)));
       hh = this.activation(
-          K.add(xH, K.dot(K.multiply(r, hTMinus1H), recurrentKernelH)));
+          add(xH, K.dot(K.multiply(r, hTMinus1H), recurrentKernelH)));
     } else {
       // TODO(cais): Add input dropout.
       let matrixX = K.dot(inputs, this.kernel.read());
@@ -1371,20 +1369,20 @@ export class GRUCell extends RNNCell {
       const recurrentR =
           K.sliceAlongLastAxis(matrixInner, this.units, this.units);
 
-      z = this.recurrentActivation(K.add(xZ, recurrentZ));
-      r = this.recurrentActivation(K.add(xR, recurrentR));
+      z = this.recurrentActivation(add(xZ, recurrentZ));
+      r = this.recurrentActivation(add(xR, recurrentR));
 
       const xH = K.sliceAlongLastAxis(matrixX, 2 * this.units, this.units);
       const recurrentH = K.dot(
           K.multiply(r, hTMinus1),
           K.sliceAlongLastAxis(
               this.recurrentKernel.read(), 2 * this.units, this.units));
-      hh = this.activation(K.add(xH, recurrentH));
+      hh = this.activation(add(xH, recurrentH));
     }
 
-    const h = K.add(
-        K.multiply(z, hTMinus1),
-        K.multiply(K.scalarPlusArray(K.getScalar(1), K.neg(z)), hh));
+    const h =
+        add(K.multiply(z, hTMinus1),
+            K.multiply(K.scalarPlusArray(K.getScalar(1), neg(z)), hh));
     // TODO(cais): Add use_learning_phase flag properly.
     return [h, h];
   }
@@ -1831,22 +1829,18 @@ export class LSTMCell extends RNNCell {
       const hTMinus1F = hTMinus1;
       const hTMinus1C = hTMinus1;
       const hTMinus1O = hTMinus1;
-      i = this.recurrentActivation(
-          K.add(xI, K.dot(hTMinus1I, recurrentKernelI)));
-      f = this.recurrentActivation(
-          K.add(xF, K.dot(hTMinus1F, recurrentKernelF)));
-      c = K.add(
+      i = this.recurrentActivation(add(xI, K.dot(hTMinus1I, recurrentKernelI)));
+      f = this.recurrentActivation(add(xF, K.dot(hTMinus1F, recurrentKernelF)));
+      c = add(
           K.multiply(f, cTMinus1),
           K.multiply(
-              i,
-              this.activation(K.add(xC, K.dot(hTMinus1C, recurrentKernelC)))));
-      o = this.recurrentActivation(
-          K.add(xO, K.dot(hTMinus1O, recurrentKernelO)));
+              i, this.activation(add(xC, K.dot(hTMinus1C, recurrentKernelC)))));
+      o = this.recurrentActivation(add(xO, K.dot(hTMinus1O, recurrentKernelO)));
     } else {
       // TODO(cais): Add input dropout.
       let z = K.dot(inputs, this.kernel.read());
       // TODO(cais): Add recurrent dropout.
-      z = K.add(z, K.dot(hTMinus1, this.recurrentKernel.read()));
+      z = add(z, K.dot(hTMinus1, this.recurrentKernel.read()));
       if (this.useBias) {
         z = K.biasAdd(z, this.bias.read());
       }
@@ -1858,7 +1852,7 @@ export class LSTMCell extends RNNCell {
 
       i = this.recurrentActivation(z0);
       f = this.recurrentActivation(z1);
-      c = K.add(K.multiply(f, cTMinus1), K.multiply(i, this.activation(z2)));
+      c = add(K.multiply(f, cTMinus1), K.multiply(i, this.activation(z2)));
       o = this.recurrentActivation(z3);
     }
 

--- a/src/layers/recurrent_test.ts
+++ b/src/layers/recurrent_test.ts
@@ -13,7 +13,7 @@
  */
 
 // tslint:disable:max-line-length
-import {Scalar, scalar, Tensor, tensor2d, tensor3d, train} from '@tensorflow/tfjs-core';
+import {neg, Scalar, scalar, Tensor, tensor2d, tensor3d, train, transpose} from '@tensorflow/tfjs-core';
 
 import * as K from '../backend/tfjs_backend';
 import * as tfl from '../index';
@@ -47,7 +47,7 @@ class RNNCellForTest extends RNNCell {
     const states = inputs.slice(1);
     const mean = K.mean(dataInputs) as Scalar;
     const newStates = states.map(state => K.scalarPlusArray(mean, state));
-    const output = K.neg(newStates[0]);
+    const output = neg(newStates[0]);
     return [output].concat(newStates);
   }
 }
@@ -432,7 +432,7 @@ describeMathCPUAndGPU('SimpleRNN Tensor', () => {
       }
 
       expect(output.shape).toEqual([batchSize, timeSteps, units]);
-      const timeMajorOutput = K.transpose(output, [1, 0, 2]);
+      const timeMajorOutput = transpose(output, [1, 0, 2]);
       const outputT0 = K.sliceAlongFirstAxis(timeMajorOutput, 0, 1);
       const outputT1 = K.sliceAlongFirstAxis(timeMajorOutput, 1, 1);
       expectTensorsClose(
@@ -644,7 +644,7 @@ describeMathCPUAndGPU('GRU Tensor', () => {
             const outputs = goldenOutputElementValues.map(
                 value => K.scalarTimesArray(
                     scalar(value), K.ones([1, batchSize, units])));
-            expectedOutput = K.transpose(
+            expectedOutput = transpose(
                 K.concatAlongFirstAxis(
                     K.concatAlongFirstAxis(outputs[0], outputs[1]), outputs[2]),
                 [1, 0, 2]);
@@ -869,7 +869,7 @@ describeMathCPUAndGPU('LSTM Tensor', () => {
             const outputAtT1 = K.scalarTimesArray(
                 scalar(goldenOutputElementValueAtT1),
                 K.ones([1, batchSize, units]));
-            expectedOutput = K.transpose(
+            expectedOutput = transpose(
                 K.concatAlongFirstAxis(outputAtT0, outputAtT1), [1, 0, 2]);
           } else {
             expectedOutput = K.scalarTimesArray(

--- a/src/layers/wrappers.ts
+++ b/src/layers/wrappers.ts
@@ -13,7 +13,7 @@
  */
 
 // tslint:disable:max-line-length
-import {serialization, Tensor} from '@tensorflow/tfjs-core';
+import {add, reverse, serialization, Tensor} from '@tensorflow/tfjs-core';
 
 import * as K from '../backend/tfjs_backend';
 import {Layer, LayerConfig} from '../engine/topology';
@@ -406,17 +406,17 @@ export class Bidirectional extends Wrapper {
     }
 
     if (this.returnSequences) {
-      yRev = K.reverse(yRev as Tensor, 1);
+      yRev = reverse(yRev as Tensor, 1);
     }
 
     let output: Tensor|Tensor[];
     if (this.mergeMode === 'concat') {
       output = K.concatenate([y as Tensor, yRev as Tensor]);
     } else if (this.mergeMode === 'sum') {
-      output = K.add(y as Tensor, yRev as Tensor);
+      output = add(y as Tensor, yRev as Tensor);
     } else if (this.mergeMode === 'ave') {
       output = K.scalarTimesArray(
-          K.getScalar(0.5), K.add(y as Tensor, yRev as Tensor));
+          K.getScalar(0.5), add(y as Tensor, yRev as Tensor));
     } else if (this.mergeMode === 'mul') {
       output = K.multiply(y as Tensor, yRev as Tensor);
     } else if (this.mergeMode == null) {

--- a/src/losses.ts
+++ b/src/losses.ts
@@ -9,7 +9,7 @@
  */
 
 /* Original Source: losses.py */
-
+import * as tfc from '@tensorflow/tfjs-core';
 import {Tensor} from '@tensorflow/tfjs-core';
 
 import * as K from './backend/tfjs_backend';
@@ -55,7 +55,7 @@ export function meanSquaredError(yTrue: Tensor, yPred: Tensor): Tensor {
  * @return Mean absolute error Tensor.
  */
 export function meanAbsoluteError(yTrue: Tensor, yPred: Tensor): Tensor {
-  return K.mean(K.abs(K.subtract(yPred, yTrue)), -1);
+  return K.mean(tfc.abs(K.subtract(yPred, yTrue)), -1);
 }
 
 /**
@@ -77,8 +77,8 @@ export function meanAbsoluteError(yTrue: Tensor, yPred: Tensor): Tensor {
 export function meanAbsolutePercentageError(
     yTrue: Tensor, yPred: Tensor): Tensor {
   const diff = K.subtract(yTrue, yPred);
-  const clippedTrue = K.clip(K.abs(yTrue), K.epsilon(), Number.MAX_VALUE);
-  const absResult = K.abs(K.divide(diff, clippedTrue));
+  const clippedTrue = K.clip(tfc.abs(yTrue), K.epsilon(), Number.MAX_VALUE);
+  const absResult = tfc.abs(K.divide(diff, clippedTrue));
   return K.scalarTimesArray(K.getScalar(100.0), K.mean(absResult, -1));
 }
 
@@ -87,10 +87,10 @@ export function meanSquaredLogarithmicError(
   const one = K.getScalar(1.0);
 
   const clippedPred = K.clip(yPred, K.epsilon(), Number.MAX_VALUE);
-  const firstLog = K.log(K.scalarPlusArray(one, clippedPred));
+  const firstLog = tfc.log(K.scalarPlusArray(one, clippedPred));
 
   const clippedTrue = K.clip(yTrue, K.epsilon(), Number.MAX_VALUE);
-  const secondLog = K.log(K.scalarPlusArray(one, clippedTrue));
+  const secondLog = tfc.log(K.scalarPlusArray(one, clippedTrue));
 
   return K.mean(K.square(K.subtract(firstLog, secondLog)), -1);
 }
@@ -99,7 +99,7 @@ export function squaredHinge(yTrue: Tensor, yPred: Tensor): Tensor {
   const zeroTensor = K.getScalar(0.0);
   const one = K.getScalar(1.0);
   const maxResult =
-      K.maximum(zeroTensor, K.subtract(one, K.multiply(yTrue, yPred)));
+      tfc.maximum(zeroTensor, K.subtract(one, K.multiply(yTrue, yPred)));
   return K.mean(K.square(maxResult), -1);
 }
 
@@ -107,16 +107,16 @@ export function hinge(yTrue: Tensor, yPred: Tensor): Tensor {
   const zeroTensor = K.getScalar(0.0);
   const one = K.getScalar(1.0);
   const maxResult =
-      K.maximum(zeroTensor, K.subtract(one, K.multiply(yTrue, yPred)));
+      tfc.maximum(zeroTensor, K.subtract(one, K.multiply(yTrue, yPred)));
   return K.mean(maxResult, -1);
 }
 
 export function categoricalHinge(yTrue: Tensor, yPred: Tensor): Tensor {
   const zeroTensor = K.getScalar(0.0);
   const one = K.getScalar(1.0);
-  const pos = K.sum(K.multiply(yTrue, yPred), -1);
-  const neg = K.max(K.multiply(K.subtract(one, yTrue), yPred), -1);
-  return K.maximum(zeroTensor, K.scalarPlusArray(one, K.subtract(neg, pos)));
+  const pos = tfc.sum(K.multiply(yTrue, yPred), -1);
+  const neg = tfc.max(K.multiply(K.subtract(one, yTrue), yPred), -1);
+  return tfc.maximum(zeroTensor, K.scalarPlusArray(one, K.subtract(neg, pos)));
 }
 
 /**
@@ -131,7 +131,7 @@ export function logcosh(yTrue: Tensor, yPred: Tensor): Tensor {
   const log2 = K.getScalar(Math.log(2.0));
   const predictionDiff = K.subtract(yPred, yTrue);
   const logcoshResult = K.subtract(
-      K.add(
+      tfc.add(
           predictionDiff,
           K.softplus(K.scalarTimesArray(K.getScalar(-2.0), predictionDiff))),
       log2);
@@ -155,12 +155,12 @@ export function kullbackLeiblerDivergence(
     yTrue: Tensor, yPred: Tensor): Tensor {
   const clippedTrue = K.clip(yTrue, K.epsilon(), 1);
   const clippedPred = K.clip(yPred, K.epsilon(), 1);
-  return K.sum(
-      K.multiply(yTrue, K.log(K.divide(clippedTrue, clippedPred))), -1);
+  return tfc.sum(
+      K.multiply(yTrue, tfc.log(K.divide(clippedTrue, clippedPred))), -1);
 }
 
 export function poisson(yTrue: Tensor, yPred: Tensor): Tensor {
-  const logPred = K.log(K.scalarPlusArray(K.getScalar(K.epsilon()), yPred));
+  const logPred = tfc.log(K.scalarPlusArray(K.getScalar(K.epsilon()), yPred));
   return K.mean(K.subtract(yPred, K.multiply(yTrue, logPred)), -1);
 }
 
@@ -187,7 +187,7 @@ export function cosineProximity(yTrue: Tensor, yPred: Tensor): Tensor {
   const trueNormalized = K.l2Normalize(yTrue, -1);
   const predNormalized = K.l2Normalize(yPred, -1);
   const trueXPred = K.multiply(trueNormalized, predNormalized);
-  return K.neg(K.sum(trueXPred, -1));
+  return tfc.neg(tfc.sum(trueXPred, -1));
 }
 
 export const mse = meanSquaredError;

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -13,7 +13,7 @@
  */
 
 // tslint:disable:max-line-length
-import {onesLike, Tensor} from '@tensorflow/tfjs-core';
+import {equal, greater, onesLike, Tensor} from '@tensorflow/tfjs-core';
 import * as K from './backend/tfjs_backend';
 import {NotImplementedError, ValueError} from './errors';
 import {categoricalCrossentropy as categoricalCrossentropyLoss, cosineProximity, meanAbsoluteError, meanAbsolutePercentageError, meanSquaredError, sparseCategoricalCrossentropy as sparseCategoricalCrossentropyLoss} from './losses';
@@ -50,8 +50,8 @@ import {LossOrMetricFn} from './types';
 export function binaryAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
   // TODO(cais): Maybe avoid creating a new Scalar on every invocation.
   const threshold = K.scalarTimesArray(K.getScalar(0.5), onesLike(yPred));
-  const yPredThresholded = K.cast(K.greater(yPred, threshold), yTrue.dtype);
-  return K.mean(K.equal(yTrue, yPredThresholded), -1);
+  const yPredThresholded = K.cast(greater(yPred, threshold), yTrue.dtype);
+  return K.mean(equal(yTrue, yPredThresholded), -1);
 }
 
 /**
@@ -71,7 +71,7 @@ export function binaryAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
  * @return Accuracy Tensor.
  */
 export function categoricalAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
-  return K.cast(K.equal(K.argmax(yTrue, -1), K.argmax(yPred, -1)), 'float32');
+  return K.cast(equal(K.argmax(yTrue, -1), K.argmax(yPred, -1)), 'float32');
 }
 
 /**

--- a/src/models_test.ts
+++ b/src/models_test.ts
@@ -9,7 +9,7 @@
  */
 
 // tslint:disable:max-line-length
-import {io, ones, Scalar, scalar, serialization, Tensor, tensor1d, tensor2d, zeros} from '@tensorflow/tfjs-core';
+import {io, ones, Scalar, scalar, serialization, sum, Tensor, tensor1d, tensor2d, zeros} from '@tensorflow/tfjs-core';
 
 import * as K from './backend/tfjs_backend';
 import {Model} from './engine/training';
@@ -85,7 +85,7 @@ describeMathCPU('model_from_json', () => {
           expect(model.layers.length).toEqual(9);
           const prediction = model.predict(K.zeros([1, 28, 28, 1])) as Tensor;
           expect(prediction.shape).toEqual([1, 10]);
-          expect(K.sum(prediction).dataSync()).toBeCloseTo(1);
+          expect(sum(prediction).dataSync()).toBeCloseTo(1);
           done();
         })
         .catch(done.fail);
@@ -114,7 +114,7 @@ describeMathCPU('model_from_json', () => {
       expect(model.layers.length).toEqual(8);
       const prediction = model.predict(K.zeros([1, 28, 28, 1])) as Tensor;
       expect(prediction.shape).toEqual([1, 10]);
-      expect(K.sum(prediction).dataSync()).toBeCloseTo(1);
+      expect(sum(prediction).dataSync()).toBeCloseTo(1);
       done();
     });
   });

--- a/src/regularizers.ts
+++ b/src/regularizers.ts
@@ -11,7 +11,7 @@
 /* original source: keras/regularizers.py */
 
 // tslint:disable:max-line-length
-import {doc, Scalar, serialization, Tensor, zeros} from '@tensorflow/tfjs-core';
+import {abs, add, doc, Scalar, serialization, sum, Tensor, zeros} from '@tensorflow/tfjs-core';
 
 import * as K from './backend/tfjs_backend';
 import {deserializeKerasObject, serializeKerasObject} from './utils/generic_utils';
@@ -75,11 +75,11 @@ export class L1L2 extends Regularizer {
     let regularization: Tensor = zeros([1]);
     if (this.hasL1) {
       regularization =
-          K.add(regularization, K.sum(K.scalarTimesArray(this.l1, K.abs(x))));
+          add(regularization, sum(K.scalarTimesArray(this.l1, abs(x))));
     }
     if (this.hasL2) {
-      regularization = K.add(
-          regularization, K.sum(K.scalarTimesArray(this.l2, K.square(x))));
+      regularization =
+          add(regularization, sum(K.scalarTimesArray(this.l2, K.square(x))));
     }
     return regularization.asScalar();
   }


### PR DESCRIPTION
We're aiming to removing as much as possible of the tfjs_backend file within the -layers repo.

Step 1: This PR removes all symbols in tfjs_backend that exactly forwarded to the core symbols.  Ie same function signature with no tweaking done to the inputs and outputs.

Step 2: Later PRs, will aim to converge layer's usage of functionally identical symbols -- some differ only in name (subtract versus sub), some differ only in unused arguments (dtype,shape are common extra args that -layers does nothing with and just calls the core symbol without them), some promote/demote from scalar<->single item 1d tensor.

Step 3: Review the remaining symbols, some might be candidates for migration to core, some migration to some other more appropriately named util/library in -layers.

One of the main points for review/discussion, convention on when/if any of these symbols should be imported directly, or only used off the imported top level symbol.  There's some mix and match on what felt most natural in code.  I think we'll want to come up with a more rigorous decision there though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/168)
<!-- Reviewable:end -->
