### PR TITLE
Redirect easily changeable backend functions straight to core

### DIFF
--- a/src/activations.ts
+++ b/src/activations.ts
@@ -149,7 +149,7 @@ export function tanh(x: Tensor): Tensor {
  * @throws ValueError: In case `dim(x) < 2`.
  */
 export function softmax(x: Tensor, axis: number = (-1)): Tensor {
-  return K.softmax(x, axis);
+  return tfc.softmax(x, axis);
 }
 
 export function serializeActivation(activation: ActivationFn):

--- a/src/backend/tfjs_backend.ts
+++ b/src/backend/tfjs_backend.ts
@@ -14,24 +14,24 @@
 
 // tslint:disable:max-line-length
 import * as tfc from '@tensorflow/tfjs-core';
-import { dispose, onesLike as coreOnesLike, Scalar, scalar, Tensor, Tensor1D, tensor1d, Tensor2D, tensor2d, Tensor3D, Tensor4D, tidy, util, variableGrads, where, zerosLike as coreZerosLike } from '@tensorflow/tfjs-core';
+import {dispose, onesLike as coreOnesLike, Scalar, scalar, Tensor, Tensor1D, tensor1d, Tensor2D, tensor2d, Tensor3D, Tensor4D, tidy, util, variableGrads, where, zerosLike as coreZerosLike} from '@tensorflow/tfjs-core';
 
-import { checkDataFormat, checkPaddingMode, checkPoolMode, DataFormat, nameScope as commonNameScope, PaddingMode, PoolMode } from '../common';
-import { Constraint } from '../constraints';
-import { NotImplementedError, ValueError } from '../errors';
-import { DType, LayerVariable, RnnStepFunction, Shape, SymbolicTensor } from '../types';
-import { pyNormalizeArrayIndex } from '../utils/generic_utils';
+import {checkDataFormat, checkPaddingMode, checkPoolMode, DataFormat, nameScope as commonNameScope, PaddingMode, PoolMode} from '../common';
+import {Constraint} from '../constraints';
+import {NotImplementedError, ValueError} from '../errors';
+import {DType, LayerVariable, RnnStepFunction, Shape, SymbolicTensor} from '../types';
+import {pyNormalizeArrayIndex} from '../utils/generic_utils';
 import * as math_utils from '../utils/math_utils';
 
-import { epsilon as common_epsilon } from './common';
-import { imageDataFormat } from './common';
+import {epsilon as common_epsilon} from './common';
+import {imageDataFormat} from './common';
 
 // tslint:enable
 
 /* Setting and getting backend from deeplearn.js. */
 
 // Default deeplearn.js backend is WebGL (GPU).
-let backend: 'cpu' | 'webgl' = 'webgl';
+let backend: 'cpu'|'webgl' = 'webgl';
 
 const DEFAULT_DTYPE = DType.float32;
 
@@ -44,17 +44,17 @@ export function disposeScalarCache() {
   }
 }
 
-export function setBackend(requestedBackend: 'cpu' | 'webgl') {
+export function setBackend(requestedBackend: 'cpu'|'webgl') {
   tfc.setBackend(requestedBackend);
   backend = requestedBackend;
   disposeScalarCache();
 }
 
-export function getBackend(): 'cpu' | 'webgl' {
+export function getBackend(): 'cpu'|'webgl' {
   return backend;
 }
 
-const scalarCache: { [typeKey: string]: { [key: number]: Scalar } } = {
+const scalarCache: {[typeKey: string]: {[key: number]: Scalar}} = {
   float32: {},
   int32: {}
 };
@@ -95,7 +95,7 @@ export function isBackendSymbolic(): boolean {
  * @param x The tensor.
  * @return Shape of the tensor.
  */
-export function shape(x: Tensor | SymbolicTensor): Shape {
+export function shape(x: Tensor|SymbolicTensor): Shape {
   return x.shape;
 }
 
@@ -105,7 +105,7 @@ export function shape(x: Tensor | SymbolicTensor): Shape {
  * @param x The tensor.
  * @return Shape of the tensor as number[].
  */
-export function intShape(x: Tensor | SymbolicTensor): number[] {
+export function intShape(x: Tensor|SymbolicTensor): number[] {
   return x.shape;
 }
 
@@ -115,7 +115,7 @@ export function intShape(x: Tensor | SymbolicTensor): number[] {
  * @param x The tensor.
  * @return Number of dimensions of `x`.
  */
-export function ndim(x: Tensor | SymbolicTensor): number {
+export function ndim(x: Tensor|SymbolicTensor): number {
   return x.shape.length;
 }
 
@@ -124,7 +124,7 @@ export function ndim(x: Tensor | SymbolicTensor): number {
  *
  * @param x The tensor.
  */
-export function dtype(x: Tensor | SymbolicTensor): DType {
+export function dtype(x: Tensor|SymbolicTensor): DType {
   // TODO(michaelterry): Update if additional data types are available.
   return (x instanceof Tensor) ? DEFAULT_DTYPE : (x as SymbolicTensor).dtype;
 }
@@ -144,7 +144,7 @@ export function dtype(x: Tensor | SymbolicTensor): DType {
  *   all values must be non-null/defined.
  */
 export function normalizeAxis(
-  x: Tensor | SymbolicTensor, axis: number | number[]): number | number[] {
+    x: Tensor|SymbolicTensor, axis: number|number[]): number|number[] {
   if (axis == null) {
     return axis;
   }
@@ -160,7 +160,7 @@ export function normalizeAxis(
  * @param x The Tensor.
  * @return Number of elements in `x`.
  */
-export function countParams(x: Tensor | SymbolicTensor): number {
+export function countParams(x: Tensor|SymbolicTensor): number {
   const shape = x.shape;
   if (shape.length > 0) {
     return shape.reduce((a: number, b: number) => a * b);
@@ -176,7 +176,7 @@ export function countParams(x: Tensor | SymbolicTensor): number {
  * @param dtype String: 'float32'|'int32'|'bool'.
  * @returns Tensor of the specified `dtype`.
  */
-export function cast(x: Tensor, dtype: 'float32' | 'int32' | 'bool'): Tensor {
+export function cast(x: Tensor, dtype: 'float32'|'int32'|'bool'): Tensor {
   return x.asType(dtype);
 }
 
@@ -218,8 +218,8 @@ export function expandDims(x: Tensor, axis = -1): Tensor {
 export function temporalPadding(x: Tensor, padding?: [number, number]): Tensor {
   if (ndim(x) !== 3) {
     throw new ValueError(
-      `temporalPadding expects input tensor to be 3-D, but received a ` +
-      `${ndim(x)}-D tensor.`);
+        `temporalPadding expects input tensor to be 3-D, but received a ` +
+        `${ndim(x)}-D tensor.`);
   }
 
   if (padding == null) {
@@ -227,8 +227,8 @@ export function temporalPadding(x: Tensor, padding?: [number, number]): Tensor {
   }
   if (padding.length !== 2) {
     throw new ValueError(
-      `temporalPadding expects input padding pattern to be a length-2 ` +
-      `array, but received a length-${padding.length} array.`);
+        `temporalPadding expects input padding pattern to be a length-2 ` +
+        `array, but received a length-${padding.length} array.`);
   }
 
   const pattern: Array<[number, number]> = [[0, 0], padding, [0, 0]];
@@ -246,22 +246,22 @@ export function temporalPadding(x: Tensor, padding?: [number, number]): Tensor {
  * @return Padded 4D `Tensor`.
  */
 export function spatial2dPadding(
-  x: Tensor, padding?: [[number, number], [number, number]],
-  dataFormat?: DataFormat): Tensor {
+    x: Tensor, padding?: [[number, number], [number, number]],
+    dataFormat?: DataFormat): Tensor {
   if (ndim(x) !== 4) {
     throw new ValueError(
-      `temporalPadding expects input tensor to be 4-D, but received a ` +
-      `${ndim(x)}-D tensor.`);
+        `temporalPadding expects input tensor to be 4-D, but received a ` +
+        `${ndim(x)}-D tensor.`);
   }
 
   if (padding == null) {
     padding = [[1, 1], [1, 1]];
   }
   if (padding.length !== 2 || padding[0].length !== 2 ||
-    padding[1].length !== 2) {
+      padding[1].length !== 2) {
     throw new ValueError(
-      'spatial2dPadding expects `padding` to be an Array of two Arrays, ' +
-      'each of which is an Array of two integers.');
+        'spatial2dPadding expects `padding` to be an Array of two Arrays, ' +
+        'each of which is an Array of two integers.');
   }
 
   if (dataFormat == null) {
@@ -269,8 +269,8 @@ export function spatial2dPadding(
   }
   if (dataFormat !== 'channelsLast' && dataFormat !== 'channelsFirst') {
     throw new ValueError(
-      `Unknown data format: ${dataFormat}. ` +
-      `Supported data formats are 'channelsLast' and 'channelsFirst.`);
+        `Unknown data format: ${dataFormat}. ` +
+        `Supported data formats are 'channelsLast' and 'channelsFirst.`);
   }
 
   let pattern: Array<[number, number]>;
@@ -297,8 +297,8 @@ export function spatial2dPadding(
 export function repeat(x: Tensor, n: number): Tensor {
   if (x.shape.length !== 2) {
     throw new ValueError(
-      `repeat() expects a rank-2 tensor, but received a ` +
-      `rank-${x.shape.length} tensor.`);
+        `repeat() expects a rank-2 tensor, but received a ` +
+        `rank-${x.shape.length} tensor.`);
   }
   const y = expandDims(x, 1);
   return tile(y, [1, n, 1]);
@@ -325,7 +325,7 @@ export function flatten(x: Tensor): Tensor {
 export function batchFlatten(x: Tensor): Tensor {
   if (ndim(x) <= 1) {
     throw new ValueError(
-      `batchFlatten requires a minimum rank of 2. Got rank: ${ndim(x)}.`);
+        `batchFlatten requires a minimum rank of 2. Got rank: ${ndim(x)}.`);
   }
   const newShape = [x.shape[0], math_utils.arrayProd(x.shape, 1)];
   return reshape(x, newShape);
@@ -340,7 +340,7 @@ export function batchFlatten(x: Tensor): Tensor {
  * @throws ValueError: If `array` is of an unsupported subtype of `Tensor`.
  */
 export function sliceAlongFirstAxis(
-  array: Tensor, start: number, size: number): Tensor {
+    array: Tensor, start: number, size: number): Tensor {
   switch (array.rank) {
     case 1:
       return tfc.slice1d(array as Tensor1D, start, size);
@@ -348,16 +348,16 @@ export function sliceAlongFirstAxis(
       return tfc.slice2d(array as Tensor2D, [start, 0], [size, array.shape[1]]);
     case 3:
       return tfc.slice3d(
-        array as Tensor3D, [start, 0, 0],
-        [size, array.shape[1], array.shape[2]]);
+          array as Tensor3D, [start, 0, 0],
+          [size, array.shape[1], array.shape[2]]);
     case 4:
       return tfc.slice4d(
-        array as Tensor4D, [start, 0, 0, 0],
-        [size, array.shape[1], array.shape[2], array.shape[3]]);
+          array as Tensor4D, [start, 0, 0, 0],
+          [size, array.shape[1], array.shape[2], array.shape[3]]);
     default:
       throw new ValueError(
-        `sliceAlongFirstAxis() received an unsupported tensor rank: ` +
-        `${array.rank}`);
+          `sliceAlongFirstAxis() received an unsupported tensor rank: ` +
+          `${array.rank}`);
   }
 }
 
@@ -370,7 +370,7 @@ export function sliceAlongFirstAxis(
  * @throws ValueError: If `array` is of an unsupported subtype of `Tensor`.
  */
 export function sliceAlongLastAxis(
-  array: Tensor, start: number, size: number): Tensor {
+    array: Tensor, start: number, size: number): Tensor {
   switch (array.rank) {
     case 1:
       return tfc.slice1d(array as Tensor1D, start, size);
@@ -378,16 +378,16 @@ export function sliceAlongLastAxis(
       return tfc.slice2d(array as Tensor2D, [0, start], [array.shape[0], size]);
     case 3:
       return tfc.slice3d(
-        array as Tensor3D, [0, 0, start],
-        [array.shape[0], array.shape[1], size]);
+          array as Tensor3D, [0, 0, start],
+          [array.shape[0], array.shape[1], size]);
     case 4:
       return tfc.slice4d(
-        array as Tensor4D, [0, 0, 0, start],
-        [array.shape[0], array.shape[1], array.shape[2], size]);
+          array as Tensor4D, [0, 0, 0, start],
+          [array.shape[0], array.shape[1], array.shape[2], size]);
     default:
       throw new ValueError(
-        `sliceAlongLastAxis() received an unsupported tensor rank: ` +
-        `${array.rank}`);
+          `sliceAlongLastAxis() received an unsupported tensor rank: ` +
+          `${array.rank}`);
   }
 }
 
@@ -401,7 +401,7 @@ export function sliceAlongLastAxis(
  * @throws ValueError: If `array` is of an unsupported subtype of `Tensor`.
  */
 export function sliceAlongAxis(
-  array: Tensor, start: number, size: number, axis: number): Tensor {
+    array: Tensor, start: number, size: number, axis: number): Tensor {
   switch (array.rank) {
     case 1:
       return tfc.slice1d(array as Tensor1D, start, size);
@@ -413,8 +413,8 @@ export function sliceAlongAxis(
           return sliceAlongLastAxis(array, start, size);
         default:
           throw new ValueError(
-            `The axis is not within the rank of the tensor ` +
-            `${axis}`);
+              `The axis is not within the rank of the tensor ` +
+              `${axis}`);
       }
     case 3:
       switch (axis) {
@@ -422,14 +422,14 @@ export function sliceAlongAxis(
           return sliceAlongFirstAxis(array, start, size);
         case 2:
           return tfc.slice3d(
-            array as Tensor3D, [0, start, 0],
-            [array.shape[0], size, array.shape[2]]);
+              array as Tensor3D, [0, start, 0],
+              [array.shape[0], size, array.shape[2]]);
         case 3:
           return sliceAlongLastAxis(array, start, size);
         default:
           throw new ValueError(
-            `The axis is not within the rank of the tensor ` +
-            `${axis}`);
+              `The axis is not within the rank of the tensor ` +
+              `${axis}`);
       }
     case 4:
       switch (axis) {
@@ -437,23 +437,23 @@ export function sliceAlongAxis(
           return sliceAlongFirstAxis(array, start, size);
         case 2:
           return tfc.slice4d(
-            array as Tensor4D, [0, start, 0, 0],
-            [array.shape[0], size, array.shape[2], array.shape[3]]);
+              array as Tensor4D, [0, start, 0, 0],
+              [array.shape[0], size, array.shape[2], array.shape[3]]);
         case 3:
           return tfc.slice4d(
-            array as Tensor4D, [0, 0, start, 0],
-            [array.shape[0], array.shape[1], size, array.shape[3]]);
+              array as Tensor4D, [0, 0, start, 0],
+              [array.shape[0], array.shape[1], size, array.shape[3]]);
         case 4:
           return sliceAlongLastAxis(array, start, size);
         default:
           throw new ValueError(
-            `The axis is not within the rank of the tensor ` +
-            `${axis}`);
+              `The axis is not within the rank of the tensor ` +
+              `${axis}`);
       }
     default:
       throw new ValueError(
-        `sliceAlongLastAxis() received an unsupported tensor rank: ` +
-        `${array.rank}`);
+          `sliceAlongLastAxis() received an unsupported tensor rank: ` +
+          `${array.rank}`);
   }
 }
 
@@ -476,16 +476,16 @@ export function sliceAlongAxis(
  *   [normalized tensor, mean of input, variance of input].
  */
 function regularNormalizeBatchInTraining(
-  x: Tensor, gamma: Tensor, beta: Tensor, reductionAxes: number[],
-  epsilon = 1e-3): [Tensor, Tensor, Tensor] {
+    x: Tensor, gamma: Tensor, beta: Tensor, reductionAxes: number[],
+    epsilon = 1e-3): [Tensor, Tensor, Tensor] {
   return tidy(() => {
-    const meanAndVariance = tfc.moments(x, reductionAxes);
-    const mean = meanAndVariance.mean;
-    const variance = meanAndVariance.variance;
-    const normed =
-      batchNormalization(x, mean, variance, beta, gamma, epsilon);
-    return [normed, mean, variance];
-  }) as [Tensor, Tensor, Tensor];
+           const meanAndVariance = tfc.moments(x, reductionAxes);
+           const mean = meanAndVariance.mean;
+           const variance = meanAndVariance.variance;
+           const normed =
+               batchNormalization(x, mean, variance, beta, gamma, epsilon);
+           return [normed, mean, variance];
+         }) as [Tensor, Tensor, Tensor];
 }
 
 /**
@@ -506,31 +506,31 @@ function regularNormalizeBatchInTraining(
  *   [normalized tensor, mean of input, variance of input].
  */
 function broadcastNormalizeBatchInTraining(
-  x: Tensor, gamma: Tensor, beta: Tensor, reductionAxes: number[],
-  epsilon = 1e-3): [Tensor, Tensor, Tensor] {
+    x: Tensor, gamma: Tensor, beta: Tensor, reductionAxes: number[],
+    epsilon = 1e-3): [Tensor, Tensor, Tensor] {
   return tidy(() => {
-    const meanAndVariance = tfc.moments(x, reductionAxes);
-    const mean = meanAndVariance.mean;
-    const variance = meanAndVariance.variance;
-    const targetShape: number[] = [];
-    for (const axis of math_utils.range(0, ndim(x))) {
-      if (reductionAxes.indexOf(axis) !== -1) {
-        targetShape.push(1);
-      } else {
-        targetShape.push(x.shape[axis]);
-      }
-    }
-    const broadcastMean = reshape(mean, targetShape);
-    const broadcastVariance = reshape(variance, targetShape);
-    const broadcastGamma =
-      gamma == null ? null : reshape(gamma, targetShape);
-    const broadcastBeta =
-      beta == null ? null : reshape(beta, targetShape);
-    const normed = batchNormalization(
-      x, broadcastMean, broadcastVariance, broadcastBeta,
-      broadcastGamma, epsilon);
-    return [normed, mean, variance];
-  }) as [Tensor, Tensor, Tensor];
+           const meanAndVariance = tfc.moments(x, reductionAxes);
+           const mean = meanAndVariance.mean;
+           const variance = meanAndVariance.variance;
+           const targetShape: number[] = [];
+           for (const axis of math_utils.range(0, ndim(x))) {
+             if (reductionAxes.indexOf(axis) !== -1) {
+               targetShape.push(1);
+             } else {
+               targetShape.push(x.shape[axis]);
+             }
+           }
+           const broadcastMean = reshape(mean, targetShape);
+           const broadcastVariance = reshape(variance, targetShape);
+           const broadcastGamma =
+               gamma == null ? null : reshape(gamma, targetShape);
+           const broadcastBeta =
+               beta == null ? null : reshape(beta, targetShape);
+           const normed = batchNormalization(
+               x, broadcastMean, broadcastVariance, broadcastBeta,
+               broadcastGamma, epsilon);
+           return [normed, mean, variance];
+         }) as [Tensor, Tensor, Tensor];
 }
 
 /**
@@ -545,15 +545,15 @@ function broadcastNormalizeBatchInTraining(
  *   [normalized tensor, mean of input, variance of input].
  */
 export function normalizeBatchInTraining(
-  x: Tensor, gamma: Tensor, beta: Tensor, reductionAxes: number[],
-  epsilon = 1e-3): [Tensor, Tensor, Tensor] {
+    x: Tensor, gamma: Tensor, beta: Tensor, reductionAxes: number[],
+    epsilon = 1e-3): [Tensor, Tensor, Tensor] {
   if (util.arraysEqual(
-    reductionAxes.slice().sort(), math_utils.range(0, ndim(x) - 1))) {
+          reductionAxes.slice().sort(), math_utils.range(0, ndim(x) - 1))) {
     return regularNormalizeBatchInTraining(
-      x, gamma, beta, reductionAxes, epsilon);
+        x, gamma, beta, reductionAxes, epsilon);
   } else {
     return broadcastNormalizeBatchInTraining(
-      x, gamma, beta, reductionAxes, epsilon);
+        x, gamma, beta, reductionAxes, epsilon);
   }
 }
 
@@ -601,8 +601,8 @@ export function concatAlongFirstAxis(a: Tensor, b: Tensor): Tensor {
       return tfc.concat4d([a as Tensor4D, b as Tensor4D], 0);
     default:
       throw new ValueError(
-        'concatAlongFirstAxis() received an unsupported tensor rank: ' +
-        a.rank);
+          'concatAlongFirstAxis() received an unsupported tensor rank: ' +
+          a.rank);
   }
 }
 
@@ -613,14 +613,14 @@ export function concatAlongFirstAxis(a: Tensor, b: Tensor): Tensor {
  *   must be the same as the number of dimensions in `x`. If a single integer,
  *   it will be treated as an Array of length 1.
  */
-export function tile(x: Tensor, n: number | number[]): Tensor {
+export function tile(x: Tensor, n: number|number[]): Tensor {
   if (!Array.isArray(n)) {
     n = [n];
   }
   if (ndim(x) !== n.length) {
     throw new ValueError(
-      `The length of input n (${n.length}) does not match ` +
-      `the number of dimensions in input x (${ndim(x)})`);
+        `The length of input n (${n.length}) does not match ` +
+        `the number of dimensions in input x (${ndim(x)})`);
   }
   return tfc.tile(x, n);
 }
@@ -637,8 +637,8 @@ export function tile(x: Tensor, n: number | number[]): Tensor {
  * @return The newly instantiated `Variable`.
  */
 export function variable(
-  x: Tensor, dtype?: DType, name?: string,
-  constraint?: Constraint): LayerVariable {
+    x: Tensor, dtype?: DType, name?: string,
+    constraint?: Constraint): LayerVariable {
   return new LayerVariable(x, dtype, name, true, constraint);
 }
 
@@ -661,7 +661,7 @@ export function batchGetValue(xs: LayerVariable[]): Tensor[] {
  *   carries the new value.
  */
 export function batchSetValue(
-  variablesAndValues: Array<[LayerVariable, Tensor]>): void {
+    variablesAndValues: Array<[LayerVariable, Tensor]>): void {
   variablesAndValues.map((variableAndValue) => {
     const variable: LayerVariable = variableAndValue[0];
     variable.write(variableAndValue[1]);
@@ -677,7 +677,7 @@ export function batchSetValue(
  * @return An all-zero Variable.
  */
 export function zerosVariable(
-  shape: Shape, dtype?: DType, name?: string): LayerVariable {
+    shape: Shape, dtype?: DType, name?: string): LayerVariable {
   // TODO(cais): Implement logic for dtype.
   return new LayerVariable(tfc.zeros(shape), dtype, name);
 }
@@ -691,7 +691,7 @@ export function zerosVariable(
  * @return A newly instantiated Variable.
  */
 export function zerosLike(
-  x: Tensor, dtype?: DType, name?: string): LayerVariable {
+    x: Tensor, dtype?: DType, name?: string): LayerVariable {
   return new LayerVariable(tfc.zerosLike(x), dtype, name);
 }
 
@@ -704,7 +704,7 @@ export function zerosLike(
  * @return An all-ones Variable.
  */
 export function onesVariable(
-  shape: Shape, dtype?: DType, name?: string): LayerVariable {
+    shape: Shape, dtype?: DType, name?: string): LayerVariable {
   // TODO(cais): Implement logic for dtype.
   const allocated = tfc.ones(shape);
   return new LayerVariable(allocated, dtype, name);
@@ -719,7 +719,7 @@ export function onesVariable(
  * @return A newly instantiated Variable.
  */
 export function onesLike(
-  x: Tensor, dtype?: DType, name?: string): LayerVariable {
+    x: Tensor, dtype?: DType, name?: string): LayerVariable {
   const allocated = tfc.onesLike(x);
   return new LayerVariable(allocated, dtype, name);
 }
@@ -762,7 +762,7 @@ export function eye(size: number, dtype?: DType, name?: string): Tensor {
  * @return A Variable, an identity matrix.
  */
 export function eyeVariable(
-  size: number, dtype?: DType, name?: string): LayerVariable {
+    size: number, dtype?: DType, name?: string): LayerVariable {
   return new LayerVariable(eye(size, dtype), dtype, name);
 }
 
@@ -799,10 +799,10 @@ export function scalarPlusArray(c: Scalar, x: Tensor): Tensor {
  * @return The uniform-random Variable.
  */
 export function randomUniformVariable(
-  shape: Shape, minval: number, maxval: number, dtype?: DType, seed?: number,
-  name = 'randomUniform'): LayerVariable {
+    shape: Shape, minval: number, maxval: number, dtype?: DType, seed?: number,
+    name = 'randomUniform'): LayerVariable {
   return new LayerVariable(
-    tfc.randomUniform(shape, minval, maxval, dtype), dtype, name);
+      tfc.randomUniform(shape, minval, maxval, dtype), dtype, name);
 }
 
 /**
@@ -816,15 +816,15 @@ export function randomUniformVariable(
  * @return The truncated-normal-random Variable.
  */
 export function truncatedNormalVariable(
-  shape: Shape, mean = 0.0, stddev = 1.0, dtype?: DType, seed?: number,
-  name = 'truncatedNormal'): LayerVariable {
+    shape: Shape, mean = 0.0, stddev = 1.0, dtype?: DType, seed?: number,
+    name = 'truncatedNormal'): LayerVariable {
   // TODO(cais): Implement logic for dtype and seed once they are supported
   // by deeplearn.js.
   if (dtype === DType.bool) {
     throw new NotImplementedError(`randomNormal does not support dType bool.`);
   }
   return new LayerVariable(
-    tfc.truncatedNormal(shape, mean, stddev, dtype, seed), dtype, name);
+      tfc.truncatedNormal(shape, mean, stddev, dtype, seed), dtype, name);
 }
 
 /**
@@ -838,8 +838,8 @@ export function truncatedNormalVariable(
  * @return The normal tensor.
  */
 export function randomNormal(
-  shape: Shape, mean = 0.0, stddev = 1.0, dtype?: DType,
-  seed?: number): Tensor {
+    shape: Shape, mean = 0.0, stddev = 1.0, dtype?: DType,
+    seed?: number): Tensor {
   if (dtype === DType.bool) {
     throw new NotImplementedError(`randomNormal does not support dType bool.`);
   }
@@ -858,10 +858,10 @@ export function randomNormal(
  * @return The truncated-normal-random Variable.
  */
 export function randomNormalVariable(
-  shape: Shape, mean = 0.0, stddev = 1.0, dtype?: DType, seed?: number,
-  name = 'randomNormal'): LayerVariable {
+    shape: Shape, mean = 0.0, stddev = 1.0, dtype?: DType, seed?: number,
+    name = 'randomNormal'): LayerVariable {
   return new LayerVariable(
-    randomNormal(shape, mean, stddev, dtype, seed), dtype, name);
+      randomNormal(shape, mean, stddev, dtype, seed), dtype, name);
 }
 
 /* Updating Variables */
@@ -912,8 +912,8 @@ export function updateSub(x: LayerVariable, decrement: Tensor): LayerVariable {
 export function dot(x: Tensor, y: Tensor): Tensor {
   if (ndim(y) !== 2) {
     throw new NotImplementedError(
-      `dot support for y other than rank 2 is not yet implemented: ` +
-      `y shape = ${shape}`);
+        `dot support for y other than rank 2 is not yet implemented: ` +
+        `y shape = ${shape}`);
   } else {
     if (ndim(x) === 2) {
       return tfc.matMul(x as Tensor2D, y as Tensor2D);
@@ -927,8 +927,8 @@ export function dot(x: Tensor, y: Tensor): Tensor {
       ]);
     } else {
       throw new NotImplementedError(
-        `dot support for x of rank ${ndim(x)} is not yet implemented: ` +
-        `x shape = ${shape}`);
+          `dot support for x of rank ${ndim(x)} is not yet implemented: ` +
+          `x shape = ${shape}`);
     }
   }
 }
@@ -948,10 +948,10 @@ export function sign(x: Tensor): Tensor {
   const zerosLikeX = coreZerosLike(x);
   const onesLikeX = coreOnesLike(x);
   return where(
-    tfc.equal(x, zerosLikeX), zerosLikeX,
-    where(
-      tfc.greater(x, coreZerosLike(x)), onesLikeX,
-      scalarTimesArray(getScalar(-1), onesLikeX)));
+      tfc.equal(x, zerosLikeX), zerosLikeX,
+      where(
+          tfc.greater(x, coreZerosLike(x)), onesLikeX,
+          scalarTimesArray(getScalar(-1), onesLikeX)));
 }
 
 /**
@@ -976,12 +976,12 @@ export function qr(x: Tensor2D): [Tensor, Tensor] {
     // function to the core.
     if (x.shape.length !== 2) {
       throw new ValueError(
-        `qr() requires a 2D Tensor, but got a ${x.shape.length}D Tensor.`);
+          `qr() requires a 2D Tensor, but got a ${x.shape.length}D Tensor.`);
     }
     if (x.shape[0] < x.shape[1]) {
       throw new ValueError(
-        `qr() requires x.shape[0] >= x.shape[1], but got shape: [${
-        x.shape}]`);
+          `qr() requires x.shape[0] >= x.shape[1], but got shape: [${
+              x.shape}]`);
     }
 
     const m = x.shape[0];
@@ -1011,8 +1011,8 @@ export function qr(x: Tensor2D): [Tensor, Tensor] {
           w = one2D.clone();
         } else {
           w = one2D.concat(
-            wPre.slice([1, 0], [wPre.shape[0] - 1, wPre.shape[1]]), 0) as
-            Tensor2D;
+                  wPre.slice([1, 0], [wPre.shape[0] - 1, wPre.shape[1]]), 0) as
+              Tensor2D;
         }
         const tau = tfc.neg(tfc.div(tfc.matMul(s, u1), normX)) as Tensor2D;
 
@@ -1023,20 +1023,20 @@ export function qr(x: Tensor2D): [Tensor, Tensor] {
           r = rjEndAll.sub(tauTimesW.matMul(w.transpose().matMul(rjEndAll)));
         } else {
           r = r.slice([0, 0], [j, n])
-            .concat(
-              rjEndAll.sub(
-                tauTimesW.matMul(w.transpose().matMul(rjEndAll))),
-              0) as Tensor2D;
+                  .concat(
+                      rjEndAll.sub(
+                          tauTimesW.matMul(w.transpose().matMul(rjEndAll))),
+                      0) as Tensor2D;
         }
         const qAllJEnd = q.slice([0, j], [m, q.shape[1] - j]);
         if (j === 0) {
           q = qAllJEnd.sub(qAllJEnd.matMul(w).matMul(tauTimesW.transpose()));
         } else {
           q = q.slice([0, 0], [m, j])
-            .concat(
-              qAllJEnd.sub(
-                qAllJEnd.matMul(w).matMul(tauTimesW.transpose())),
-              1) as Tensor2D;
+                  .concat(
+                      qAllJEnd.sub(
+                          qAllJEnd.matMul(w).matMul(tauTimesW.transpose())),
+                      1) as Tensor2D;
         }
         return [w, r, q];
       });
@@ -1059,8 +1059,8 @@ export function qr(x: Tensor2D): [Tensor, Tensor] {
 export function oneHot(indices: Tensor, numClasses: number): Tensor {
   if (ndim(indices) !== 1) {
     throw new Error(
-      'Only 1D one-hot tensors are supported in the ' +
-      'deeplearn backend, at present.');
+        'Only 1D one-hot tensors are supported in the ' +
+        'deeplearn backend, at present.');
   }
   indices = indices.toInt();
   return tfc.oneHot(indices as Tensor1D, numClasses).toFloat();
@@ -1078,7 +1078,7 @@ export function oneHot(indices: Tensor, numClasses: number): Tensor {
  *   the reduced dimensions are retained with length 1.
  */
 export function mean(
-  x: Tensor, axis?: number | number[], keepDims?: boolean): Scalar | Tensor {
+    x: Tensor, axis?: number|number[], keepDims?: boolean): Scalar|Tensor {
   // TODO(michaelterry): Remove once negative supported axes in deeplearn.js
   axis = normalizeAxis(x, axis);
   return tfc.mean(x, axis, keepDims);
@@ -1102,7 +1102,7 @@ export function argmax(x: Tensor, axis = -1): Tensor {
  * @returns The result of the gathering as a tensor.
  */
 export function gather(
-  reference: Tensor, indices: number[] | Tensor1D, axis?: number): Tensor {
+    reference: Tensor, indices: number[]|Tensor1D, axis?: number): Tensor {
   if (Array.isArray(indices)) {
     indices = tensor1d(indices, 'int32');
   } else {
@@ -1132,13 +1132,13 @@ export function square(x: Tensor): Tensor {
  *   nearest integer and converted to a tensor.
  * @returns A tensor of the same shape as `x`.
  */
-export function pow(x: Tensor, a: Tensor | number): Tensor {
+export function pow(x: Tensor, a: Tensor|number): Tensor {
   if (typeof (a) === 'number') {
     a = scalar(Math.round(a), 'int32');
   }
   if (a.dtype !== 'int32') {
     throw new NotImplementedError(
-      `Non-int32 dtype (${a.dtype}) is not supported by pow() yet`);
+        `Non-int32 dtype (${a.dtype}) is not supported by pow() yet`);
   }
   return tfc.pow(x, a as Tensor);
 }
@@ -1160,29 +1160,29 @@ export function pow(x: Tensor, a: Tensor | number): Tensor {
  * @returns The result of the batch normalization.
  */
 export function batchNormalization(
-  x: Tensor, mean: Tensor, variance: Tensor, beta?: Tensor, gamma?: Tensor,
-  epsilon = 1e-3): Tensor {
+    x: Tensor, mean: Tensor, variance: Tensor, beta?: Tensor, gamma?: Tensor,
+    epsilon = 1e-3): Tensor {
   let out: Tensor;
   if (ndim(x) === 2) {
     out = tfc.batchNormalization2d(
-      x as Tensor2D, mean as Tensor2D | Tensor1D,
-      variance as Tensor2D | Tensor1D, epsilon, gamma as Tensor2D | Tensor1D,
-      beta as Tensor2D | Tensor1D);
+        x as Tensor2D, mean as Tensor2D | Tensor1D,
+        variance as Tensor2D | Tensor1D, epsilon, gamma as Tensor2D | Tensor1D,
+        beta as Tensor2D | Tensor1D);
   } else if (ndim(x) === 3) {
     // TODO(cais): Check rank; give proper error message.
     out = tfc.batchNormalization3d(
-      x as Tensor3D, mean as Tensor3D | Tensor1D,
-      variance as Tensor3D | Tensor1D, epsilon, gamma as Tensor3D | Tensor1D,
-      beta as Tensor3D | Tensor1D);
+        x as Tensor3D, mean as Tensor3D | Tensor1D,
+        variance as Tensor3D | Tensor1D, epsilon, gamma as Tensor3D | Tensor1D,
+        beta as Tensor3D | Tensor1D);
   } else if (ndim(x) === 4) {
     out = tfc.batchNormalization4d(
-      x as Tensor4D, mean as Tensor4D | Tensor1D,
-      variance as Tensor4D | Tensor1D, epsilon, gamma as Tensor4D | Tensor1D,
-      beta as Tensor4D | Tensor1D);
+        x as Tensor4D, mean as Tensor4D | Tensor1D,
+        variance as Tensor4D | Tensor1D, epsilon, gamma as Tensor4D | Tensor1D,
+        beta as Tensor4D | Tensor1D);
   } else {
     throw new NotImplementedError(
-      `batchNormalization is not implememnted for array of rank ${ndim(x)} ` +
-      `yet`);
+        `batchNormalization is not implememnted for array of rank ${ndim(x)} ` +
+        `yet`);
   }
   return out;
 }
@@ -1198,7 +1198,7 @@ export function batchNormalization(
  * @throws ValueError: If the rank of `bias` is incorrect.
  */
 export function biasAdd(
-  x: Tensor, bias: Tensor, dataFormat?: DataFormat): Tensor {
+    x: Tensor, bias: Tensor, dataFormat?: DataFormat): Tensor {
   if (dataFormat == null) {
     dataFormat = imageDataFormat();
   }
@@ -1206,8 +1206,8 @@ export function biasAdd(
 
   if (ndim(bias) !== 1 && ndim(bias) !== ndim(x)) {
     throw new ValueError(
-      'Unexpected bias dimensions: ' + ndim(bias) +
-      '; expected it to be 1 or ' + ndim(x));
+        'Unexpected bias dimensions: ' + ndim(bias) +
+        '; expected it to be 1 or ' + ndim(x));
   }
   const biasShape = bias.shape;
 
@@ -1218,7 +1218,7 @@ export function biasAdd(
         y = x.add(bias.reshape([1, biasShape[0], 1, 1, 1]));
       } else {
         y = x.add(bias.reshape(
-          [1, biasShape[3], biasShape[0], biasShape[1], biasShape[2]]));
+            [1, biasShape[3], biasShape[0], biasShape[1], biasShape[2]]));
       }
     } else if (dataFormat === 'channelsLast') {
       if (biasShape.length === 1) {
@@ -1273,8 +1273,8 @@ export function elu(x: Tensor, alpha = 1): Tensor {
   // TODO(cais): Add support for alpha values other than 1.
   if (alpha !== 1) {
     throw new NotImplementedError(
-      `Support for alpha values other than 1 (${alpha}) is not implemented ` +
-      `yet.`);
+        `Support for alpha values other than 1 (${alpha}) is not implemented ` +
+        `yet.`);
   }
   return tfc.elu(x);
 }
@@ -1314,23 +1314,24 @@ export function softsign(x: Tensor): Tensor {
  * @returns Result of the dropout operation.
  */
 export function dropout(
-  x: Tensor, level: Scalar, noiseShape?: number[], seed?: number): Tensor {
+    x: Tensor, level: Scalar, noiseShape?: number[], seed?: number): Tensor {
   // TODO(cais): Switch to deeplearn.js implementation of dropout when it
   //   becomes avaialable.
   if (noiseShape != null && !util.arraysEqual(x.shape, noiseShape)) {
     throw new NotImplementedError(
-      'Non-default noise shape is not implemented yet: ' +
-      JSON.stringify(noiseShape));
+        'Non-default noise shape is not implemented yet: ' +
+        JSON.stringify(noiseShape));
   }
   if (seed != null) {
     throw new NotImplementedError('seed is not implemented for dropout yet.');
   }
   let multiplier = tfc.step(tfc.add(
-    tfc.neg(level) as Scalar, tfc.randomUniform(x.shape, 0, 1, DType.float32)));
+      tfc.neg(level) as Scalar,
+      tfc.randomUniform(x.shape, 0, 1, DType.float32)));
   // Scale the kept elements, so the expected sum is unchanged.
   multiplier = tfc.mul(
-    tfc.div(getScalar(1), tfc.sub(getScalar(1), level)) as Scalar,
-    multiplier);
+      tfc.div(getScalar(1), tfc.sub(getScalar(1), level)) as Scalar,
+      multiplier);
   return tfc.mul(x, multiplier);
 }
 
@@ -1378,8 +1379,8 @@ function preprocessConv2DInput(x: Tensor, dataFormat: DataFormat): Tensor {
  * @throws ValueError, if `x`, `kernel` or `bias` is not of the correct rank.
  */
 export function conv1dWithBias(
-  x: Tensor, kernel: Tensor, bias: Tensor, strides = 1, padding = 'valid',
-  dataFormat?: DataFormat, dilationRate = 1): Tensor {
+    x: Tensor, kernel: Tensor, bias: Tensor, strides = 1, padding = 'valid',
+    dataFormat?: DataFormat, dilationRate = 1): Tensor {
   if (dataFormat == null) {
     dataFormat = imageDataFormat();
   }
@@ -1388,18 +1389,18 @@ export function conv1dWithBias(
   // Check the ranks of x, kernel and bias.
   if (x.shape.length !== 3) {
     throw new ValueError(
-      `The input of a conv1dWithBias operation should be 3, but is ` +
-      `${x.shape.length} instead.`);
+        `The input of a conv1dWithBias operation should be 3, but is ` +
+        `${x.shape.length} instead.`);
   }
   if (kernel.shape.length !== 3) {
     throw new ValueError(
-      `The kernel for a conv1dWithBias operation should be 3, but is ` +
-      `${kernel.shape.length} instead`);
+        `The kernel for a conv1dWithBias operation should be 3, but is ` +
+        `${kernel.shape.length} instead`);
   }
   if (bias != null && bias.shape.length !== 1) {
     throw new ValueError(
-      `The bias for a conv1dWithBias operation should be 1, but is ` +
-      `${kernel.shape.length} instead`);
+        `The bias for a conv1dWithBias operation should be 1, but is ` +
+        `${kernel.shape.length} instead`);
   }
 
   // TODO(cais): Support CAUSAL padding mode.
@@ -1409,12 +1410,12 @@ export function conv1dWithBias(
   }
   if (padding === 'causal') {
     throw new NotImplementedError(
-      'The support for CAUSAL padding mode in conv1dWithBias is not ' +
-      'implemented yet.');
+        'The support for CAUSAL padding mode in conv1dWithBias is not ' +
+        'implemented yet.');
   }
   let y: Tensor = tfc.conv1d(
-    x as Tensor2D | Tensor3D, kernel as Tensor3D, strides,
-    padding === 'same' ? 'same' : 'valid', 'NWC', dilationRate);
+      x as Tensor2D | Tensor3D, kernel as Tensor3D, strides,
+      padding === 'same' ? 'same' : 'valid', 'NWC', dilationRate);
   if (bias != null) {
     y = biasAdd(y, bias);
   }
@@ -1434,11 +1435,11 @@ export function conv1dWithBias(
  * @throws ValueError, if `x`, `kernel` or `bias` is not of the correct rank.
  */
 export function conv1d(
-  x: Tensor, kernel: Tensor, strides = 1, padding = 'valid',
-  dataFormat?: DataFormat, dilationRate = 1): Tensor {
+    x: Tensor, kernel: Tensor, strides = 1, padding = 'valid',
+    dataFormat?: DataFormat, dilationRate = 1): Tensor {
   checkDataFormat(dataFormat);
   return conv1dWithBias(
-    x, kernel, null, strides, padding, dataFormat, dilationRate);
+      x, kernel, null, strides, padding, dataFormat, dilationRate);
 }
 
 /**
@@ -1452,11 +1453,11 @@ export function conv1d(
  * @returns Result of the 2D pooling.
  */
 export function conv2d(
-  x: Tensor, kernel: Tensor, strides = [1, 1], padding = 'valid',
-  dataFormat?: DataFormat, dilationRate?: [number, number]): Tensor {
+    x: Tensor, kernel: Tensor, strides = [1, 1], padding = 'valid',
+    dataFormat?: DataFormat, dilationRate?: [number, number]): Tensor {
   checkDataFormat(dataFormat);
   return conv2dWithBias(
-    x, kernel, null, strides, padding, dataFormat, dilationRate);
+      x, kernel, null, strides, padding, dataFormat, dilationRate);
 }
 
 /**
@@ -1465,32 +1466,32 @@ export function conv2d(
  * is exactly the same as `conv2d`, except the added `bias`.
  */
 export function conv2dWithBias(
-  x: Tensor, kernel: Tensor, bias: Tensor, strides = [1, 1],
-  padding = 'valid', dataFormat?: DataFormat,
-  dilationRate?: [number, number]): Tensor {
+    x: Tensor, kernel: Tensor, bias: Tensor, strides = [1, 1],
+    padding = 'valid', dataFormat?: DataFormat,
+    dilationRate?: [number, number]): Tensor {
   if (dataFormat == null) {
     dataFormat = imageDataFormat();
   }
   checkDataFormat(dataFormat);
   if (ndim(x) !== 3 && ndim(x) !== 4) {
     throw new ValueError(
-      `conv2dWithBias expects input to be of rank 3 or 4, but received ` +
-      `${ndim(x)}.`);
+        `conv2dWithBias expects input to be of rank 3 or 4, but received ` +
+        `${ndim(x)}.`);
   }
   if (ndim(kernel) !== 3 && ndim(kernel) !== 4) {
     throw new ValueError(
-      `conv2dWithBias expects kernel to be of rank 3 or 4, but received ` +
-      `${ndim(x)}.`);
+        `conv2dWithBias expects kernel to be of rank 3 or 4, but received ` +
+        `${ndim(x)}.`);
   }
   let y = preprocessConv2DInput(x, dataFormat);
   if (padding === 'causal') {
     throw new NotImplementedError(
-      'The support for CAUSAL padding mode in conv1dWithBias is not ' +
-      'implemented yet.');
+        'The support for CAUSAL padding mode in conv1dWithBias is not ' +
+        'implemented yet.');
   }
   y = tfc.conv2d(
-    y as Tensor3D | Tensor4D, kernel as Tensor4D, strides as [number, number],
-    padding === 'same' ? 'same' : 'valid', 'NHWC', dilationRate);
+      y as Tensor3D | Tensor4D, kernel as Tensor4D, strides as [number, number],
+      padding === 'same' ? 'same' : 'valid', 'NHWC', dilationRate);
   if (bias != null) {
     y = biasAdd(y, bias as Tensor1D);
   }
@@ -1513,9 +1514,9 @@ export function conv2dWithBias(
  * @throws ValueError If depthwiseKernel is not a 4D array.
  */
 export function depthwiseConv2d(
-  x: Tensor, depthwiseKernel: Tensor, strides: [number, number] = [1, 1],
-  padding = 'valid', dataFormat?: DataFormat,
-  dilationRate?: [number, number]): Tensor {
+    x: Tensor, depthwiseKernel: Tensor, strides: [number, number] = [1, 1],
+    padding = 'valid', dataFormat?: DataFormat,
+    dilationRate?: [number, number]): Tensor {
   if (dataFormat == null) {
     dataFormat = imageDataFormat();
   }
@@ -1523,17 +1524,17 @@ export function depthwiseConv2d(
   let y = preprocessConv2DInput(x, dataFormat);
   if (ndim(x) !== 4) {
     throw new ValueError(
-      `Input for depthwiseConv2d is required to be 4-D, but is instead ` +
-      `${ndim(x)}-D`);
+        `Input for depthwiseConv2d is required to be 4-D, but is instead ` +
+        `${ndim(x)}-D`);
   }
   if (ndim(depthwiseKernel) !== 4) {
     throw new ValueError(
-      `depthwiseKernel is required to be 4-D, but is instead ` +
-      `${ndim(depthwiseKernel)}-D`);
+        `depthwiseKernel is required to be 4-D, but is instead ` +
+        `${ndim(depthwiseKernel)}-D`);
   }
   y = tfc.depthwiseConv2d(
-    y as Tensor4D, depthwiseKernel as Tensor4D, strides,
-    padding === 'same' ? 'same' : 'valid', 'NHWC', dilationRate);
+      y as Tensor4D, depthwiseKernel as Tensor4D, strides,
+      padding === 'same' ? 'same' : 'valid', 'NHWC', dilationRate);
   if (dataFormat === 'channelsFirst') {
     y = tfc.transpose(y, [0, 3, 1, 2]);
   }
@@ -1551,9 +1552,9 @@ export function depthwiseConv2d(
  * @returns Result of the 2D pooling.
  */
 export function pool2d(
-  x: Tensor, poolSize: [number, number], strides?: [number, number],
-  padding?: PaddingMode, dataFormat?: DataFormat,
-  poolMode?: PoolMode): Tensor {
+    x: Tensor, poolSize: [number, number], strides?: [number, number],
+    padding?: PaddingMode, dataFormat?: DataFormat,
+    poolMode?: PoolMode): Tensor {
   checkDataFormat(dataFormat);
   checkPoolMode(poolMode);
   checkPaddingMode(padding);
@@ -1582,8 +1583,8 @@ export function pool2d(
     // TODO(cais): Check the dtype and rank of x and give clear error message
     //   if those are incorrect.
     y = tfc.avgPool(
-      // TODO(cais): Rank check?
-      x as Tensor3D | Tensor4D, poolSize, strides, paddingString);
+        // TODO(cais): Rank check?
+        x as Tensor3D | Tensor4D, poolSize, strides, paddingString);
   }
   if (dataFormat === 'channelsFirst') {
     y = tfc.transpose(y, [0, 3, 1, 2]);  // NHWC -> NCHW.
@@ -1609,7 +1610,7 @@ export function floatx(): DType {
   return DType.float32;
 }
 
-const _uidPrefixes: { [prefix: string]: number } = {};
+const _uidPrefixes: {[prefix: string]: number} = {};
 
 /**
  * Provides a unique UID given a string prefix.
@@ -1634,7 +1635,7 @@ export function getUid(prefix = ''): string {
  *   a tensor of logits.
  */
 export function categoricalCrossentropy(
-  target: Tensor, output: Tensor, fromLogits = false): Tensor {
+    target: Tensor, output: Tensor, fromLogits = false): Tensor {
   if (fromLogits) {
     output = tfc.softmax(output);
   } else {
@@ -1644,7 +1645,7 @@ export function categoricalCrossentropy(
   }
   output = tfc.clipByValue(output, epsilon(), 1 - epsilon());
   return tfc.neg(tfc.sum(
-    tfc.mul(target.toFloat(), tfc.log(output)), shape(output).length - 1));
+      tfc.mul(target.toFloat(), tfc.log(output)), shape(output).length - 1));
 }
 
 /**
@@ -1657,11 +1658,11 @@ export function categoricalCrossentropy(
  *   a tensor of logits.
  */
 export function sparseCategoricalCrossentropy(
-  target: Tensor, output: Tensor, fromLogits = false): Tensor {
+    target: Tensor, output: Tensor, fromLogits = false): Tensor {
   const flatTarget = tfc.floor(flatten(target)).toInt() as Tensor1D;
   const outputShape = shape(output);
   const oneHotTarget = reshape(
-    tfc.oneHot(flatTarget, outputShape[outputShape.length - 1]), outputShape);
+      tfc.oneHot(flatTarget, outputShape[outputShape.length - 1]), outputShape);
   return categoricalCrossentropy(oneHotTarget, output, fromLogits);
 }
 
@@ -1674,7 +1675,7 @@ export function sparseCategoricalCrossentropy(
  *   default, we consider that `output` encodes a probability distribution.
  */
 export function binaryCrossentropy(
-  target: Tensor, output: Tensor, fromLogits = false): Tensor {
+    target: Tensor, output: Tensor, fromLogits = false): Tensor {
   let y: Tensor;
   if (!fromLogits) {
     y = tfc.clipByValue(output, epsilon(), 1 - epsilon());
@@ -1707,11 +1708,11 @@ export function binaryCrossentropy(
  * @param output The logits.
  */
 export function sigmoidCrossEntropyWithLogits(
-  target: Tensor, output: Tensor): Tensor {
+    target: Tensor, output: Tensor): Tensor {
   const maxOutput = tfc.maximum(output, tfc.zerosLike(output));
   const outputXTarget = tfc.mul(output, target);
   const sigmoidOutput =
-    tfc.log(tfc.add(getScalar(1), tfc.exp(tfc.neg(tfc.abs(output)))));
+      tfc.log(tfc.add(getScalar(1), tfc.exp(tfc.neg(tfc.abs(output)))));
   const result = tfc.add(tfc.sub(maxOutput, outputXTarget), sigmoidOutput);
   return result;
 }
@@ -1787,9 +1788,9 @@ export function inTrainPhase<T>(x: () => T, alt: () => T, training = false): T {
  * @throws ValueError If input dimension is less than 3.
  */
 export function rnn(
-  stepFunction: RnnStepFunction, inputs: Tensor, initialStates: Tensor[],
-  goBackwards = false, mask?: Tensor, constants?: Tensor[], unroll = false,
-  inputLength?: number): [Tensor, Tensor, Tensor[]] {
+    stepFunction: RnnStepFunction, inputs: Tensor, initialStates: Tensor[],
+    goBackwards = false, mask?: Tensor, constants?: Tensor[], unroll = false,
+    inputLength?: number): [Tensor, Tensor, Tensor[]] {
   const ndim = inputs.shape.length;
   if (ndim < 3) {
     throw new ValueError(`Input should be at least 3D, but is ${ndim}D.`);
@@ -1802,21 +1803,21 @@ export function rnn(
 
   if (mask != null) {
     throw new NotImplementedError(
-      'The rnn() function of the deeplearn.js backend does not support ' +
-      'masking yet.');
+        'The rnn() function of the deeplearn.js backend does not support ' +
+        'masking yet.');
   }
 
   if (constants != null) {
     throw new NotImplementedError(
-      'The rnn() functoin of the deeplearn.js backend does not support ' +
-      'constants yet.');
+        'The rnn() functoin of the deeplearn.js backend does not support ' +
+        'constants yet.');
   }
 
   // Porting Note: the unroll option is ignored by the imperative backend.
   if (unroll) {
     console.warn(
-      'Backend rnn(): the unroll = true option is not applicable to the ' +
-      'imperative deeplearn.js backend.');
+        'Backend rnn(): the unroll = true option is not applicable to the ' +
+        'imperative deeplearn.js backend.');
   }
 
   if (goBackwards) {
@@ -1847,7 +1848,7 @@ export function rnn(
       outputs = lastOutput.reshape([1].concat(lastOutput.shape));
     } else {
       outputs = concatAlongFirstAxis(
-        outputs, lastOutput.reshape([1].concat(lastOutput.shape)));
+          outputs, lastOutput.reshape([1].concat(lastOutput.shape)));
     }
     // TODO(soergel): Call K.concatenate() to perform only one concatenation at
     // the end, once the backend function is available.
@@ -1857,7 +1858,7 @@ export function rnn(
   return [
     lastOutput,
     tfc.transpose(
-      outputs, [1, 0].concat(math_utils.range(2, outputs.shape.length))),
+        outputs, [1, 0].concat(math_utils.range(2, outputs.shape.length))),
     states
   ];
 }
@@ -1871,11 +1872,11 @@ export function rnn(
  * @returns An Array of gradients tensors.
  */
 export function gradients(
-  lossFn: () => Scalar, variables: LayerVariable[]): Tensor[] {
+    lossFn: () => Scalar, variables: LayerVariable[]): Tensor[] {
   // TODO(cais): The return type signature can be simplified if deeplearn makes
   //   the corresponding type public.
   const variableList =
-    variables.map(variable => variable.read() as tfc.Variable);
+      variables.map(variable => variable.read() as tfc.Variable);
   const valudAndGrads = variableGrads(lossFn, variableList);
   return variables.map(variable => valudAndGrads.grads[variable.name]);
 }

--- a/src/backend/tfjs_backend.ts
+++ b/src/backend/tfjs_backend.ts
@@ -14,24 +14,24 @@
 
 // tslint:disable:max-line-length
 import * as tfc from '@tensorflow/tfjs-core';
-import {dispose, onesLike as coreOnesLike, Scalar, scalar, Tensor, Tensor1D, tensor1d, Tensor2D, tensor2d, Tensor3D, Tensor4D, tidy, util, variableGrads, where, zerosLike as coreZerosLike} from '@tensorflow/tfjs-core';
+import { dispose, onesLike as coreOnesLike, Scalar, scalar, Tensor, Tensor1D, tensor1d, Tensor2D, tensor2d, Tensor3D, Tensor4D, tidy, util, variableGrads, where, zerosLike as coreZerosLike } from '@tensorflow/tfjs-core';
 
-import {checkDataFormat, checkPaddingMode, checkPoolMode, DataFormat, nameScope as commonNameScope, PaddingMode, PoolMode} from '../common';
-import {Constraint} from '../constraints';
-import {NotImplementedError, ValueError} from '../errors';
-import {DType, LayerVariable, RnnStepFunction, Shape, SymbolicTensor} from '../types';
-import {pyNormalizeArrayIndex} from '../utils/generic_utils';
+import { checkDataFormat, checkPaddingMode, checkPoolMode, DataFormat, nameScope as commonNameScope, PaddingMode, PoolMode } from '../common';
+import { Constraint } from '../constraints';
+import { NotImplementedError, ValueError } from '../errors';
+import { DType, LayerVariable, RnnStepFunction, Shape, SymbolicTensor } from '../types';
+import { pyNormalizeArrayIndex } from '../utils/generic_utils';
 import * as math_utils from '../utils/math_utils';
 
-import {epsilon as common_epsilon} from './common';
-import {imageDataFormat} from './common';
+import { epsilon as common_epsilon } from './common';
+import { imageDataFormat } from './common';
 
 // tslint:enable
 
 /* Setting and getting backend from deeplearn.js. */
 
 // Default deeplearn.js backend is WebGL (GPU).
-let backend: 'cpu'|'webgl' = 'webgl';
+let backend: 'cpu' | 'webgl' = 'webgl';
 
 const DEFAULT_DTYPE = DType.float32;
 
@@ -44,17 +44,17 @@ export function disposeScalarCache() {
   }
 }
 
-export function setBackend(requestedBackend: 'cpu'|'webgl') {
+export function setBackend(requestedBackend: 'cpu' | 'webgl') {
   tfc.setBackend(requestedBackend);
   backend = requestedBackend;
   disposeScalarCache();
 }
 
-export function getBackend(): 'cpu'|'webgl' {
+export function getBackend(): 'cpu' | 'webgl' {
   return backend;
 }
 
-const scalarCache: {[typeKey: string]: {[key: number]: Scalar}} = {
+const scalarCache: { [typeKey: string]: { [key: number]: Scalar } } = {
   float32: {},
   int32: {}
 };
@@ -95,7 +95,7 @@ export function isBackendSymbolic(): boolean {
  * @param x The tensor.
  * @return Shape of the tensor.
  */
-export function shape(x: Tensor|SymbolicTensor): Shape {
+export function shape(x: Tensor | SymbolicTensor): Shape {
   return x.shape;
 }
 
@@ -105,7 +105,7 @@ export function shape(x: Tensor|SymbolicTensor): Shape {
  * @param x The tensor.
  * @return Shape of the tensor as number[].
  */
-export function intShape(x: Tensor|SymbolicTensor): number[] {
+export function intShape(x: Tensor | SymbolicTensor): number[] {
   return x.shape;
 }
 
@@ -115,7 +115,7 @@ export function intShape(x: Tensor|SymbolicTensor): number[] {
  * @param x The tensor.
  * @return Number of dimensions of `x`.
  */
-export function ndim(x: Tensor|SymbolicTensor): number {
+export function ndim(x: Tensor | SymbolicTensor): number {
   return x.shape.length;
 }
 
@@ -124,7 +124,7 @@ export function ndim(x: Tensor|SymbolicTensor): number {
  *
  * @param x The tensor.
  */
-export function dtype(x: Tensor|SymbolicTensor): DType {
+export function dtype(x: Tensor | SymbolicTensor): DType {
   // TODO(michaelterry): Update if additional data types are available.
   return (x instanceof Tensor) ? DEFAULT_DTYPE : (x as SymbolicTensor).dtype;
 }
@@ -144,7 +144,7 @@ export function dtype(x: Tensor|SymbolicTensor): DType {
  *   all values must be non-null/defined.
  */
 export function normalizeAxis(
-    x: Tensor|SymbolicTensor, axis: number|number[]): number|number[] {
+  x: Tensor | SymbolicTensor, axis: number | number[]): number | number[] {
   if (axis == null) {
     return axis;
   }
@@ -160,7 +160,7 @@ export function normalizeAxis(
  * @param x The Tensor.
  * @return Number of elements in `x`.
  */
-export function countParams(x: Tensor|SymbolicTensor): number {
+export function countParams(x: Tensor | SymbolicTensor): number {
   const shape = x.shape;
   if (shape.length > 0) {
     return shape.reduce((a: number, b: number) => a * b);
@@ -176,7 +176,7 @@ export function countParams(x: Tensor|SymbolicTensor): number {
  * @param dtype String: 'float32'|'int32'|'bool'.
  * @returns Tensor of the specified `dtype`.
  */
-export function cast(x: Tensor, dtype: 'float32'|'int32'|'bool'): Tensor {
+export function cast(x: Tensor, dtype: 'float32' | 'int32' | 'bool'): Tensor {
   return x.asType(dtype);
 }
 
@@ -190,8 +190,6 @@ export function reshape(x: Tensor, shape: Shape): Tensor {
   // TODO(cais): Should this call TensorMath.reshape instead for backprop?
   return x.reshape(shape);
 }
-
-export const permuteDimensions = tfc.transpose;
 
 /**
  * Adds a 1-sized dimension at index "axis".
@@ -208,14 +206,6 @@ export function expandDims(x: Tensor, axis = -1): Tensor {
   return reshape(x, outShape);
 }
 
-/**
- * Removes a 1-dimension from the tensor at index "axis".
- * @param x Input tensor
- * @param axis which axes to remove.
- */
-export function squeeze(x: Tensor, axis: number): Tensor {
-  return tfc.squeeze(x, [axis]);
-}
 
 /**
  * Pads the middle dimension of a 3D tensor.
@@ -228,8 +218,8 @@ export function squeeze(x: Tensor, axis: number): Tensor {
 export function temporalPadding(x: Tensor, padding?: [number, number]): Tensor {
   if (ndim(x) !== 3) {
     throw new ValueError(
-        `temporalPadding expects input tensor to be 3-D, but received a ` +
-        `${ndim(x)}-D tensor.`);
+      `temporalPadding expects input tensor to be 3-D, but received a ` +
+      `${ndim(x)}-D tensor.`);
   }
 
   if (padding == null) {
@@ -237,8 +227,8 @@ export function temporalPadding(x: Tensor, padding?: [number, number]): Tensor {
   }
   if (padding.length !== 2) {
     throw new ValueError(
-        `temporalPadding expects input padding pattern to be a length-2 ` +
-        `array, but received a length-${padding.length} array.`);
+      `temporalPadding expects input padding pattern to be a length-2 ` +
+      `array, but received a length-${padding.length} array.`);
   }
 
   const pattern: Array<[number, number]> = [[0, 0], padding, [0, 0]];
@@ -256,22 +246,22 @@ export function temporalPadding(x: Tensor, padding?: [number, number]): Tensor {
  * @return Padded 4D `Tensor`.
  */
 export function spatial2dPadding(
-    x: Tensor, padding?: [[number, number], [number, number]],
-    dataFormat?: DataFormat): Tensor {
+  x: Tensor, padding?: [[number, number], [number, number]],
+  dataFormat?: DataFormat): Tensor {
   if (ndim(x) !== 4) {
     throw new ValueError(
-        `temporalPadding expects input tensor to be 4-D, but received a ` +
-        `${ndim(x)}-D tensor.`);
+      `temporalPadding expects input tensor to be 4-D, but received a ` +
+      `${ndim(x)}-D tensor.`);
   }
 
   if (padding == null) {
     padding = [[1, 1], [1, 1]];
   }
   if (padding.length !== 2 || padding[0].length !== 2 ||
-      padding[1].length !== 2) {
+    padding[1].length !== 2) {
     throw new ValueError(
-        'spatial2dPadding expects `padding` to be an Array of two Arrays, ' +
-        'each of which is an Array of two integers.');
+      'spatial2dPadding expects `padding` to be an Array of two Arrays, ' +
+      'each of which is an Array of two integers.');
   }
 
   if (dataFormat == null) {
@@ -279,8 +269,8 @@ export function spatial2dPadding(
   }
   if (dataFormat !== 'channelsLast' && dataFormat !== 'channelsFirst') {
     throw new ValueError(
-        `Unknown data format: ${dataFormat}. ` +
-        `Supported data formats are 'channelsLast' and 'channelsFirst.`);
+      `Unknown data format: ${dataFormat}. ` +
+      `Supported data formats are 'channelsLast' and 'channelsFirst.`);
   }
 
   let pattern: Array<[number, number]>;
@@ -307,8 +297,8 @@ export function spatial2dPadding(
 export function repeat(x: Tensor, n: number): Tensor {
   if (x.shape.length !== 2) {
     throw new ValueError(
-        `repeat() expects a rank-2 tensor, but received a ` +
-        `rank-${x.shape.length} tensor.`);
+      `repeat() expects a rank-2 tensor, but received a ` +
+      `rank-${x.shape.length} tensor.`);
   }
   const y = expandDims(x, 1);
   return tile(y, [1, n, 1]);
@@ -335,7 +325,7 @@ export function flatten(x: Tensor): Tensor {
 export function batchFlatten(x: Tensor): Tensor {
   if (ndim(x) <= 1) {
     throw new ValueError(
-        `batchFlatten requires a minimum rank of 2. Got rank: ${ndim(x)}.`);
+      `batchFlatten requires a minimum rank of 2. Got rank: ${ndim(x)}.`);
   }
   const newShape = [x.shape[0], math_utils.arrayProd(x.shape, 1)];
   return reshape(x, newShape);
@@ -350,7 +340,7 @@ export function batchFlatten(x: Tensor): Tensor {
  * @throws ValueError: If `array` is of an unsupported subtype of `Tensor`.
  */
 export function sliceAlongFirstAxis(
-    array: Tensor, start: number, size: number): Tensor {
+  array: Tensor, start: number, size: number): Tensor {
   switch (array.rank) {
     case 1:
       return tfc.slice1d(array as Tensor1D, start, size);
@@ -358,16 +348,16 @@ export function sliceAlongFirstAxis(
       return tfc.slice2d(array as Tensor2D, [start, 0], [size, array.shape[1]]);
     case 3:
       return tfc.slice3d(
-          array as Tensor3D, [start, 0, 0],
-          [size, array.shape[1], array.shape[2]]);
+        array as Tensor3D, [start, 0, 0],
+        [size, array.shape[1], array.shape[2]]);
     case 4:
       return tfc.slice4d(
-          array as Tensor4D, [start, 0, 0, 0],
-          [size, array.shape[1], array.shape[2], array.shape[3]]);
+        array as Tensor4D, [start, 0, 0, 0],
+        [size, array.shape[1], array.shape[2], array.shape[3]]);
     default:
       throw new ValueError(
-          `sliceAlongFirstAxis() received an unsupported tensor rank: ` +
-          `${array.rank}`);
+        `sliceAlongFirstAxis() received an unsupported tensor rank: ` +
+        `${array.rank}`);
   }
 }
 
@@ -380,7 +370,7 @@ export function sliceAlongFirstAxis(
  * @throws ValueError: If `array` is of an unsupported subtype of `Tensor`.
  */
 export function sliceAlongLastAxis(
-    array: Tensor, start: number, size: number): Tensor {
+  array: Tensor, start: number, size: number): Tensor {
   switch (array.rank) {
     case 1:
       return tfc.slice1d(array as Tensor1D, start, size);
@@ -388,16 +378,16 @@ export function sliceAlongLastAxis(
       return tfc.slice2d(array as Tensor2D, [0, start], [array.shape[0], size]);
     case 3:
       return tfc.slice3d(
-          array as Tensor3D, [0, 0, start],
-          [array.shape[0], array.shape[1], size]);
+        array as Tensor3D, [0, 0, start],
+        [array.shape[0], array.shape[1], size]);
     case 4:
       return tfc.slice4d(
-          array as Tensor4D, [0, 0, 0, start],
-          [array.shape[0], array.shape[1], array.shape[2], size]);
+        array as Tensor4D, [0, 0, 0, start],
+        [array.shape[0], array.shape[1], array.shape[2], size]);
     default:
       throw new ValueError(
-          `sliceAlongLastAxis() received an unsupported tensor rank: ` +
-          `${array.rank}`);
+        `sliceAlongLastAxis() received an unsupported tensor rank: ` +
+        `${array.rank}`);
   }
 }
 
@@ -411,7 +401,7 @@ export function sliceAlongLastAxis(
  * @throws ValueError: If `array` is of an unsupported subtype of `Tensor`.
  */
 export function sliceAlongAxis(
-    array: Tensor, start: number, size: number, axis: number): Tensor {
+  array: Tensor, start: number, size: number, axis: number): Tensor {
   switch (array.rank) {
     case 1:
       return tfc.slice1d(array as Tensor1D, start, size);
@@ -423,8 +413,8 @@ export function sliceAlongAxis(
           return sliceAlongLastAxis(array, start, size);
         default:
           throw new ValueError(
-              `The axis is not within the rank of the tensor ` +
-              `${axis}`);
+            `The axis is not within the rank of the tensor ` +
+            `${axis}`);
       }
     case 3:
       switch (axis) {
@@ -432,14 +422,14 @@ export function sliceAlongAxis(
           return sliceAlongFirstAxis(array, start, size);
         case 2:
           return tfc.slice3d(
-              array as Tensor3D, [0, start, 0],
-              [array.shape[0], size, array.shape[2]]);
+            array as Tensor3D, [0, start, 0],
+            [array.shape[0], size, array.shape[2]]);
         case 3:
           return sliceAlongLastAxis(array, start, size);
         default:
           throw new ValueError(
-              `The axis is not within the rank of the tensor ` +
-              `${axis}`);
+            `The axis is not within the rank of the tensor ` +
+            `${axis}`);
       }
     case 4:
       switch (axis) {
@@ -447,23 +437,23 @@ export function sliceAlongAxis(
           return sliceAlongFirstAxis(array, start, size);
         case 2:
           return tfc.slice4d(
-              array as Tensor4D, [0, start, 0, 0],
-              [array.shape[0], size, array.shape[2], array.shape[3]]);
+            array as Tensor4D, [0, start, 0, 0],
+            [array.shape[0], size, array.shape[2], array.shape[3]]);
         case 3:
           return tfc.slice4d(
-              array as Tensor4D, [0, 0, start, 0],
-              [array.shape[0], array.shape[1], size, array.shape[3]]);
+            array as Tensor4D, [0, 0, start, 0],
+            [array.shape[0], array.shape[1], size, array.shape[3]]);
         case 4:
           return sliceAlongLastAxis(array, start, size);
         default:
           throw new ValueError(
-              `The axis is not within the rank of the tensor ` +
-              `${axis}`);
+            `The axis is not within the rank of the tensor ` +
+            `${axis}`);
       }
     default:
       throw new ValueError(
-          `sliceAlongLastAxis() received an unsupported tensor rank: ` +
-          `${array.rank}`);
+        `sliceAlongLastAxis() received an unsupported tensor rank: ` +
+        `${array.rank}`);
   }
 }
 
@@ -486,16 +476,16 @@ export function sliceAlongAxis(
  *   [normalized tensor, mean of input, variance of input].
  */
 function regularNormalizeBatchInTraining(
-    x: Tensor, gamma: Tensor, beta: Tensor, reductionAxes: number[],
-    epsilon = 1e-3): [Tensor, Tensor, Tensor] {
+  x: Tensor, gamma: Tensor, beta: Tensor, reductionAxes: number[],
+  epsilon = 1e-3): [Tensor, Tensor, Tensor] {
   return tidy(() => {
-           const meanAndVariance = tfc.moments(x, reductionAxes);
-           const mean = meanAndVariance.mean;
-           const variance = meanAndVariance.variance;
-           const normed =
-               batchNormalization(x, mean, variance, beta, gamma, epsilon);
-           return [normed, mean, variance];
-         }) as [Tensor, Tensor, Tensor];
+    const meanAndVariance = tfc.moments(x, reductionAxes);
+    const mean = meanAndVariance.mean;
+    const variance = meanAndVariance.variance;
+    const normed =
+      batchNormalization(x, mean, variance, beta, gamma, epsilon);
+    return [normed, mean, variance];
+  }) as [Tensor, Tensor, Tensor];
 }
 
 /**
@@ -516,31 +506,31 @@ function regularNormalizeBatchInTraining(
  *   [normalized tensor, mean of input, variance of input].
  */
 function broadcastNormalizeBatchInTraining(
-    x: Tensor, gamma: Tensor, beta: Tensor, reductionAxes: number[],
-    epsilon = 1e-3): [Tensor, Tensor, Tensor] {
+  x: Tensor, gamma: Tensor, beta: Tensor, reductionAxes: number[],
+  epsilon = 1e-3): [Tensor, Tensor, Tensor] {
   return tidy(() => {
-           const meanAndVariance = tfc.moments(x, reductionAxes);
-           const mean = meanAndVariance.mean;
-           const variance = meanAndVariance.variance;
-           const targetShape: number[] = [];
-           for (const axis of math_utils.range(0, ndim(x))) {
-             if (reductionAxes.indexOf(axis) !== -1) {
-               targetShape.push(1);
-             } else {
-               targetShape.push(x.shape[axis]);
-             }
-           }
-           const broadcastMean = reshape(mean, targetShape);
-           const broadcastVariance = reshape(variance, targetShape);
-           const broadcastGamma =
-               gamma == null ? null : reshape(gamma, targetShape);
-           const broadcastBeta =
-               beta == null ? null : reshape(beta, targetShape);
-           const normed = batchNormalization(
-               x, broadcastMean, broadcastVariance, broadcastBeta,
-               broadcastGamma, epsilon);
-           return [normed, mean, variance];
-         }) as [Tensor, Tensor, Tensor];
+    const meanAndVariance = tfc.moments(x, reductionAxes);
+    const mean = meanAndVariance.mean;
+    const variance = meanAndVariance.variance;
+    const targetShape: number[] = [];
+    for (const axis of math_utils.range(0, ndim(x))) {
+      if (reductionAxes.indexOf(axis) !== -1) {
+        targetShape.push(1);
+      } else {
+        targetShape.push(x.shape[axis]);
+      }
+    }
+    const broadcastMean = reshape(mean, targetShape);
+    const broadcastVariance = reshape(variance, targetShape);
+    const broadcastGamma =
+      gamma == null ? null : reshape(gamma, targetShape);
+    const broadcastBeta =
+      beta == null ? null : reshape(beta, targetShape);
+    const normed = batchNormalization(
+      x, broadcastMean, broadcastVariance, broadcastBeta,
+      broadcastGamma, epsilon);
+    return [normed, mean, variance];
+  }) as [Tensor, Tensor, Tensor];
 }
 
 /**
@@ -555,15 +545,15 @@ function broadcastNormalizeBatchInTraining(
  *   [normalized tensor, mean of input, variance of input].
  */
 export function normalizeBatchInTraining(
-    x: Tensor, gamma: Tensor, beta: Tensor, reductionAxes: number[],
-    epsilon = 1e-3): [Tensor, Tensor, Tensor] {
+  x: Tensor, gamma: Tensor, beta: Tensor, reductionAxes: number[],
+  epsilon = 1e-3): [Tensor, Tensor, Tensor] {
   if (util.arraysEqual(
-          reductionAxes.slice().sort(), math_utils.range(0, ndim(x) - 1))) {
+    reductionAxes.slice().sort(), math_utils.range(0, ndim(x) - 1))) {
     return regularNormalizeBatchInTraining(
-        x, gamma, beta, reductionAxes, epsilon);
+      x, gamma, beta, reductionAxes, epsilon);
   } else {
     return broadcastNormalizeBatchInTraining(
-        x, gamma, beta, reductionAxes, epsilon);
+      x, gamma, beta, reductionAxes, epsilon);
   }
 }
 
@@ -611,8 +601,8 @@ export function concatAlongFirstAxis(a: Tensor, b: Tensor): Tensor {
       return tfc.concat4d([a as Tensor4D, b as Tensor4D], 0);
     default:
       throw new ValueError(
-          'concatAlongFirstAxis() received an unsupported tensor rank: ' +
-          a.rank);
+        'concatAlongFirstAxis() received an unsupported tensor rank: ' +
+        a.rank);
   }
 }
 
@@ -623,14 +613,14 @@ export function concatAlongFirstAxis(a: Tensor, b: Tensor): Tensor {
  *   must be the same as the number of dimensions in `x`. If a single integer,
  *   it will be treated as an Array of length 1.
  */
-export function tile(x: Tensor, n: number|number[]): Tensor {
+export function tile(x: Tensor, n: number | number[]): Tensor {
   if (!Array.isArray(n)) {
     n = [n];
   }
   if (ndim(x) !== n.length) {
     throw new ValueError(
-        `The length of input n (${n.length}) does not match ` +
-        `the number of dimensions in input x (${ndim(x)})`);
+      `The length of input n (${n.length}) does not match ` +
+      `the number of dimensions in input x (${ndim(x)})`);
   }
   return tfc.tile(x, n);
 }
@@ -647,8 +637,8 @@ export function tile(x: Tensor, n: number|number[]): Tensor {
  * @return The newly instantiated `Variable`.
  */
 export function variable(
-    x: Tensor, dtype?: DType, name?: string,
-    constraint?: Constraint): LayerVariable {
+  x: Tensor, dtype?: DType, name?: string,
+  constraint?: Constraint): LayerVariable {
   return new LayerVariable(x, dtype, name, true, constraint);
 }
 
@@ -671,24 +661,11 @@ export function batchGetValue(xs: LayerVariable[]): Tensor[] {
  *   carries the new value.
  */
 export function batchSetValue(
-    variablesAndValues: Array<[LayerVariable, Tensor]>): void {
+  variablesAndValues: Array<[LayerVariable, Tensor]>): void {
   variablesAndValues.map((variableAndValue) => {
     const variable: LayerVariable = variableAndValue[0];
     variable.write(variableAndValue[1]);
   });
-}
-
-/**
- * Instantiates an all-zeros tensor and returns it.
- *
- * @param shape Shape of the tensor.
- * @param dtype DType of the tensor.
- * @param name Name of the tensor.
- * @return An all-zero Tensor.
- */
-export function zeros(shape: Shape, dtype?: DType): Tensor {
-  // TODO(cais): Implement logic for dtype.
-  return tfc.zeros(shape);
 }
 
 /**
@@ -700,9 +677,9 @@ export function zeros(shape: Shape, dtype?: DType): Tensor {
  * @return An all-zero Variable.
  */
 export function zerosVariable(
-    shape: Shape, dtype?: DType, name?: string): LayerVariable {
+  shape: Shape, dtype?: DType, name?: string): LayerVariable {
   // TODO(cais): Implement logic for dtype.
-  return new LayerVariable(zeros(shape), dtype, name);
+  return new LayerVariable(tfc.zeros(shape), dtype, name);
 }
 
 /**
@@ -714,21 +691,8 @@ export function zerosVariable(
  * @return A newly instantiated Variable.
  */
 export function zerosLike(
-    x: Tensor, dtype?: DType, name?: string): LayerVariable {
+  x: Tensor, dtype?: DType, name?: string): LayerVariable {
   return new LayerVariable(tfc.zerosLike(x), dtype, name);
-}
-
-/**
- * Instantiates an all-ones tensor and returns it.
- *
- * @param shape Shape of the tensor.
- * @param dtype DType of the tensor.
- * @param name Name of the tensor.
- * @return An all-ones tensor.
- */
-export function ones(shape: Shape, dtype?: DType): Tensor {
-  // TODO(cais): Implement logic for dtype.
-  return tfc.ones(shape);
 }
 
 /**
@@ -740,7 +704,7 @@ export function ones(shape: Shape, dtype?: DType): Tensor {
  * @return An all-ones Variable.
  */
 export function onesVariable(
-    shape: Shape, dtype?: DType, name?: string): LayerVariable {
+  shape: Shape, dtype?: DType, name?: string): LayerVariable {
   // TODO(cais): Implement logic for dtype.
   const allocated = tfc.ones(shape);
   return new LayerVariable(allocated, dtype, name);
@@ -755,7 +719,7 @@ export function onesVariable(
  * @return A newly instantiated Variable.
  */
 export function onesLike(
-    x: Tensor, dtype?: DType, name?: string): LayerVariable {
+  x: Tensor, dtype?: DType, name?: string): LayerVariable {
   const allocated = tfc.onesLike(x);
   return new LayerVariable(allocated, dtype, name);
 }
@@ -798,38 +762,8 @@ export function eye(size: number, dtype?: DType, name?: string): Tensor {
  * @return A Variable, an identity matrix.
  */
 export function eyeVariable(
-    size: number, dtype?: DType, name?: string): LayerVariable {
+  size: number, dtype?: DType, name?: string): LayerVariable {
   return new LayerVariable(eye(size, dtype), dtype, name);
-}
-
-/**
- * Subtract two tensors, element-wise, with support for broadcasting.
- * @param x First tensor to subtract element-wise.
- * @param y Second tensor to subtract element-wise.
- * @returns Result of the subtraction.
- */
-export function subtract(x: Tensor, y: Tensor): Tensor {
-  return tfc.sub(x, y);
-}
-
-/**
- * Multiply two tensors, element-wise, with support for broadcasting.
- * @param x First tensor to multiply.
- * @param y Second tensor to multiply.
- * @returns Result of the multiplication.
- */
-export function multiply(x: Tensor, y: Tensor): Tensor {
-  return tfc.mul(x, y);
-}
-
-/**
- * Divide two tensors element-wise, with support for broadcasting.
- * @param x First tensor to divide element-wise.
- * @param y Second tensor to divide element-wise.
- * @returns Result of the division.
- */
-export function divide(x: Tensor, y: Tensor): Tensor {
-  return tfc.div(x, y);
 }
 
 /**
@@ -855,21 +789,6 @@ export function scalarPlusArray(c: Scalar, x: Tensor): Tensor {
 /* Creation of random tensors. */
 
 /**
- * Get a tensor with uniform distribution of values.
- * @param shape Shape of the tensor.
- * @param minval Lower bound of the uniform distribution.
- * @param maxval Upper bound of the uniform distribution.
- * @return The uniform-random tensor.
- */
-export function randomUniform(
-    shape: Shape, minval: number, maxval: number, dtype?: DType,
-    seed?: number): Tensor {
-  // TODO(cais): Implement logic for dtype and seed once they are supported
-  // by deeplearn.js.
-  return tfc.randomUniform(shape, minval, maxval);
-}
-
-/**
  * Get a Variable with uniform distribution of values.
  * @param shape Shape of the tensor.
  * @param minval Lower bound of the uniform distribution.
@@ -880,35 +799,10 @@ export function randomUniform(
  * @return The uniform-random Variable.
  */
 export function randomUniformVariable(
-    shape: Shape, minval: number, maxval: number, dtype?: DType, seed?: number,
-    name = 'randomUniform'): LayerVariable {
+  shape: Shape, minval: number, maxval: number, dtype?: DType, seed?: number,
+  name = 'randomUniform'): LayerVariable {
   return new LayerVariable(
-      randomUniform(shape, minval, maxval, dtype, seed), dtype, name);
-}
-
-/**
- * Get a tensor with truncated normal distribution of values.
- *
- * The truncated normal distribution is the same as a normal distribution,
- * except the values that are more than two stddev from the mean are dropped
- * and re-picked.
- * TODO(cais): The above specification regarding range truncation is not
- * true yet, due to the underlying Tensor.randTruncatedNormal from
- * deeplearn.js. Get it fixed.
- *
- * @param shape Shape of the tensor.
- * @param mean mean value of the normal distribution.
- * @param stddev standard deviation of the normal distribution.
- * @param dtype
- * @param seed
- * @return The truncated-normal tensor.
- */
-export function truncatedNormal(
-    shape: Shape, mean = 0.0, stddev = 1.0, dtype?: DType,
-    seed?: number): Tensor {
-  // TODO(cais): Implement logic for dtype and seed once they are supported
-  // by deeplearn.js.
-  return tfc.truncatedNormal(shape, mean, stddev);
+    tfc.randomUniform(shape, minval, maxval, dtype), dtype, name);
 }
 
 /**
@@ -922,12 +816,15 @@ export function truncatedNormal(
  * @return The truncated-normal-random Variable.
  */
 export function truncatedNormalVariable(
-    shape: Shape, mean = 0.0, stddev = 1.0, dtype?: DType, seed?: number,
-    name = 'truncatedNormal'): LayerVariable {
+  shape: Shape, mean = 0.0, stddev = 1.0, dtype?: DType, seed?: number,
+  name = 'truncatedNormal'): LayerVariable {
   // TODO(cais): Implement logic for dtype and seed once they are supported
   // by deeplearn.js.
+  if (dtype === DType.bool) {
+    throw new NotImplementedError(`randomNormal does not support dType bool.`);
+  }
   return new LayerVariable(
-      truncatedNormal(shape, mean, stddev, dtype, seed), dtype, name);
+    tfc.truncatedNormal(shape, mean, stddev, dtype, seed), dtype, name);
 }
 
 /**
@@ -941,8 +838,8 @@ export function truncatedNormalVariable(
  * @return The normal tensor.
  */
 export function randomNormal(
-    shape: Shape, mean = 0.0, stddev = 1.0, dtype?: DType,
-    seed?: number): Tensor {
+  shape: Shape, mean = 0.0, stddev = 1.0, dtype?: DType,
+  seed?: number): Tensor {
   if (dtype === DType.bool) {
     throw new NotImplementedError(`randomNormal does not support dType bool.`);
   }
@@ -961,10 +858,10 @@ export function randomNormal(
  * @return The truncated-normal-random Variable.
  */
 export function randomNormalVariable(
-    shape: Shape, mean = 0.0, stddev = 1.0, dtype?: DType, seed?: number,
-    name = 'randomNormal'): LayerVariable {
+  shape: Shape, mean = 0.0, stddev = 1.0, dtype?: DType, seed?: number,
+  name = 'randomNormal'): LayerVariable {
   return new LayerVariable(
-      randomNormal(shape, mean, stddev, dtype, seed), dtype, name);
+    randomNormal(shape, mean, stddev, dtype, seed), dtype, name);
 }
 
 /* Updating Variables */
@@ -1015,8 +912,8 @@ export function updateSub(x: LayerVariable, decrement: Tensor): LayerVariable {
 export function dot(x: Tensor, y: Tensor): Tensor {
   if (ndim(y) !== 2) {
     throw new NotImplementedError(
-        `dot support for y other than rank 2 is not yet implemented: ` +
-        `y shape = ${shape}`);
+      `dot support for y other than rank 2 is not yet implemented: ` +
+      `y shape = ${shape}`);
   } else {
     if (ndim(x) === 2) {
       return tfc.matMul(x as Tensor2D, y as Tensor2D);
@@ -1030,8 +927,8 @@ export function dot(x: Tensor, y: Tensor): Tensor {
       ]);
     } else {
       throw new NotImplementedError(
-          `dot support for x of rank ${ndim(x)} is not yet implemented: ` +
-          `x shape = ${shape}`);
+        `dot support for x of rank ${ndim(x)} is not yet implemented: ` +
+        `x shape = ${shape}`);
     }
   }
 }
@@ -1051,10 +948,10 @@ export function sign(x: Tensor): Tensor {
   const zerosLikeX = coreZerosLike(x);
   const onesLikeX = coreOnesLike(x);
   return where(
-      tfc.equal(x, zerosLikeX), zerosLikeX,
-      where(
-          tfc.greater(x, coreZerosLike(x)), onesLikeX,
-          scalarTimesArray(getScalar(-1), onesLikeX)));
+    tfc.equal(x, zerosLikeX), zerosLikeX,
+    where(
+      tfc.greater(x, coreZerosLike(x)), onesLikeX,
+      scalarTimesArray(getScalar(-1), onesLikeX)));
 }
 
 /**
@@ -1079,12 +976,12 @@ export function qr(x: Tensor2D): [Tensor, Tensor] {
     // function to the core.
     if (x.shape.length !== 2) {
       throw new ValueError(
-          `qr() requires a 2D Tensor, but got a ${x.shape.length}D Tensor.`);
+        `qr() requires a 2D Tensor, but got a ${x.shape.length}D Tensor.`);
     }
     if (x.shape[0] < x.shape[1]) {
       throw new ValueError(
-          `qr() requires x.shape[0] >= x.shape[1], but got shape: [${
-              x.shape}]`);
+        `qr() requires x.shape[0] >= x.shape[1], but got shape: [${
+        x.shape}]`);
     }
 
     const m = x.shape[0];
@@ -1108,16 +1005,16 @@ export function qr(x: Tensor2D): [Tensor, Tensor] {
         const normX = tfc.norm(rjEnd1);
         const rjj = r.slice([j, j], [1, 1]);
         const s = tfc.neg(sign(rjj)) as Tensor2D;
-        const u1 = rjj.sub(multiply(s, normX)) as Tensor2D;
-        const wPre = divide(rjEnd1, u1);
+        const u1 = rjj.sub(tfc.mul(s, normX)) as Tensor2D;
+        const wPre = tfc.div(rjEnd1, u1);
         if (wPre.shape[0] === 1) {
           w = one2D.clone();
         } else {
           w = one2D.concat(
-                  wPre.slice([1, 0], [wPre.shape[0] - 1, wPre.shape[1]]), 0) as
-              Tensor2D;
+            wPre.slice([1, 0], [wPre.shape[0] - 1, wPre.shape[1]]), 0) as
+            Tensor2D;
         }
-        const tau = tfc.neg(divide(tfc.matMul(s, u1), normX)) as Tensor2D;
+        const tau = tfc.neg(tfc.div(tfc.matMul(s, u1), normX)) as Tensor2D;
 
         // -- R := HR, Q := QH.
         const rjEndAll = r.slice([j, 0], [m - j, n]);
@@ -1126,20 +1023,20 @@ export function qr(x: Tensor2D): [Tensor, Tensor] {
           r = rjEndAll.sub(tauTimesW.matMul(w.transpose().matMul(rjEndAll)));
         } else {
           r = r.slice([0, 0], [j, n])
-                  .concat(
-                      rjEndAll.sub(
-                          tauTimesW.matMul(w.transpose().matMul(rjEndAll))),
-                      0) as Tensor2D;
+            .concat(
+              rjEndAll.sub(
+                tauTimesW.matMul(w.transpose().matMul(rjEndAll))),
+              0) as Tensor2D;
         }
         const qAllJEnd = q.slice([0, j], [m, q.shape[1] - j]);
         if (j === 0) {
           q = qAllJEnd.sub(qAllJEnd.matMul(w).matMul(tauTimesW.transpose()));
         } else {
           q = q.slice([0, 0], [m, j])
-                  .concat(
-                      qAllJEnd.sub(
-                          qAllJEnd.matMul(w).matMul(tauTimesW.transpose())),
-                      1) as Tensor2D;
+            .concat(
+              qAllJEnd.sub(
+                qAllJEnd.matMul(w).matMul(tauTimesW.transpose())),
+              1) as Tensor2D;
         }
         return [w, r, q];
       });
@@ -1162,8 +1059,8 @@ export function qr(x: Tensor2D): [Tensor, Tensor] {
 export function oneHot(indices: Tensor, numClasses: number): Tensor {
   if (ndim(indices) !== 1) {
     throw new Error(
-        'Only 1D one-hot tensors are supported in the ' +
-        'deeplearn backend, at present.');
+      'Only 1D one-hot tensors are supported in the ' +
+      'deeplearn backend, at present.');
   }
   indices = indices.toInt();
   return tfc.oneHot(indices as Tensor1D, numClasses).toFloat();
@@ -1181,7 +1078,7 @@ export function oneHot(indices: Tensor, numClasses: number): Tensor {
  *   the reduced dimensions are retained with length 1.
  */
 export function mean(
-    x: Tensor, axis?: number|number[], keepDims?: boolean): Scalar|Tensor {
+  x: Tensor, axis?: number | number[], keepDims?: boolean): Scalar | Tensor {
   // TODO(michaelterry): Remove once negative supported axes in deeplearn.js
   axis = normalizeAxis(x, axis);
   return tfc.mean(x, axis, keepDims);
@@ -1205,7 +1102,7 @@ export function argmax(x: Tensor, axis = -1): Tensor {
  * @returns The result of the gathering as a tensor.
  */
 export function gather(
-    reference: Tensor, indices: number[]|Tensor1D, axis?: number): Tensor {
+  reference: Tensor, indices: number[] | Tensor1D, axis?: number): Tensor {
   if (Array.isArray(indices)) {
     indices = tensor1d(indices, 'int32');
   } else {
@@ -1235,27 +1132,15 @@ export function square(x: Tensor): Tensor {
  *   nearest integer and converted to a tensor.
  * @returns A tensor of the same shape as `x`.
  */
-export function pow(x: Tensor, a: Tensor|number): Tensor {
+export function pow(x: Tensor, a: Tensor | number): Tensor {
   if (typeof (a) === 'number') {
     a = scalar(Math.round(a), 'int32');
   }
   if (a.dtype !== 'int32') {
     throw new NotImplementedError(
-        `Non-int32 dtype (${a.dtype}) is not supported by pow() yet`);
+      `Non-int32 dtype (${a.dtype}) is not supported by pow() yet`);
   }
   return tfc.pow(x, a as Tensor);
-}
-
-/**
- * Clips values element-wise.
- *
- * @param x Input Tensor or Variable.
- * @param minValue The lowest allowed value in the output
- * @param maxValue The highest allowed value in the output
- * @returns Tensor with values limited to be between min_value and max_value
- */
-export function clip(x: Tensor, minValue: number, maxValue: number): Tensor {
-  return tfc.clipByValue(x, minValue, maxValue);
 }
 
 /* Normalization operations. */
@@ -1275,29 +1160,29 @@ export function clip(x: Tensor, minValue: number, maxValue: number): Tensor {
  * @returns The result of the batch normalization.
  */
 export function batchNormalization(
-    x: Tensor, mean: Tensor, variance: Tensor, beta?: Tensor, gamma?: Tensor,
-    epsilon = 1e-3): Tensor {
+  x: Tensor, mean: Tensor, variance: Tensor, beta?: Tensor, gamma?: Tensor,
+  epsilon = 1e-3): Tensor {
   let out: Tensor;
   if (ndim(x) === 2) {
     out = tfc.batchNormalization2d(
-        x as Tensor2D, mean as Tensor2D | Tensor1D,
-        variance as Tensor2D | Tensor1D, epsilon, gamma as Tensor2D | Tensor1D,
-        beta as Tensor2D | Tensor1D);
+      x as Tensor2D, mean as Tensor2D | Tensor1D,
+      variance as Tensor2D | Tensor1D, epsilon, gamma as Tensor2D | Tensor1D,
+      beta as Tensor2D | Tensor1D);
   } else if (ndim(x) === 3) {
     // TODO(cais): Check rank; give proper error message.
     out = tfc.batchNormalization3d(
-        x as Tensor3D, mean as Tensor3D | Tensor1D,
-        variance as Tensor3D | Tensor1D, epsilon, gamma as Tensor3D | Tensor1D,
-        beta as Tensor3D | Tensor1D);
+      x as Tensor3D, mean as Tensor3D | Tensor1D,
+      variance as Tensor3D | Tensor1D, epsilon, gamma as Tensor3D | Tensor1D,
+      beta as Tensor3D | Tensor1D);
   } else if (ndim(x) === 4) {
     out = tfc.batchNormalization4d(
-        x as Tensor4D, mean as Tensor4D | Tensor1D,
-        variance as Tensor4D | Tensor1D, epsilon, gamma as Tensor4D | Tensor1D,
-        beta as Tensor4D | Tensor1D);
+      x as Tensor4D, mean as Tensor4D | Tensor1D,
+      variance as Tensor4D | Tensor1D, epsilon, gamma as Tensor4D | Tensor1D,
+      beta as Tensor4D | Tensor1D);
   } else {
     throw new NotImplementedError(
-        `batchNormalization is not implememnted for array of rank ${ndim(x)} ` +
-        `yet`);
+      `batchNormalization is not implememnted for array of rank ${ndim(x)} ` +
+      `yet`);
   }
   return out;
 }
@@ -1313,7 +1198,7 @@ export function batchNormalization(
  * @throws ValueError: If the rank of `bias` is incorrect.
  */
 export function biasAdd(
-    x: Tensor, bias: Tensor, dataFormat?: DataFormat): Tensor {
+  x: Tensor, bias: Tensor, dataFormat?: DataFormat): Tensor {
   if (dataFormat == null) {
     dataFormat = imageDataFormat();
   }
@@ -1321,8 +1206,8 @@ export function biasAdd(
 
   if (ndim(bias) !== 1 && ndim(bias) !== ndim(x)) {
     throw new ValueError(
-        'Unexpected bias dimensions: ' + ndim(bias) +
-        '; expected it to be 1 or ' + ndim(x));
+      'Unexpected bias dimensions: ' + ndim(bias) +
+      '; expected it to be 1 or ' + ndim(x));
   }
   const biasShape = bias.shape;
 
@@ -1333,7 +1218,7 @@ export function biasAdd(
         y = x.add(bias.reshape([1, biasShape[0], 1, 1, 1]));
       } else {
         y = x.add(bias.reshape(
-            [1, biasShape[3], biasShape[0], biasShape[1], biasShape[2]]));
+          [1, biasShape[3], biasShape[0], biasShape[1], biasShape[2]]));
       }
     } else if (dataFormat === 'channelsLast') {
       if (biasShape.length === 1) {
@@ -1388,8 +1273,8 @@ export function elu(x: Tensor, alpha = 1): Tensor {
   // TODO(cais): Add support for alpha values other than 1.
   if (alpha !== 1) {
     throw new NotImplementedError(
-        `Support for alpha values other than 1 (${alpha}) is not implemented ` +
-        `yet.`);
+      `Support for alpha values other than 1 (${alpha}) is not implemented ` +
+      `yet.`);
   }
   return tfc.elu(x);
 }
@@ -1429,23 +1314,23 @@ export function softsign(x: Tensor): Tensor {
  * @returns Result of the dropout operation.
  */
 export function dropout(
-    x: Tensor, level: Scalar, noiseShape?: number[], seed?: number): Tensor {
+  x: Tensor, level: Scalar, noiseShape?: number[], seed?: number): Tensor {
   // TODO(cais): Switch to deeplearn.js implementation of dropout when it
   //   becomes avaialable.
   if (noiseShape != null && !util.arraysEqual(x.shape, noiseShape)) {
     throw new NotImplementedError(
-        'Non-default noise shape is not implemented yet: ' +
-        JSON.stringify(noiseShape));
+      'Non-default noise shape is not implemented yet: ' +
+      JSON.stringify(noiseShape));
   }
   if (seed != null) {
     throw new NotImplementedError('seed is not implemented for dropout yet.');
   }
   let multiplier = tfc.step(tfc.add(
-      tfc.neg(level) as Scalar, randomUniform(x.shape, 0, 1, DType.float32)));
+    tfc.neg(level) as Scalar, tfc.randomUniform(x.shape, 0, 1, DType.float32)));
   // Scale the kept elements, so the expected sum is unchanged.
   multiplier = tfc.mul(
-      divide(getScalar(1), subtract(getScalar(1), level)) as Scalar,
-      multiplier);
+    tfc.div(getScalar(1), tfc.sub(getScalar(1), level)) as Scalar,
+    multiplier);
   return tfc.mul(x, multiplier);
 }
 
@@ -1458,7 +1343,7 @@ export function l2Normalize(x: Tensor, axis?: number): Tensor {
   const squareSum = tfc.sum(square(x), axis, true);
   const epsilonTensor = scalarTimesArray(scalar(epsilon()), tfc.onesLike(x));
   const norm = tfc.sqrt(tfc.maximum(squareSum, epsilonTensor));
-  return divide(x, norm);
+  return tfc.div(x, norm);
 }
 
 /**
@@ -1493,8 +1378,8 @@ function preprocessConv2DInput(x: Tensor, dataFormat: DataFormat): Tensor {
  * @throws ValueError, if `x`, `kernel` or `bias` is not of the correct rank.
  */
 export function conv1dWithBias(
-    x: Tensor, kernel: Tensor, bias: Tensor, strides = 1, padding = 'valid',
-    dataFormat?: DataFormat, dilationRate = 1): Tensor {
+  x: Tensor, kernel: Tensor, bias: Tensor, strides = 1, padding = 'valid',
+  dataFormat?: DataFormat, dilationRate = 1): Tensor {
   if (dataFormat == null) {
     dataFormat = imageDataFormat();
   }
@@ -1503,18 +1388,18 @@ export function conv1dWithBias(
   // Check the ranks of x, kernel and bias.
   if (x.shape.length !== 3) {
     throw new ValueError(
-        `The input of a conv1dWithBias operation should be 3, but is ` +
-        `${x.shape.length} instead.`);
+      `The input of a conv1dWithBias operation should be 3, but is ` +
+      `${x.shape.length} instead.`);
   }
   if (kernel.shape.length !== 3) {
     throw new ValueError(
-        `The kernel for a conv1dWithBias operation should be 3, but is ` +
-        `${kernel.shape.length} instead`);
+      `The kernel for a conv1dWithBias operation should be 3, but is ` +
+      `${kernel.shape.length} instead`);
   }
   if (bias != null && bias.shape.length !== 1) {
     throw new ValueError(
-        `The bias for a conv1dWithBias operation should be 1, but is ` +
-        `${kernel.shape.length} instead`);
+      `The bias for a conv1dWithBias operation should be 1, but is ` +
+      `${kernel.shape.length} instead`);
   }
 
   // TODO(cais): Support CAUSAL padding mode.
@@ -1524,12 +1409,12 @@ export function conv1dWithBias(
   }
   if (padding === 'causal') {
     throw new NotImplementedError(
-        'The support for CAUSAL padding mode in conv1dWithBias is not ' +
-        'implemented yet.');
+      'The support for CAUSAL padding mode in conv1dWithBias is not ' +
+      'implemented yet.');
   }
   let y: Tensor = tfc.conv1d(
-      x as Tensor2D | Tensor3D, kernel as Tensor3D, strides,
-      padding === 'same' ? 'same' : 'valid', 'NWC', dilationRate);
+    x as Tensor2D | Tensor3D, kernel as Tensor3D, strides,
+    padding === 'same' ? 'same' : 'valid', 'NWC', dilationRate);
   if (bias != null) {
     y = biasAdd(y, bias);
   }
@@ -1549,11 +1434,11 @@ export function conv1dWithBias(
  * @throws ValueError, if `x`, `kernel` or `bias` is not of the correct rank.
  */
 export function conv1d(
-    x: Tensor, kernel: Tensor, strides = 1, padding = 'valid',
-    dataFormat?: DataFormat, dilationRate = 1): Tensor {
+  x: Tensor, kernel: Tensor, strides = 1, padding = 'valid',
+  dataFormat?: DataFormat, dilationRate = 1): Tensor {
   checkDataFormat(dataFormat);
   return conv1dWithBias(
-      x, kernel, null, strides, padding, dataFormat, dilationRate);
+    x, kernel, null, strides, padding, dataFormat, dilationRate);
 }
 
 /**
@@ -1567,11 +1452,11 @@ export function conv1d(
  * @returns Result of the 2D pooling.
  */
 export function conv2d(
-    x: Tensor, kernel: Tensor, strides = [1, 1], padding = 'valid',
-    dataFormat?: DataFormat, dilationRate?: [number, number]): Tensor {
+  x: Tensor, kernel: Tensor, strides = [1, 1], padding = 'valid',
+  dataFormat?: DataFormat, dilationRate?: [number, number]): Tensor {
   checkDataFormat(dataFormat);
   return conv2dWithBias(
-      x, kernel, null, strides, padding, dataFormat, dilationRate);
+    x, kernel, null, strides, padding, dataFormat, dilationRate);
 }
 
 /**
@@ -1580,32 +1465,32 @@ export function conv2d(
  * is exactly the same as `conv2d`, except the added `bias`.
  */
 export function conv2dWithBias(
-    x: Tensor, kernel: Tensor, bias: Tensor, strides = [1, 1],
-    padding = 'valid', dataFormat?: DataFormat,
-    dilationRate?: [number, number]): Tensor {
+  x: Tensor, kernel: Tensor, bias: Tensor, strides = [1, 1],
+  padding = 'valid', dataFormat?: DataFormat,
+  dilationRate?: [number, number]): Tensor {
   if (dataFormat == null) {
     dataFormat = imageDataFormat();
   }
   checkDataFormat(dataFormat);
   if (ndim(x) !== 3 && ndim(x) !== 4) {
     throw new ValueError(
-        `conv2dWithBias expects input to be of rank 3 or 4, but received ` +
-        `${ndim(x)}.`);
+      `conv2dWithBias expects input to be of rank 3 or 4, but received ` +
+      `${ndim(x)}.`);
   }
   if (ndim(kernel) !== 3 && ndim(kernel) !== 4) {
     throw new ValueError(
-        `conv2dWithBias expects kernel to be of rank 3 or 4, but received ` +
-        `${ndim(x)}.`);
+      `conv2dWithBias expects kernel to be of rank 3 or 4, but received ` +
+      `${ndim(x)}.`);
   }
   let y = preprocessConv2DInput(x, dataFormat);
   if (padding === 'causal') {
     throw new NotImplementedError(
-        'The support for CAUSAL padding mode in conv1dWithBias is not ' +
-        'implemented yet.');
+      'The support for CAUSAL padding mode in conv1dWithBias is not ' +
+      'implemented yet.');
   }
   y = tfc.conv2d(
-      y as Tensor3D | Tensor4D, kernel as Tensor4D, strides as [number, number],
-      padding === 'same' ? 'same' : 'valid', 'NHWC', dilationRate);
+    y as Tensor3D | Tensor4D, kernel as Tensor4D, strides as [number, number],
+    padding === 'same' ? 'same' : 'valid', 'NHWC', dilationRate);
   if (bias != null) {
     y = biasAdd(y, bias as Tensor1D);
   }
@@ -1628,9 +1513,9 @@ export function conv2dWithBias(
  * @throws ValueError If depthwiseKernel is not a 4D array.
  */
 export function depthwiseConv2d(
-    x: Tensor, depthwiseKernel: Tensor, strides: [number, number] = [1, 1],
-    padding = 'valid', dataFormat?: DataFormat,
-    dilationRate?: [number, number]): Tensor {
+  x: Tensor, depthwiseKernel: Tensor, strides: [number, number] = [1, 1],
+  padding = 'valid', dataFormat?: DataFormat,
+  dilationRate?: [number, number]): Tensor {
   if (dataFormat == null) {
     dataFormat = imageDataFormat();
   }
@@ -1638,17 +1523,17 @@ export function depthwiseConv2d(
   let y = preprocessConv2DInput(x, dataFormat);
   if (ndim(x) !== 4) {
     throw new ValueError(
-        `Input for depthwiseConv2d is required to be 4-D, but is instead ` +
-        `${ndim(x)}-D`);
+      `Input for depthwiseConv2d is required to be 4-D, but is instead ` +
+      `${ndim(x)}-D`);
   }
   if (ndim(depthwiseKernel) !== 4) {
     throw new ValueError(
-        `depthwiseKernel is required to be 4-D, but is instead ` +
-        `${ndim(depthwiseKernel)}-D`);
+      `depthwiseKernel is required to be 4-D, but is instead ` +
+      `${ndim(depthwiseKernel)}-D`);
   }
   y = tfc.depthwiseConv2d(
-      y as Tensor4D, depthwiseKernel as Tensor4D, strides,
-      padding === 'same' ? 'same' : 'valid', 'NHWC', dilationRate);
+    y as Tensor4D, depthwiseKernel as Tensor4D, strides,
+    padding === 'same' ? 'same' : 'valid', 'NHWC', dilationRate);
   if (dataFormat === 'channelsFirst') {
     y = tfc.transpose(y, [0, 3, 1, 2]);
   }
@@ -1666,9 +1551,9 @@ export function depthwiseConv2d(
  * @returns Result of the 2D pooling.
  */
 export function pool2d(
-    x: Tensor, poolSize: [number, number], strides?: [number, number],
-    padding?: PaddingMode, dataFormat?: DataFormat,
-    poolMode?: PoolMode): Tensor {
+  x: Tensor, poolSize: [number, number], strides?: [number, number],
+  padding?: PaddingMode, dataFormat?: DataFormat,
+  poolMode?: PoolMode): Tensor {
   checkDataFormat(dataFormat);
   checkPoolMode(poolMode);
   checkPaddingMode(padding);
@@ -1697,8 +1582,8 @@ export function pool2d(
     // TODO(cais): Check the dtype and rank of x and give clear error message
     //   if those are incorrect.
     y = tfc.avgPool(
-        // TODO(cais): Rank check?
-        x as Tensor3D | Tensor4D, poolSize, strides, paddingString);
+      // TODO(cais): Rank check?
+      x as Tensor3D | Tensor4D, poolSize, strides, paddingString);
   }
   if (dataFormat === 'channelsFirst') {
     y = tfc.transpose(y, [0, 3, 1, 2]);  // NHWC -> NCHW.
@@ -1724,7 +1609,7 @@ export function floatx(): DType {
   return DType.float32;
 }
 
-const _uidPrefixes: {[prefix: string]: number} = {};
+const _uidPrefixes: { [prefix: string]: number } = {};
 
 /**
  * Provides a unique UID given a string prefix.
@@ -1740,24 +1625,6 @@ export function getUid(prefix = ''): string {
 }
 
 /**
- * Computes the softmax function on an input tensor across the last dimension.
- *
- * Implemented by:
- *  shuffling the dimensions in x to put the axis last
- *  reshaping into a 2D tensor
- *  taking the softmax over the last dimension, and then reshaping back.
- *  undoing the dimension shuffle
- *
- * @param xNDA numeric tensor with 1 or more dimensions.
- *
- * @return A Tensor the same shape as x, but with softmax calculated
- * across the last dimension.
- */
-export function softmax(x: Tensor, axis = -1): Tensor {
-  return tfc.softmax(x, axis);
-}
-
-/**
  * Categorical crossentropy between an output tensor and a target tensor.
  *
  * @param target A tensor of the same shape as `output`.
@@ -1767,17 +1634,17 @@ export function softmax(x: Tensor, axis = -1): Tensor {
  *   a tensor of logits.
  */
 export function categoricalCrossentropy(
-    target: Tensor, output: Tensor, fromLogits = false): Tensor {
+  target: Tensor, output: Tensor, fromLogits = false): Tensor {
   if (fromLogits) {
-    output = softmax(output);
+    output = tfc.softmax(output);
   } else {
     // scale preds so that the class probabilities of each sample sum to 1.
     const outputSum = tfc.sum(output, shape(output).length - 1, true);
-    output = divide(output, outputSum);
+    output = tfc.div(output, outputSum);
   }
-  output = clip(output, epsilon(), 1 - epsilon());
+  output = tfc.clipByValue(output, epsilon(), 1 - epsilon());
   return tfc.neg(tfc.sum(
-      tfc.mul(target.toFloat(), tfc.log(output)), shape(output).length - 1));
+    tfc.mul(target.toFloat(), tfc.log(output)), shape(output).length - 1));
 }
 
 /**
@@ -1790,11 +1657,11 @@ export function categoricalCrossentropy(
  *   a tensor of logits.
  */
 export function sparseCategoricalCrossentropy(
-    target: Tensor, output: Tensor, fromLogits = false): Tensor {
+  target: Tensor, output: Tensor, fromLogits = false): Tensor {
   const flatTarget = tfc.floor(flatten(target)).toInt() as Tensor1D;
   const outputShape = shape(output);
   const oneHotTarget = reshape(
-      tfc.oneHot(flatTarget, outputShape[outputShape.length - 1]), outputShape);
+    tfc.oneHot(flatTarget, outputShape[outputShape.length - 1]), outputShape);
   return categoricalCrossentropy(oneHotTarget, output, fromLogits);
 }
 
@@ -1807,11 +1674,11 @@ export function sparseCategoricalCrossentropy(
  *   default, we consider that `output` encodes a probability distribution.
  */
 export function binaryCrossentropy(
-    target: Tensor, output: Tensor, fromLogits = false): Tensor {
+  target: Tensor, output: Tensor, fromLogits = false): Tensor {
   let y: Tensor;
   if (!fromLogits) {
-    y = clip(output, epsilon(), 1 - epsilon());
-    y = tfc.log(divide(y, subtract(tfc.onesLike(y), y)));
+    y = tfc.clipByValue(output, epsilon(), 1 - epsilon());
+    y = tfc.log(tfc.div(y, tfc.sub(tfc.onesLike(y), y)));
   } else {
     y = output;
   }
@@ -1840,11 +1707,11 @@ export function binaryCrossentropy(
  * @param output The logits.
  */
 export function sigmoidCrossEntropyWithLogits(
-    target: Tensor, output: Tensor): Tensor {
+  target: Tensor, output: Tensor): Tensor {
   const maxOutput = tfc.maximum(output, tfc.zerosLike(output));
   const outputXTarget = tfc.mul(output, target);
   const sigmoidOutput =
-      tfc.log(tfc.add(getScalar(1), tfc.exp(tfc.neg(tfc.abs(output)))));
+    tfc.log(tfc.add(getScalar(1), tfc.exp(tfc.neg(tfc.abs(output)))));
   const result = tfc.add(tfc.sub(maxOutput, outputXTarget), sigmoidOutput);
   return result;
 }
@@ -1862,7 +1729,7 @@ export function hardSigmoid(x: Tensor): Tensor {
   // TODO(cais): Maybe avoid creating scalar constants on each invocation by
   //   turning them into module-level constants.
   const y = scalarPlusArray(scalar(0.5), scalarTimesArray(scalar(0.2), x));
-  return clip(y, 0, 1);
+  return tfc.clipByValue(y, 0, 1);
 }
 
 /**
@@ -1920,9 +1787,9 @@ export function inTrainPhase<T>(x: () => T, alt: () => T, training = false): T {
  * @throws ValueError If input dimension is less than 3.
  */
 export function rnn(
-    stepFunction: RnnStepFunction, inputs: Tensor, initialStates: Tensor[],
-    goBackwards = false, mask?: Tensor, constants?: Tensor[], unroll = false,
-    inputLength?: number): [Tensor, Tensor, Tensor[]] {
+  stepFunction: RnnStepFunction, inputs: Tensor, initialStates: Tensor[],
+  goBackwards = false, mask?: Tensor, constants?: Tensor[], unroll = false,
+  inputLength?: number): [Tensor, Tensor, Tensor[]] {
   const ndim = inputs.shape.length;
   if (ndim < 3) {
     throw new ValueError(`Input should be at least 3D, but is ${ndim}D.`);
@@ -1935,21 +1802,21 @@ export function rnn(
 
   if (mask != null) {
     throw new NotImplementedError(
-        'The rnn() function of the deeplearn.js backend does not support ' +
-        'masking yet.');
+      'The rnn() function of the deeplearn.js backend does not support ' +
+      'masking yet.');
   }
 
   if (constants != null) {
     throw new NotImplementedError(
-        'The rnn() functoin of the deeplearn.js backend does not support ' +
-        'constants yet.');
+      'The rnn() functoin of the deeplearn.js backend does not support ' +
+      'constants yet.');
   }
 
   // Porting Note: the unroll option is ignored by the imperative backend.
   if (unroll) {
     console.warn(
-        'Backend rnn(): the unroll = true option is not applicable to the ' +
-        'imperative deeplearn.js backend.');
+      'Backend rnn(): the unroll = true option is not applicable to the ' +
+      'imperative deeplearn.js backend.');
   }
 
   if (goBackwards) {
@@ -1980,7 +1847,7 @@ export function rnn(
       outputs = lastOutput.reshape([1].concat(lastOutput.shape));
     } else {
       outputs = concatAlongFirstAxis(
-          outputs, lastOutput.reshape([1].concat(lastOutput.shape)));
+        outputs, lastOutput.reshape([1].concat(lastOutput.shape)));
     }
     // TODO(soergel): Call K.concatenate() to perform only one concatenation at
     // the end, once the backend function is available.
@@ -1990,7 +1857,7 @@ export function rnn(
   return [
     lastOutput,
     tfc.transpose(
-        outputs, [1, 0].concat(math_utils.range(2, outputs.shape.length))),
+      outputs, [1, 0].concat(math_utils.range(2, outputs.shape.length))),
     states
   ];
 }
@@ -2004,11 +1871,11 @@ export function rnn(
  * @returns An Array of gradients tensors.
  */
 export function gradients(
-    lossFn: () => Scalar, variables: LayerVariable[]): Tensor[] {
+  lossFn: () => Scalar, variables: LayerVariable[]): Tensor[] {
   // TODO(cais): The return type signature can be simplified if deeplearn makes
   //   the corresponding type public.
   const variableList =
-      variables.map(variable => variable.read() as tfc.Variable);
+    variables.map(variable => variable.read() as tfc.Variable);
   const valudAndGrads = variableGrads(lossFn, variableList);
   return variables.map(variable => valudAndGrads.grads[variable.name]);
 }

--- a/src/backend/tfjs_backend_test.ts
+++ b/src/backend/tfjs_backend_test.ts
@@ -14,13 +14,13 @@
 
 // tslint:disable:max-line-length
 import * as tfc from '@tensorflow/tfjs-core';
-import {Scalar, scalar, slice, Tensor,memory, tensor1d, tensor2d, tensor3d, tensor4d, Tensor4D, zeros} from '@tensorflow/tfjs-core';
+import { Scalar, scalar, slice, Tensor, memory, tensor1d, tensor2d, tensor3d, tensor4d, Tensor4D, zeros } from '@tensorflow/tfjs-core';
 
-import {DataFormat, PaddingMode, PoolMode} from '../common';
-import {DType, LayerVariable, SymbolicTensor} from '../types';
-import {unique} from '../utils/generic_utils';
-import {range} from '../utils/math_utils';
-import {describeMathCPU, describeMathCPUAndGPU, expectTensorsClose} from '../utils/test_utils';
+import { DataFormat, PaddingMode, PoolMode } from '../common';
+import { DType, LayerVariable, SymbolicTensor } from '../types';
+import { unique } from '../utils/generic_utils';
+import { range } from '../utils/math_utils';
+import { describeMathCPU, describeMathCPUAndGPU, expectTensorsClose } from '../utils/test_utils';
 
 import * as K from './tfjs_backend';
 
@@ -196,7 +196,7 @@ describeMathCPU('countParams', () => {
 describeMathCPUAndGPU('cast', () => {
   it('float32 to int32', () => {
     const x =
-        tensor2d([[-1.1, -1.6], [1.1, 2.2], [3.6, 4.7]], [3, 2], 'float32');
+      tensor2d([[-1.1, -1.6], [1.1, 2.2], [3.6, 4.7]], [3, 2], 'float32');
     const y = K.cast(x, 'int32');
     expect(y.dtype).toEqual('int32');
     expect(y.shape).toEqual([3, 2]);
@@ -211,7 +211,7 @@ describeMathCPUAndGPU('cast', () => {
   });
   it('float32 to bool', () => {
     const x =
-        tensor2d([[-1.1, -1.6], [0.0, 2.2], [3.6, 4.7]], [3, 2], 'float32');
+      tensor2d([[-1.1, -1.6], [0.0, 2.2], [3.6, 4.7]], [3, 2], 'float32');
     const y = K.cast(x, 'bool');
     expect(y.dtype).toEqual('bool');
     expect(y.shape).toEqual([3, 2]);
@@ -272,8 +272,8 @@ describeMathCPUAndGPU('Reshape', () => {
 
   it('3D to 2D', () => {
     const x = tensor3d(
-        [[[10, 20, 30], [40, 50, 60]], [[-10, -20, -30], [-40, -50, -60]]],
-        [2, 2, 3]);
+      [[[10, 20, 30], [40, 50, 60]], [[-10, -20, -30], [-40, -50, -60]]],
+      [2, 2, 3]);
     const reshaped = K.reshape(x, [2, 6]);
     expect(reshaped.shape).toEqual([2, 6]);
     expect(reshaped.dataSync()).toEqual(new Float32Array([
@@ -298,35 +298,17 @@ describeMathCPUAndGPU('expandDims', () => {
   it('2D to 3D: Last dimension', () => {
     const x = tensor2d([[10, 20], [30, 40]], [2, 2]);
     expectTensorsClose(
-        K.expandDims(x), tensor3d([[[10], [20]], [[30], [40]]], [2, 2, 1]));
+      K.expandDims(x), tensor3d([[[10], [20]], [[30], [40]]], [2, 2, 1]));
   });
   it('2D to 3D: Second dimension', () => {
     const x = tensor2d([[10, 20], [30, 40]], [2, 2]);
     expectTensorsClose(
-        K.expandDims(x, 1), tensor3d([[[10, 20]], [[30, 40]]], [2, 1, 2]));
+      K.expandDims(x, 1), tensor3d([[[10, 20]], [[30, 40]]], [2, 1, 2]));
   });
   it('2D to 3D: First dimension', () => {
     const x = tensor2d([[10, 20], [30, 40]], [2, 2]);
     expectTensorsClose(
-        K.expandDims(x, 0), tensor3d([[[10, 20], [30, 40]]], [1, 2, 2]));
-  });
-});
-
-describeMathCPUAndGPU('squeeze', () => {
-  it('1D to Scalar', () => {
-    const value = 10;
-    const xTensor = tensor1d([value]);
-    expectTensorsClose(K.squeeze(xTensor, 0), scalar(value));
-  });
-  it('2D to 1D: Last dimension', () => {
-    const x = tensor2d([[10], [20], [30]]);
-    const y = tensor1d([10, 20, 30]);
-    expectTensorsClose(K.squeeze(x, 1), y);
-  });
-  it('2D to 1D: First dimension', () => {
-    const x = tensor2d([[10, 20, 30]]);
-    const y = tensor1d([10, 20, 30]);
-    expectTensorsClose(K.squeeze(x, 0), y);
+      K.expandDims(x, 0), tensor3d([[[10, 20], [30, 40]]], [1, 2, 2]));
   });
 });
 
@@ -335,50 +317,50 @@ describeMathCPUAndGPU('temporalPadding', () => {
     const x = tensor3d([[[1, 2], [3, 4]], [[-1, -2], [-3, -4]]]);
     const y = K.temporalPadding(x);
     expectTensorsClose(y, tensor3d([
-                         [[0, 0], [1, 2], [3, 4], [0, 0]],
-                         [[0, 0], [-1, -2], [-3, -4], [0, 0]]
-                       ]));
+      [[0, 0], [1, 2], [3, 4], [0, 0]],
+      [[0, 0], [-1, -2], [-3, -4], [0, 0]]
+    ]));
   });
   it('custom padding 2-2', () => {
     const x = tensor3d([[[1, 2], [3, 4]], [[-1, -2], [-3, -4]]]);
     const y = K.temporalPadding(x, [2, 2]);
     expectTensorsClose(
-        y, tensor3d([
-          [[0, 0], [0, 0], [1, 2], [3, 4], [0, 0], [0, 0]],
-          [[0, 0], [0, 0], [-1, -2], [-3, -4], [0, 0], [0, 0]]
-        ]));
+      y, tensor3d([
+        [[0, 0], [0, 0], [1, 2], [3, 4], [0, 0], [0, 0]],
+        [[0, 0], [0, 0], [-1, -2], [-3, -4], [0, 0], [0, 0]]
+      ]));
   });
 });
 
 describeMathCPUAndGPU('spatial2dPadding', () => {
   it('default padding 1-1-1-1', () => {
-    const x = K.ones([2, 3, 4, 3]);
+    const x = tfc.ones([2, 3, 4, 3]);
     const y = K.spatial2dPadding(x);
 
     expect(y.shape).toEqual([2, 5, 6, 3]);
     expectTensorsClose(slice(y, [0, 1, 1, 0], [2, 3, 4, 3]), x);
     expectTensorsClose(
-        slice(y, [0, 0, 0, 0], [2, 1, 6, 3]), K.zeros([2, 1, 6, 3]));
+      slice(y, [0, 0, 0, 0], [2, 1, 6, 3]), tfc.zeros([2, 1, 6, 3]));
     expectTensorsClose(
-        slice(y, [0, 4, 0, 0], [2, 1, 6, 3]), K.zeros([2, 1, 6, 3]));
+      slice(y, [0, 4, 0, 0], [2, 1, 6, 3]), tfc.zeros([2, 1, 6, 3]));
     expectTensorsClose(
-        slice(y, [0, 0, 0, 0], [2, 5, 1, 3]), K.zeros([2, 5, 1, 3]));
+      slice(y, [0, 0, 0, 0], [2, 5, 1, 3]), tfc.zeros([2, 5, 1, 3]));
     expectTensorsClose(
-        slice(y, [0, 0, 5, 0], [2, 5, 1, 3]), K.zeros([2, 5, 1, 3]));
+      slice(y, [0, 0, 5, 0], [2, 5, 1, 3]), tfc.zeros([2, 5, 1, 3]));
   });
 
   it('custom padding 2-2-3-0', () => {
-    const x = K.ones([2, 3, 4, 3]);
+    const x = tfc.ones([2, 3, 4, 3]);
     const y = K.spatial2dPadding(x, [[2, 2], [3, 0]]);
     expect(y.shape).toEqual([2, 7, 7, 3]);
 
     expectTensorsClose(slice(y, [0, 2, 3, 0], [2, 3, 4, 3]), x);
     expectTensorsClose(
-        slice(y, [0, 0, 0, 0], [2, 2, 7, 3]), K.zeros([2, 2, 7, 3]));
+      slice(y, [0, 0, 0, 0], [2, 2, 7, 3]), tfc.zeros([2, 2, 7, 3]));
     expectTensorsClose(
-        slice(y, [0, 5, 0, 0], [2, 2, 7, 3]), K.zeros([2, 2, 7, 3]));
+      slice(y, [0, 5, 0, 0], [2, 2, 7, 3]), tfc.zeros([2, 2, 7, 3]));
     expectTensorsClose(
-        slice(y, [0, 0, 0, 0], [2, 7, 3, 3]), K.zeros([2, 7, 3, 3]));
+      slice(y, [0, 0, 0, 0], [2, 7, 3, 3]), tfc.zeros([2, 7, 3, 3]));
   });
 });
 
@@ -387,15 +369,15 @@ describeMathCPUAndGPU('Repeat', () => {
     const x = tensor2d([[1, 2], [3, 4]], [2, 2]);
     const y = K.repeat(x, 3);
     expectTensorsClose(
-        y,
-        tensor3d(
-            [[[1, 2], [1, 2], [1, 2]], [[3, 4], [3, 4], [3, 4]]], [2, 3, 2]));
+      y,
+      tensor3d(
+        [[[1, 2], [1, 2], [1, 2]], [[3, 4], [3, 4], [3, 4]]], [2, 3, 2]));
   });
   it('Non-2D array leads to AssertionError', () => {
     const x = tensor1d([1, 2, 3]);
     expect(() => K.repeat(x, 2))
-        .toThrowError(
-            /repeat\(\) expects a rank-2 tensor, but received a rank-1 tensor/);
+      .toThrowError(
+        /repeat\(\) expects a rank-2 tensor, but received a rank-1 tensor/);
   });
 });
 
@@ -416,8 +398,8 @@ describeMathCPUAndGPU('Flatten', () => {
 
   it('3D Tensor', () => {
     const x = tensor3d(
-        [[[10, 20, 30], [40, 50, 60]], [[-10, -20, -30], [-40, -50, -60]]],
-        [2, 2, 3]);
+      [[[10, 20, 30], [40, 50, 60]], [[-10, -20, -30], [-40, -50, -60]]],
+      [2, 2, 3]);
     const flattend = K.flatten(x);
     expect(flattend.shape).toEqual([12]);
     expect(flattend.dataSync()).toEqual(new Float32Array([
@@ -427,7 +409,7 @@ describeMathCPUAndGPU('Flatten', () => {
 
   it('4D Tensor', () => {
     const x = tensor4d(
-        [1, 2, 3, 4, 5, 6, 7, 8, -8, -7, -6, -5, -4, -3, -2, -1], [2, 2, 2, 2]);
+      [1, 2, 3, 4, 5, 6, 7, 8, -8, -7, -6, -5, -4, -3, -2, -1], [2, 2, 2, 2]);
     const flattend = K.flatten(x);
     expect(flattend.shape).toEqual([16]);
     expect(flattend.dataSync()).toEqual(new Float32Array([
@@ -440,15 +422,15 @@ describeMathCPUAndGPU('batchFlatten', () => {
   it('Scalar Tensor leads to error', () => {
     const x = scalar(1337);
     expect(() => K.batchFlatten(x))
-        .toThrowError(
-            /batchFlatten requires a minimum rank of 2\. Got rank: 0/);
+      .toThrowError(
+        /batchFlatten requires a minimum rank of 2\. Got rank: 0/);
   });
 
   it('1D Tensor leads to error', () => {
     const x = tensor1d([1, 3, 3, 7]);
     expect(() => K.batchFlatten(x))
-        .toThrowError(
-            /batchFlatten requires a minimum rank of 2\. Got rank: 1/);
+      .toThrowError(
+        /batchFlatten requires a minimum rank of 2\. Got rank: 1/);
   });
 
   it('2D Tensor', () => {
@@ -460,8 +442,8 @@ describeMathCPUAndGPU('batchFlatten', () => {
 
   it('3D Tensor', () => {
     const x = tensor3d(
-        [[[10, 20, 30], [40, 50, 60]], [[-10, -20, -30], [-40, -50, -60]]],
-        [2, 2, 3]);
+      [[[10, 20, 30], [40, 50, 60]], [[-10, -20, -30], [-40, -50, -60]]],
+      [2, 2, 3]);
     const batchFlattened = K.batchFlatten(x);
     expect(batchFlattened.shape).toEqual([2, 6]);
     expect(batchFlattened.dataSync()).toEqual(new Float32Array([
@@ -471,7 +453,7 @@ describeMathCPUAndGPU('batchFlatten', () => {
 
   it('4D Tensor', () => {
     const x = tensor4d(
-        [1, 2, 3, 4, 5, 6, 7, 8, -8, -7, -6, -5, -4, -3, -2, -1], [2, 2, 2, 2]);
+      [1, 2, 3, 4, 5, 6, 7, 8, -8, -7, -6, -5, -4, -3, -2, -1], [2, 2, 2, 2]);
     const batchFlattened = K.batchFlatten(x);
     expect(batchFlattened.shape).toEqual([2, 8]);
     expect(batchFlattened.dataSync()).toEqual(new Float32Array([
@@ -491,22 +473,22 @@ describeMathCPUAndGPU('sliceAlongFirstAxis', () => {
   it('2D', () => {
     const x = tensor2d(array2DData, [4, 2]);
     expectTensorsClose(
-        K.sliceAlongFirstAxis(x, 1, 2), tensor2d([[20, 21], [30, 31]], [2, 2]));
+      K.sliceAlongFirstAxis(x, 1, 2), tensor2d([[20, 21], [30, 31]], [2, 2]));
   });
 
   const array3DData = [[[10]], [[20]], [[30]], [[40]]];
   it('3D', () => {
     const x = tensor3d(array3DData, [4, 1, 1]);
     expectTensorsClose(
-        K.sliceAlongFirstAxis(x, 1, 2), tensor3d([[[20]], [[30]]], [2, 1, 1]));
+      K.sliceAlongFirstAxis(x, 1, 2), tensor3d([[[20]], [[30]]], [2, 1, 1]));
   });
 
   const array4DData = [[[[10]]], [[[20]]], [[[30]]], [[[40]]]];
   it('4D', () => {
     const x = tensor4d(array4DData, [4, 1, 1, 1]);
     expectTensorsClose(
-        K.sliceAlongFirstAxis(x, 1, 2),
-        tensor4d([[[[20]]], [[[30]]]], [2, 1, 1, 1]));
+      K.sliceAlongFirstAxis(x, 1, 2),
+      tensor4d([[[[20]]], [[[30]]]], [2, 1, 1, 1]));
   });
 
   it('Scalar leads to error', () => {
@@ -527,21 +509,21 @@ describeMathCPUAndGPU('sliceAlongLastAxis', () => {
   it('2D', () => {
     const x = tensor2d(array2DData, [2, 4]);
     expectTensorsClose(
-        K.sliceAlongLastAxis(x, 1, 2), tensor2d([[11, 12], [21, 22]], [2, 2]));
+      K.sliceAlongLastAxis(x, 1, 2), tensor2d([[11, 12], [21, 22]], [2, 2]));
   });
 
   const array3DData = [[[10, 20, 30, 40]]];
   it('3D', () => {
     const x = tensor3d(array3DData, [1, 1, 4]);
     expectTensorsClose(
-        K.sliceAlongLastAxis(x, 1, 2), tensor3d([[[20, 30]]], [1, 1, 2]));
+      K.sliceAlongLastAxis(x, 1, 2), tensor3d([[[20, 30]]], [1, 1, 2]));
   });
 
   const array4DData = [[[[10, 20, 30, 40]]]];
   it('3D', () => {
     const x = tensor4d(array4DData, [1, 1, 1, 4]);
     expectTensorsClose(
-        K.sliceAlongLastAxis(x, 1, 2), tensor4d([[[[20, 30]]]], [1, 1, 1, 2]));
+      K.sliceAlongLastAxis(x, 1, 2), tensor4d([[[[20, 30]]]], [1, 1, 1, 2]));
   });
 });
 
@@ -557,33 +539,33 @@ describeMathCPUAndGPU('sliceAlongAxis', () => {
   it('2D-1', () => {
     const x = tensor2d(array2DData, [4, 2]);
     expectTensorsClose(
-        K.sliceAlongAxis(x, 1, 2, 1), tensor2d([[20, 21], [30, 31]], [2, 2]));
+      K.sliceAlongAxis(x, 1, 2, 1), tensor2d([[20, 21], [30, 31]], [2, 2]));
   });
 
   it('2D-2', () => {
     const x = tensor2d(array2DData, [4, 2]);
     expectTensorsClose(
-        K.sliceAlongAxis(x, 0, 1, 2),
-        tensor2d([[10], [20], [30], [40]], [4, 1]));
+      K.sliceAlongAxis(x, 0, 1, 2),
+      tensor2d([[10], [20], [30], [40]], [4, 1]));
   });
 
   const array3DData = [[[1, 2], [3, 4]], [[5, 6], [7, 8]]];
   it('3D-1', () => {
     const x = tensor3d(array3DData, [2, 2, 2]);
     expectTensorsClose(
-        K.sliceAlongAxis(x, 0, 1, 1), tensor3d([[[1, 2], [3, 4]]], [1, 2, 2]));
+      K.sliceAlongAxis(x, 0, 1, 1), tensor3d([[[1, 2], [3, 4]]], [1, 2, 2]));
   });
   it('3D-2', () => {
     const x = tensor3d(array3DData, [2, 2, 2]);
     expectTensorsClose(
-        K.sliceAlongAxis(x, 0, 1, 2),
-        tensor3d([[[1, 2]], [[5, 6]]], [2, 1, 2]));
+      K.sliceAlongAxis(x, 0, 1, 2),
+      tensor3d([[[1, 2]], [[5, 6]]], [2, 1, 2]));
   });
   it('3D-3', () => {
     const x = tensor3d(array3DData, [2, 2, 2]);
     expectTensorsClose(
-        K.sliceAlongAxis(x, 0, 1, 3),
-        tensor3d([[[1], [3]], [[5], [7]]], [2, 2, 1]));
+      K.sliceAlongAxis(x, 0, 1, 3),
+      tensor3d([[[1], [3]], [[5], [7]]], [2, 2, 1]));
   });
 
 
@@ -591,8 +573,8 @@ describeMathCPUAndGPU('sliceAlongAxis', () => {
     const array4DData = [[[[10, 1]]], [[[20, 2]]], [[[30, 3]]], [[[40, 4]]]];
     const x = tensor4d(array4DData, [4, 1, 1, 2]);
     expectTensorsClose(
-        K.sliceAlongAxis(x, 0, 1, 4),
-        tensor4d([[[[10]]], [[[20]]], [[[30]]], [[[40]]]], [4, 1, 1, 1]));
+      K.sliceAlongAxis(x, 0, 1, 4),
+      tensor4d([[[[10]]], [[[20]]], [[[30]]], [[[40]]]], [4, 1, 1, 1]));
   });
 });
 describeMathCPUAndGPU('normalizeBatchInTraining', () => {
@@ -622,89 +604,89 @@ describeMathCPUAndGPU('normalizeBatchInTraining', () => {
     const beta = tensor1d([0, 0, 0, 0]);
     const reductionAxes = [0];
     const [normed, mean, variance] =
-        K.normalizeBatchInTraining(x, gamma, beta, reductionAxes);
+      K.normalizeBatchInTraining(x, gamma, beta, reductionAxes);
     expectTensorsClose(
-        normed,
-        tensor2d(
-            [
-              [-0.805371, -0.9502233, -1.1624058, -1.3885813],
-              [-0.6040282, -0.4319197, -0.11624074, 0.46286058],
-              [1.4093992, 1.3821429, 1.2786462, 0.92572117]
-            ],
-            [3, 4]));
+      normed,
+      tensor2d(
+        [
+          [-0.805371, -0.9502233, -1.1624058, -1.3885813],
+          [-0.6040282, -0.4319197, -0.11624074, 0.46286058],
+          [1.4093992, 1.3821429, 1.2786462, 0.92572117]
+        ],
+        [3, 4]));
     expectTensorsClose(mean, tensor1d([5.0, 5.6666665, 6.3333335, 7.0]));
     expectTensorsClose(
-        variance, tensor1d([24.666666, 14.888889, 8.222222, 4.6666665]));
+      variance, tensor1d([24.666666, 14.888889, 8.222222, 4.6666665]));
   });
 
   it('3D, no broadcasting', () => {
     const x = tensor3d(
-        [[[1, 2], [3, 4]], [[2, 4], [6, 8]], [[12, 11], [10, 9]]], [3, 2, 2]);
+      [[[1, 2], [3, 4]], [[2, 4], [6, 8]], [[12, 11], [10, 9]]], [3, 2, 2]);
     const gamma = tensor1d([1, 1]);
     const beta = tensor1d([0, 0]);
     const reductionAxes = [0, 1];
     const [normed, mean, variance] =
-        K.normalizeBatchInTraining(x, gamma, beta, reductionAxes);
+      K.normalizeBatchInTraining(x, gamma, beta, reductionAxes);
     expectTensorsClose(
-        normed,
-        tensor3d(
-            [
-              [[-1.1355163, -1.3552775], [-0.6488664, -0.7297648]],
-              [[-0.8921913, -0.7297648], [0.08110833, 0.5212605]],
-              [[1.5410578, 1.4595294], [1.0544081, 0.8340168]]
-            ],
-            [3, 2, 2]));
+      normed,
+      tensor3d(
+        [
+          [[-1.1355163, -1.3552775], [-0.6488664, -0.7297648]],
+          [[-0.8921913, -0.7297648], [0.08110833, 0.5212605]],
+          [[1.5410578, 1.4595294], [1.0544081, 0.8340168]]
+        ],
+        [3, 2, 2]));
     expectTensorsClose(mean, tensor1d([5.6666665, 6.3333335]));
     expectTensorsClose(variance, tensor1d([16.88889, 10.222222]));
   });
 
   it('3D, broadcasting', () => {
     const x = tensor3d(
-        [[[1, 2], [3, 4]], [[2, 4], [6, 8]], [[12, 11], [10, 9]]], [3, 2, 2]);
+      [[[1, 2], [3, 4]], [[2, 4], [6, 8]], [[12, 11], [10, 9]]], [3, 2, 2]);
     const gamma = tensor2d([[1, 1], [1, 1]], [2, 2]);
     const beta = tensor2d([[0, 0], [0, 0]], [2, 2]);
     const reductionAxes = [0];
     const [normed, mean, variance] =
-        K.normalizeBatchInTraining(x, gamma, beta, reductionAxes);
+      K.normalizeBatchInTraining(x, gamma, beta, reductionAxes);
     expectTensorsClose(
-        normed,
-        tensor3d(
-            [
-              [[-0.805371, -0.9502233], [-1.1624058, -1.3885813]],
-              [[-0.6040282, -0.4319197], [-0.11624074, 0.46286058]],
-              [[1.4093992, 1.3821429], [1.2786462, 0.92572117]]
-            ],
-            [3, 2, 2]));
+      normed,
+      tensor3d(
+        [
+          [[-0.805371, -0.9502233], [-1.1624058, -1.3885813]],
+          [[-0.6040282, -0.4319197], [-0.11624074, 0.46286058]],
+          [[1.4093992, 1.3821429], [1.2786462, 0.92572117]]
+        ],
+        [3, 2, 2]));
     expectTensorsClose(
-        mean, tensor2d([[5, 5.6666665], [6.3333335, 7]], [2, 2]));
+      mean, tensor2d([[5, 5.6666665], [6.3333335, 7]], [2, 2]));
     expectTensorsClose(
-        variance,
-        tensor2d([[24.666666, 14.888889], [8.222222, 4.6666665]], [2, 2]));
+      variance,
+      tensor2d([[24.666666, 14.888889], [8.222222, 4.6666665]], [2, 2]));
   });
 
   it('4D, broadcasting', () => {
     const x = tensor4d(
-        [[[[1, 2], [3, 4]], [[2, 4], [6, 8]], [[12, 11], [10, 9]]]],
-        [1, 3, 2, 2]);
+      [[[[1, 2], [3, 4]], [[2, 4], [6, 8]], [[12, 11], [10, 9]]]],
+      [1, 3, 2, 2]);
     const gamma = tensor2d([[1, 1], [1, 1]], [2, 2]);
     const beta = tensor2d([[0, 0], [0, 0]], [2, 2]);
     const reductionAxes = [0, 1];
     const [normed, mean, variance] =
-        K.normalizeBatchInTraining(x, gamma, beta, reductionAxes);
+      K.normalizeBatchInTraining(x, gamma, beta, reductionAxes);
     expectTensorsClose(
-        normed,
-        tensor4d(
-            [[
-              [[-0.805371, -0.9502233], [-1.1624058, -1.3885813]],
-              [[-0.6040282, -0.4319197], [-0.11624074, 0.46286058]],
-              [[1.4093992, 1.3821429], [1.2786462, 0.92572117]]
-            ]],
-            [1, 3, 2, 2]));
+      normed,
+      tensor4d(
+        [[
+          [[-0.805371, -0.9502233], [-1.1624058, -1.3885813]],
+          [[-0.6040282, -0.4319197], [-0.11624074, 0.46286058]],
+          [[1.4093992, 1.3821429], [1.2786462, 0.92572117]]
+        ]],
+        [1, 3, 2, 2]));
     expectTensorsClose(
-        mean, tensor2d([[5, 5.6666665], [6.3333335, 7]], [2, 2]));
+      mean, tensor2d([[5, 5.6666665], [6.3333335, 7]], [2, 2]));
     expectTensorsClose(
-        variance,
-        tensor2d([[24.666666, 14.888889], [8.222222, 4.6666665]], [2, 2]));
+      variance,
+      tensor2d([[24.666666, 14.888889], [8.222222, 4.6666665]], [2, 2]));
   });
 });
 
@@ -743,18 +725,18 @@ describeMathCPUAndGPU('concatenate', () => {
     const x = tensor4d([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 2, 1]);
     const y = tensor4d([-1, -2, -3, -4, -5, -6, -7, -8], [2, 2, 2, 1]);
     let expected = tensor4d(
-        [1, -1, 2, -2, 3, -3, 4, -4, 5, -5, 6, -6, 7, -7, 8, -8], [2, 2, 2, 2]);
+      [1, -1, 2, -2, 3, -3, 4, -4, 5, -5, 6, -6, 7, -7, 8, -8], [2, 2, 2, 2]);
     expectTensorsClose(K.concatenate([x, y]), expected);
     expectTensorsClose(K.concatenate([x, y], -1), expected);
     expectTensorsClose(K.concatenate([x, y], 3), expected);
     expected = tensor4d(
-        [1, 2, -1, -2, 3, 4, -3, -4, 5, 6, -5, -6, 7, 8, -7, -8], [2, 2, 4, 1]);
+      [1, 2, -1, -2, 3, 4, -3, -4, 5, 6, -5, -6, 7, 8, -7, -8], [2, 2, 4, 1]);
     expectTensorsClose(K.concatenate([x, y], 2), expected);
     expected = tensor4d(
-        [1, 2, 3, 4, -1, -2, -3, -4, 5, 6, 7, 8, -5, -6, -7, -8], [2, 4, 2, 1]);
+      [1, 2, 3, 4, -1, -2, -3, -4, 5, 6, 7, 8, -5, -6, -7, -8], [2, 4, 2, 1]);
     expectTensorsClose(K.concatenate([x, y], 1), expected);
     expected = tensor4d(
-        [1, 2, 3, 4, 5, 6, 7, 8, -1, -2, -3, -4, -5, -6, -7, -8], [4, 2, 2, 1]);
+      [1, 2, 3, 4, 5, 6, 7, 8, -1, -2, -3, -4, -5, -6, -7, -8], [4, 2, 2, 1]);
     expectTensorsClose(K.concatenate([x, y], 0), expected);
   });
 });
@@ -766,8 +748,8 @@ describeMathCPUAndGPU('concatAlongFirstAxis', () => {
     const a = tensor1d(array1DData1);
     const b = tensor1d(array1DData2);
     expectTensorsClose(
-        K.concatAlongFirstAxis(a, b),
-        tensor1d([10, 20, 30, 40, -10, -20, -30, -40]));
+      K.concatAlongFirstAxis(a, b),
+      tensor1d([10, 20, 30, 40, -10, -20, -30, -40]));
   });
 
   const array2DData1 = [[10, 11], [20, 21]];
@@ -776,8 +758,8 @@ describeMathCPUAndGPU('concatAlongFirstAxis', () => {
     const a = tensor2d(array2DData1, [2, 2]);
     const b = tensor2d(array2DData2, [2, 2]);
     expectTensorsClose(
-        K.concatAlongFirstAxis(a, b),
-        tensor2d([[10, 11], [20, 21], [30, 31], [40, 41]], [4, 2]));
+      K.concatAlongFirstAxis(a, b),
+      tensor2d([[10, 11], [20, 21], [30, 31], [40, 41]], [4, 2]));
   });
 
   const array3DData1 = [[[10]], [[20]]];
@@ -786,8 +768,8 @@ describeMathCPUAndGPU('concatAlongFirstAxis', () => {
     const a = tensor3d(array3DData1, [2, 1, 1]);
     const b = tensor3d(array3DData2, [2, 1, 1]);
     expectTensorsClose(
-        K.concatAlongFirstAxis(a, b),
-        tensor3d([[[10]], [[20]], [[30]], [[40]]], [4, 1, 1]));
+      K.concatAlongFirstAxis(a, b),
+      tensor3d([[[10]], [[20]], [[30]], [[40]]], [4, 1, 1]));
   });
 
   const array4DData1 = [[[[10]]], [[[20]]]];
@@ -796,8 +778,8 @@ describeMathCPUAndGPU('concatAlongFirstAxis', () => {
     const a = tensor4d(array4DData1, [2, 1, 1, 1]);
     const b = tensor4d(array4DData2, [2, 1, 1, 1]);
     expectTensorsClose(
-        K.concatAlongFirstAxis(a, b),
-        tensor4d([[[[10]]], [[[20]]], [[[30]]], [[[40]]]], [4, 1, 1, 1]));
+      K.concatAlongFirstAxis(a, b),
+      tensor4d([[[[10]]], [[[20]]], [[[30]]], [[[40]]]], [4, 1, 1, 1]));
   });
 
   it('Scalar leads to error', () => {
@@ -825,23 +807,23 @@ describeMathCPUAndGPU('tile', () => {
     const n = [2, 3];
     const y = K.tile(x, n);
     expectTensorsClose(
-        y,
-        tensor2d(
-            [
-              [1, 3, 1, 3, 1, 3], [3, 7, 3, 7, 3, 7], [1, 3, 1, 3, 1, 3],
-              [3, 7, 3, 7, 3, 7]
-            ],
-            [4, 6]));
+      y,
+      tensor2d(
+        [
+          [1, 3, 1, 3, 1, 3], [3, 7, 3, 7, 3, 7], [1, 3, 1, 3, 1, 3],
+          [3, 7, 3, 7, 3, 7]
+        ],
+        [4, 6]));
   });
   it('3D', () => {
     const x = tensor3d([[[1]]], [1, 1, 1]);
     const n = [2, 3, 4];
     const y = K.tile(x, n);
-    expectTensorsClose(y, K.ones([2, 3, 4]));
+    expectTensorsClose(y, tfc.ones([2, 3, 4]));
   });
   it('Mismatch in x dimensions and n length leads to exception', () => {
-    expect(() => K.tile(K.zeros([2, 2]), 1))
-        .toThrowError(/The length of input n \(1\) does not match .*2/);
+    expect(() => K.tile(tfc.zeros([2, 2]), 1))
+      .toThrowError(/The length of input n \(1\) does not match .*2/);
   });
 });
 
@@ -986,25 +968,25 @@ describeMathCPUAndGPU('OnesVariable', () => {
 
 describeMathCPUAndGPU('ZerosLike', () => {
   it('Scalar', () => {
-    const s = K.zerosLike(K.randomUniform([], -10, 10));
+    const s = K.zerosLike(tfc.randomUniform([], -10, 10));
     expect(K.shape(s.read())).toEqual([]);
     expect(s.read().dataSync()).toEqual(new Float32Array([0]));
   });
 
   it('Vector', () => {
-    const v = K.zerosLike(K.randomUniform([3], -10, 10));
+    const v = K.zerosLike(tfc.randomUniform([3], -10, 10));
     expect(K.shape(v.read())).toEqual([3]);
     expect(v.read().dataSync()).toEqual(new Float32Array([0, 0, 0]));
   });
 
   it('Matrix', () => {
-    const m = K.zerosLike(K.randomUniform([2, 2], -10, 10));
+    const m = K.zerosLike(tfc.randomUniform([2, 2], -10, 10));
     expect(K.shape(m.read())).toEqual([2, 2]);
     expect(m.read().dataSync()).toEqual(new Float32Array([0, 0, 0, 0]));
   });
 
   it('3D', () => {
-    const t = K.zerosLike(K.randomUniform([2, 2, 2], -10, 10));
+    const t = K.zerosLike(tfc.randomUniform([2, 2, 2], -10, 10));
     expect(K.shape(t.read())).toEqual([2, 2, 2]);
     expect(t.read().dataSync()).toEqual(new Float32Array([
       0, 0, 0, 0, 0, 0, 0, 0
@@ -1012,7 +994,7 @@ describeMathCPUAndGPU('ZerosLike', () => {
   });
 
   it('4D', () => {
-    const q = K.zerosLike(K.randomUniform([1, 2, 1, 3], -10, 10));
+    const q = K.zerosLike(tfc.randomUniform([1, 2, 1, 3], -10, 10));
     expect(K.shape(q.read())).toEqual([1, 2, 1, 3]);
     expect(q.read().dataSync()).toEqual(new Float32Array([0, 0, 0, 0, 0, 0]));
   });
@@ -1020,25 +1002,25 @@ describeMathCPUAndGPU('ZerosLike', () => {
 
 describeMathCPUAndGPU('OnesLike', () => {
   it('Scalar', () => {
-    const s = K.onesLike(K.randomUniform([], -10, 10));
+    const s = K.onesLike(tfc.randomUniform([], -10, 10));
     expect(K.shape(s.read())).toEqual([]);
     expect(s.read().dataSync()).toEqual(new Float32Array([1]));
   });
 
   it('Vector', () => {
-    const v = K.onesLike(K.randomUniform([3], -10, 10));
+    const v = K.onesLike(tfc.randomUniform([3], -10, 10));
     expect(K.shape(v.read())).toEqual([3]);
     expect(v.read().dataSync()).toEqual(new Float32Array([1, 1, 1]));
   });
 
   it('Matrix', () => {
-    const m = K.onesLike(K.randomUniform([2, 2], -10, 10));
+    const m = K.onesLike(tfc.randomUniform([2, 2], -10, 10));
     expect(K.shape(m.read())).toEqual([2, 2]);
     expect(m.read().dataSync()).toEqual(new Float32Array([1, 1, 1, 1]));
   });
 
   it('3D', () => {
-    const t = K.onesLike(K.randomUniform([2, 2, 2], -10, 10));
+    const t = K.onesLike(tfc.randomUniform([2, 2, 2], -10, 10));
     expect(K.shape(t.read())).toEqual([2, 2, 2]);
     expect(t.read().dataSync()).toEqual(new Float32Array([
       1, 1, 1, 1, 1, 1, 1, 1
@@ -1046,7 +1028,7 @@ describeMathCPUAndGPU('OnesLike', () => {
   });
 
   it('4D', () => {
-    const q = K.onesLike(K.randomUniform([1, 2, 1, 3], -10, 10));
+    const q = K.onesLike(tfc.randomUniform([1, 2, 1, 3], -10, 10));
     expect(K.shape(q.read())).toEqual([1, 2, 1, 3]);
     expect(q.read().dataSync()).toEqual(new Float32Array([1, 1, 1, 1, 1, 1]));
   });
@@ -1106,41 +1088,12 @@ describeMathCPUAndGPU('eye (I-matrix builder)', () => {
   });
 });
 
-
-describeMathCPUAndGPU('subtract', () => {
-  it('3D', () => {
-    const shape = [2, 3, 4];
-    const x = K.ones(shape);
-    const y = K.ones(shape);
-    expectTensorsClose(K.subtract(x, y), K.zeros(shape));
-  });
-});
-
-describeMathCPUAndGPU('Multiply', () => {
-  it('3D', () => {
-    const shape = [2, 3, 4];
-    const x = K.scalarTimesArray(scalar(4), K.ones(shape));
-    const y = K.scalarTimesArray(scalar(5), K.ones(shape));
-    expectTensorsClose(
-        K.multiply(x, y), K.scalarTimesArray(scalar(20), K.ones(shape)));
-  });
-});
-
-describeMathCPUAndGPU('divide', () => {
-  it('3D', () => {
-    const shape = [2, 3, 4];
-    const x = K.scalarTimesArray(scalar(4), K.ones(shape));
-    const y = K.scalarTimesArray(scalar(4), K.ones(shape));
-    expectTensorsClose(K.divide(x, y), K.ones(shape));
-  });
-});
-
 describeMathCPUAndGPU('scalarTimesArray', () => {
   it('Scalar x Scalar', () => {
     expectTensorsClose(K.scalarTimesArray(scalar(-2), scalar(-3)), scalar(6));
   });
   it('Scalar x 4D', () => {
-    const y = K.scalarTimesArray(scalar(-2), K.ones([2, 2, 2, 2]));
+    const y = K.scalarTimesArray(scalar(-2), tfc.ones([2, 2, 2, 2]));
     expect(y.shape).toEqual([2, 2, 2, 2]);
     const yValues = Array.from(y.dataSync());
     expect(unique(yValues)).toEqual([-2]);
@@ -1153,76 +1106,11 @@ describeMathCPUAndGPU('scalarPlusArray', () => {
   });
   it('Scalar + 4D', () => {
     const shape = [2, 2, 2, 2];
-    const y = K.scalarPlusArray(scalar(-1), K.ones(shape));
-    expectTensorsClose(y, K.zeros(shape));
+    const y = K.scalarPlusArray(scalar(-1), tfc.ones(shape));
+    expectTensorsClose(y, tfc.zeros(shape));
   });
 });
 
-describeMathCPUAndGPU('randomUniform', () => {
-  it('Scalar', () => {
-    const s = K.randomUniform([], -10, 10);
-    expect(K.shape(s)).toEqual([]);
-    expect(s.dataSync()[0]).toBeGreaterThanOrEqual(-10);
-    expect(s.dataSync()[0]).toBeLessThanOrEqual(10);
-  });
-
-  it('1D', () => {
-    const v = K.randomUniform([20], -10, 10);
-    expect(K.shape(v)).toEqual([20]);
-    const vValuesSorted = v.dataSync().sort();
-    expect(vValuesSorted[0]).toBeGreaterThanOrEqual(-10);
-    expect(vValuesSorted[vValuesSorted.length - 1]).toBeLessThanOrEqual(10);
-  });
-
-  it('2D', () => {
-    const x = K.randomUniform([3, 20], 100, 200);
-    expect(K.shape(x)).toEqual([3, 20]);
-    const xValuesSorted = x.dataSync().sort();
-    expect(xValuesSorted[0]).toBeGreaterThanOrEqual(100);
-    expect(xValuesSorted[xValuesSorted.length - 1]).toBeLessThanOrEqual(200);
-  });
-
-  it('3D', () => {
-    const y = K.randomUniform([2, 3, 4], -100, -50);
-    expect(K.shape(y)).toEqual([2, 3, 4]);
-    const yValuesSorted = y.dataSync().sort();
-    expect(yValuesSorted[0]).toBeGreaterThanOrEqual(-100);
-    expect(yValuesSorted[yValuesSorted.length - 1]).toBeLessThanOrEqual(-50);
-  });
-});
-
-describeMathCPUAndGPU('truncatedNormal', () => {
-  it('Scalar', () => {
-    const s = K.truncatedNormal([], 0, 10);
-    expect(K.shape(s)).toEqual([]);
-    expect(s.dataSync()[0]).toBeGreaterThan(-20);
-    expect(s.dataSync()[0]).toBeLessThan(20);
-  });
-
-  it('1D', () => {
-    const v = K.truncatedNormal([20], 0, 2);
-    expect(K.shape(v)).toEqual([20]);
-    const vValuesSorted = v.dataSync().sort();
-    expect(vValuesSorted[0]).toBeGreaterThan(-4);
-    expect(vValuesSorted[vValuesSorted.length - 1]).toBeLessThan(4);
-  });
-
-  it('2D', () => {
-    const x = K.truncatedNormal([3, 20], -10, 20);
-    expect(K.shape(x)).toEqual([3, 20]);
-    const xValuesSorted = x.dataSync().sort();
-    expect(xValuesSorted[0]).toBeGreaterThan(-50);
-    expect(xValuesSorted[xValuesSorted.length - 1]).toBeLessThan(30);
-  });
-
-  it('3D', () => {
-    const y = K.truncatedNormal([2, 3, 4], 100, 10);
-    expect(K.shape(y)).toEqual([2, 3, 4]);
-    const yValuesSorted = y.dataSync().sort();
-    expect(yValuesSorted[0]).toBeGreaterThan(80);
-    expect(yValuesSorted[yValuesSorted.length - 1]).toBeLessThan(120);
-  });
-});
 
 describeMathCPUAndGPU('randomNormal', () => {
   const dtypes = [DType.float32, DType.int32];
@@ -1300,7 +1188,7 @@ describeMathCPUAndGPU('dot', () => {
     const x = tensor3d([[[1, 0], [0, -1]], [[-2, 0], [0, -2]]], [2, 2, 2]);
     const y = tensor2d([[-1], [1]], [2, 1]);
     expectTensorsClose(
-        K.dot(x, y), tensor3d([[[-1], [-1]], [[2], [-2]]], [2, 2, 1]));
+      K.dot(x, y), tensor3d([[[-1], [-1]], [[2], [-2]]], [2, 2, 1]));
   });
   it('2D x 1D leads to error', () => {
     const x = tensor2d([[1, 0], [0, -1]], [2, 2]);
@@ -1348,7 +1236,7 @@ describeMathCPUAndGPU('qr', () => {
     const x = tensor2d([[1, 3], [-2, -4]], [2, 2]);
     const [q, r] = K.qr(x);
     expectTensorsClose(
-        q, tensor2d([[-0.4472, -0.8944], [0.8944, -0.4472]], [2, 2]));
+      q, tensor2d([[-0.4472, -0.8944], [0.8944, -0.4472]], [2, 2]));
     expectTensorsClose(r, tensor2d([[-2.2361, -4.9193], [0, -0.8944]], [2, 2]));
   });
 
@@ -1356,33 +1244,33 @@ describeMathCPUAndGPU('qr', () => {
     const x = tensor2d([[1, 3, 2], [-2, 0, 7], [8, -9, 4]], [3, 3]);
     const [q, r] = K.qr(x);
     expectTensorsClose(
-        q,
-        tensor2d(
-            [
-              [-0.1204, 0.8729, 0.4729], [0.2408, -0.4364, 0.8669],
-              [-0.9631, -0.2182, 0.1576]
-            ],
-            [3, 3]));
+      q,
+      tensor2d(
+        [
+          [-0.1204, 0.8729, 0.4729], [0.2408, -0.4364, 0.8669],
+          [-0.9631, -0.2182, 0.1576]
+        ],
+        [3, 3]));
     expectTensorsClose(
-        r,
-        tensor2d(
-            [[-8.3066, 8.3066, -2.4077], [0, 4.5826, -2.1822], [0, 0, 7.6447]],
-            [3, 3]));
+      r,
+      tensor2d(
+        [[-8.3066, 8.3066, -2.4077], [0, 4.5826, -2.1822], [0, 0, 7.6447]],
+        [3, 3]));
   });
 
   it('3x2', () => {
     const x = tensor2d([[1, 2], [3, -3], [-2, 1]], [3, 2]);
     const [q, r] = K.qr(x);
     expectTensorsClose(
-        q,
-        tensor2d(
-            [
-              [-0.2673, 0.9221, 0.2798], [-0.8018, -0.3738, 0.4663],
-              [0.5345, -0.0997, 0.8393]
-            ],
-            [3, 3]));
+      q,
+      tensor2d(
+        [
+          [-0.2673, 0.9221, 0.2798], [-0.8018, -0.3738, 0.4663],
+          [0.5345, -0.0997, 0.8393]
+        ],
+        [3, 3]));
     expectTensorsClose(
-        r, tensor2d([[-3.7417, 2.4054], [0, 2.8661], [0, 0]], [3, 2]));
+      r, tensor2d([[-3.7417, 2.4054], [0, 2.8661], [0, 0]], [3, 2]));
   });
 
   it('does not leak memory', () => {
@@ -1421,92 +1309,92 @@ describeMathCPUAndGPU('OneHot', () => {
     const numClasses = 5;
     const indices = tensor1d([1, 3]);
     expectTensorsClose(
-        K.oneHot(indices, numClasses),
-        tensor2d([[0, 1, 0, 0, 0], [0, 0, 0, 1, 0]], [2, 5]));
+      K.oneHot(indices, numClasses),
+      tensor2d([[0, 1, 0, 0, 0], [0, 0, 0, 1, 0]], [2, 5]));
   });
 });
 
 describeMathCPUAndGPU('Mean', () => {
   it('reduce_mean', () => {
     expectTensorsClose(
-        K.mean(tensor2d([[4, -1], [0, -2]], [2, 2])), scalar(0.25));
+      K.mean(tensor2d([[4, -1], [0, -2]], [2, 2])), scalar(0.25));
   });
   it('mean 2D, axis=1, keepdims=false', () => {
     expectTensorsClose(
-        K.mean(tensor2d([[4, -1], [0, -2]], [2, 2]), 1), tensor1d([1.5, -1]));
+      K.mean(tensor2d([[4, -1], [0, -2]], [2, 2]), 1), tensor1d([1.5, -1]));
   });
   it('mean 2D, axis=1, keepdims=true', () => {
     expectTensorsClose(
-        K.mean(tensor2d([[4, -1], [0, -2]], [2, 2]), 1, true),
-        tensor2d([[1.5], [-1]], [2, 1]));
+      K.mean(tensor2d([[4, -1], [0, -2]], [2, 2]), 1, true),
+      tensor2d([[1.5], [-1]], [2, 1]));
   });
   it('mean 3D, axis=[1,2], keepdims=false', () => {
     expectTensorsClose(
-        K.mean(
-            tensor3d([[[4, -1], [0, -2]], [[40, -10], [0, -20]]], [2, 2, 2]),
-            [1, 2]),
-        tensor1d([0.25, 2.5]));
+      K.mean(
+        tensor3d([[[4, -1], [0, -2]], [[40, -10], [0, -20]]], [2, 2, 2]),
+        [1, 2]),
+      tensor1d([0.25, 2.5]));
   });
   it('mean 3D, axis=[1,2], keepdims=true', () => {
     expectTensorsClose(
-        K.mean(
-            tensor3d([[[4, -1], [0, -2]], [[40, -10], [0, -20]]], [2, 2, 2]),
-            [1, 2], true),
-        tensor3d([[[0.25]], [[2.5]]], [2, 1, 1]));
+      K.mean(
+        tensor3d([[[4, -1], [0, -2]], [[40, -10], [0, -20]]], [2, 2, 2]),
+        [1, 2], true),
+      tensor3d([[[0.25]], [[2.5]]], [2, 1, 1]));
   });
   it('reduce_mean keepdims=true', () => {
     expectTensorsClose(
-        K.mean(tensor2d([[4, -1], [0, -2]], [2, 2]), undefined, true),
-        tensor2d([[0.25]], [1, 1]));
+      K.mean(tensor2d([[4, -1], [0, -2]], [2, 2]), undefined, true),
+      tensor2d([[0.25]], [1, 1]));
   });
 });
 
 describeMathCPUAndGPU('Argmax', () => {
   it('2D, default axis', () => {
     expectTensorsClose(
-        K.argmax(tensor2d([[4, -1], [-2, 0]], [2, 2])),
-        tensor1d([0, 1], 'int32'));
+      K.argmax(tensor2d([[4, -1], [-2, 0]], [2, 2])),
+      tensor1d([0, 1], 'int32'));
   });
   it('2D, axis=-1', () => {
     expectTensorsClose(
-        K.argmax(tensor2d([[4, -1], [-2, 0]], [2, 2]), -1),
-        tensor1d([0, 1], 'int32'));
+      K.argmax(tensor2d([[4, -1], [-2, 0]], [2, 2]), -1),
+      tensor1d([0, 1], 'int32'));
   });
   it('2D, axis=0', () => {
     expectTensorsClose(
-        K.argmax(tensor2d([[4, -1], [3, 2]], [2, 2]), 0),
-        tensor1d([0, 1], 'int32'));
+      K.argmax(tensor2d([[4, -1], [3, 2]], [2, 2]), 0),
+      tensor1d([0, 1], 'int32'));
   });
 });
 
 describeMathCPUAndGPU('Gather', () => {
   it('1D, Array of numbers with repeats', () => {
     expectTensorsClose(
-        K.gather(tensor1d([0, 10, 20, 30]), [2, 2, 3, 1]),
-        tensor1d([20, 20, 30, 10]));
+      K.gather(tensor1d([0, 10, 20, 30]), [2, 2, 3, 1]),
+      tensor1d([20, 20, 30, 10]));
   });
   it('2D, Array of numbers', () => {
     expectTensorsClose(
-        K.gather(tensor2d([[10, 20], [30, 40], [50, 60]], [3, 2]), [2, 0]),
-        tensor2d([[50, 60], [10, 20]], [2, 2]));
+      K.gather(tensor2d([[10, 20], [30, 40], [50, 60]], [3, 2]), [2, 0]),
+      tensor2d([[50, 60], [10, 20]], [2, 2]));
   });
   it('2D, Tensor1D', () => {
     expectTensorsClose(
-        K.gather(
-            tensor2d([[10, 20], [30, 40], [50, 60]], [3, 2]), tensor1d([2, 1])),
-        tensor2d([[50, 60], [30, 40]], [2, 2]));
+      K.gather(
+        tensor2d([[10, 20], [30, 40], [50, 60]], [3, 2]), tensor1d([2, 1])),
+      tensor2d([[50, 60], [30, 40]], [2, 2]));
   });
   it('3D, Tensor1D', () => {
     expectTensorsClose(
-        K.gather(
-            tensor3d([[[10, 20], [30, 40]], [[50, 60], [70, 80]]], [2, 2, 2]),
-            tensor1d([1, 0])),
-        tensor3d([[[50, 60], [70, 80]], [[10, 20], [30, 40]]], [2, 2, 2]));
+      K.gather(
+        tensor3d([[[10, 20], [30, 40]], [[50, 60], [70, 80]]], [2, 2, 2]),
+        tensor1d([1, 0])),
+      tensor3d([[[50, 60], [70, 80]], [[10, 20], [30, 40]]], [2, 2, 2]));
   });
   it('2D, Non-default axis', () => {
     expectTensorsClose(
-        K.gather(tensor2d([[10, 20], [30, 40], [50, 60]], [3, 2]), [1], 1),
-        tensor2d([[20], [40], [60]], [3, 1]));
+      K.gather(tensor2d([[10, 20], [30, 40], [50, 60]], [3, 2]), [1], 1),
+      tensor2d([[20], [40], [60]], [3, 1]));
   });
 });
 
@@ -1514,51 +1402,42 @@ describeMathCPUAndGPU('Gather', () => {
 describeMathCPUAndGPU('Square', () => {
   it('Element-wise square', () => {
     expectTensorsClose(
-        K.square(tensor2d([[1, -2], [-3, 4]], [2, 2])),
-        tensor2d([1, 4, 9, 16], [2, 2]));
+      K.square(tensor2d([[1, -2], [-3, 4]], [2, 2])),
+      tensor2d([1, 4, 9, 16], [2, 2]));
   });
 });
 
 describeMathCPUAndGPU('Pow', () => {
   it('Element-wise Pow: Positive Scalar', () => {
     expectTensorsClose(
-        K.pow(tensor2d([[1, 1.5], [2, 2.5]], [2, 2]), scalar(2, 'int32')),
-        tensor2d([[1, 2.25], [4, 6.25]], [2, 2]));
+      K.pow(tensor2d([[1, 1.5], [2, 2.5]], [2, 2]), scalar(2, 'int32')),
+      tensor2d([[1, 2.25], [4, 6.25]], [2, 2]));
   });
   it('Element-wise Pow: Negative Scalar', () => {
     expectTensorsClose(
-        K.pow(tensor2d([[1, 1.5], [2, 2.5]], [2, 2]), scalar(-2, 'int32')),
-        tensor2d(
-            [[1, 1 / (1.5 * 1.5)], [1 / (2 * 2), 1 / (2.5 * 2.5)]], [2, 2]));
+      K.pow(tensor2d([[1, 1.5], [2, 2.5]], [2, 2]), scalar(-2, 'int32')),
+      tensor2d(
+        [[1, 1 / (1.5 * 1.5)], [1 / (2 * 2), 1 / (2.5 * 2.5)]], [2, 2]));
   });
   it('Element-wise Pow: Zero Scalar', () => {
     expectTensorsClose(
-        K.pow(tensor2d([[1, 1.5], [2, 2.5]], [2, 2]), scalar(0, 'int32')),
-        tensor2d([[1, 1], [1, 1]], [2, 2]));
+      K.pow(tensor2d([[1, 1.5], [2, 2.5]], [2, 2]), scalar(0, 'int32')),
+      tensor2d([[1, 1], [1, 1]], [2, 2]));
   });
   it('Element-wise Pow: number', () => {
     expectTensorsClose(
-        K.pow(tensor2d([[1, 1.5], [2, 2.5]], [2, 2]), 2),
-        tensor2d([[1, 2.25], [4, 6.25]], [2, 2]));
+      K.pow(tensor2d([[1, 1.5], [2, 2.5]], [2, 2]), 2),
+      tensor2d([[1, 2.25], [4, 6.25]], [2, 2]));
   });
 });
-
-describeMathCPUAndGPU('Clip', () => {
-  it('Element-wise Clip', () => {
-    expectTensorsClose(
-        K.clip(tensor2d([[-5, -2], [2, 5]], [2, 2]), -3, 3),
-        tensor2d([-3, -2, 2, 3], [2, 2]));
-  });
-});
-
 
 describeMathCPUAndGPU('softsign', () => {
   it('Element-wise softsign', () => {
     expectTensorsClose(
-        tfc.tanh(tensor2d([[-2, -1], [1, 2]], [2, 2])),
-        tensor2d(
-            [Math.tanh(-2), Math.tanh(-1), Math.tanh(1), Math.tanh(2)],
-            [2, 2]));
+      tfc.tanh(tensor2d([[-2, -1], [1, 2]], [2, 2])),
+      tensor2d(
+        [Math.tanh(-2), Math.tanh(-1), Math.tanh(1), Math.tanh(2)],
+        [2, 2]));
   });
 });
 
@@ -1569,16 +1448,16 @@ describeMathCPUAndGPU('batchNormalization', () => {
     const mean = tensor2d([[5, 5], [5, 5]], [2, 2]);
     const variance = tensor2d([[4, 16], [4, 16]], [2, 2]);
     expectTensorsClose(
-        K.batchNormalization(x, mean, variance, null, null, 0),
-        tensor2d([[2.5, 3.75], [12.5, 8.75]], [2, 2]));
+      K.batchNormalization(x, mean, variance, null, null, 0),
+      tensor2d([[2.5, 3.75], [12.5, 8.75]], [2, 2]));
   });
   it('2D, no broadcast, no gamma, no beta, custom epsilon', () => {
     const x = tensor2d([[30, 30], [60, 60]], [2, 2]);
     const mean = tensor2d([[0, 0], [0, 0]], [2, 2]);
     const variance = tensor2d([[7, 7], [7, 7]], [2, 2]);
     expectTensorsClose(
-        K.batchNormalization(x, mean, variance, null, null, 2),
-        tensor2d([[10, 10], [20, 20]], [2, 2]));
+      K.batchNormalization(x, mean, variance, null, null, 2),
+      tensor2d([[10, 10], [20, 20]], [2, 2]));
   });
   it('2D, no broadcast, gamma, no beta', () => {
     const x = tensor2d([[10, 20], [30, 40]], [2, 2]);
@@ -1586,8 +1465,8 @@ describeMathCPUAndGPU('batchNormalization', () => {
     const variance = tensor2d([[4, 16], [4, 16]], [2, 2]);
     const gamma = tensor2d([[1, 2], [3, 4]], [2, 2]);
     expectTensorsClose(
-        K.batchNormalization(x, mean, variance, null, gamma, 0),
-        tensor2d([[2.5, 7.5], [37.5, 35]], [2, 2]));
+      K.batchNormalization(x, mean, variance, null, gamma, 0),
+      tensor2d([[2.5, 7.5], [37.5, 35]], [2, 2]));
   });
   it('2D, no broadcast, gamma, beta', () => {
     const x = tensor2d([[10, 20], [30, 40]], [2, 2]);
@@ -1596,8 +1475,8 @@ describeMathCPUAndGPU('batchNormalization', () => {
     const gamma = tensor2d([[1, 2], [3, 4]], [2, 2]);
     const beta = tensor2d([[-1, -1], [-2, -2]], [2, 2]);
     expectTensorsClose(
-        K.batchNormalization(x, mean, variance, beta, gamma, 0),
-        tensor2d([[1.5, 6.5], [35.5, 33]], [2, 2]));
+      K.batchNormalization(x, mean, variance, beta, gamma, 0),
+      tensor2d([[1.5, 6.5], [35.5, 33]], [2, 2]));
   });
   it('2D, broadcast, gamma, beta', () => {
     const x = tensor2d([[10, 20], [30, 40]], [2, 2]);
@@ -1606,30 +1485,30 @@ describeMathCPUAndGPU('batchNormalization', () => {
     const gamma = tensor1d([3, 4]);
     const beta = tensor1d([-1, -2]);
     expectTensorsClose(
-        K.batchNormalization(x, mean, variance, beta, gamma, 0),
-        tensor2d([[23, 28], [83, 68]], [2, 2]));
+      K.batchNormalization(x, mean, variance, beta, gamma, 0),
+      tensor2d([[23, 28], [83, 68]], [2, 2]));
   });
   it('3D, no broadcast, no gamma, no beta', () => {
     const x = tensor3d([[[10, 20], [30, 40]], [[10, 20], [30, 40]]], [2, 2, 2]);
     const mean = tensor3d([[[5, 5], [5, 5]], [[5, 5], [5, 5]]], [2, 2, 2]);
     const variance =
-        tensor3d([[[4, 16], [4, 16]], [[16, 25], [16, 25]]], [2, 2, 2]);
+      tensor3d([[[4, 16], [4, 16]], [[16, 25], [16, 25]]], [2, 2, 2]);
     expectTensorsClose(
-        K.batchNormalization(x, mean, variance, null, null, 0),
-        tensor3d(
-            [[[2.5, 3.75], [12.5, 8.75]], [[1.25, 3], [6.25, 7]]], [2, 2, 2]));
+      K.batchNormalization(x, mean, variance, null, null, 0),
+      tensor3d(
+        [[[2.5, 3.75], [12.5, 8.75]], [[1.25, 3], [6.25, 7]]], [2, 2, 2]));
   });
   it('3D, no broadcast, gamma, beta', () => {
     const x = tensor3d([[[10, 20], [30, 40]], [[10, 20], [30, 40]]], [2, 2, 2]);
     const mean = tensor3d([[[5, 5], [5, 5]], [[5, 5], [5, 5]]], [2, 2, 2]);
     const variance =
-        tensor3d([[[4, 16], [4, 16]], [[16, 25], [16, 25]]], [2, 2, 2]);
+      tensor3d([[[4, 16], [4, 16]], [[16, 25], [16, 25]]], [2, 2, 2]);
     const gamma = tensor3d([[[2, 2], [2, 2]], [[4, 4], [4, 4]]], [2, 2, 2]);
     const beta =
-        tensor3d([[[-1, -1], [-2, -2]], [[-1, -1], [-2, -2]]], [2, 2, 2]);
+      tensor3d([[[-1, -1], [-2, -2]], [[-1, -1], [-2, -2]]], [2, 2, 2]);
     expectTensorsClose(
-        K.batchNormalization(x, mean, variance, beta, gamma, 0),
-        tensor3d([[[4, 6.5], [23, 15.5]], [[4, 11], [23, 26]]], [2, 2, 2]));
+      K.batchNormalization(x, mean, variance, beta, gamma, 0),
+      tensor3d([[[4, 6.5], [23, 15.5]], [[4, 11], [23, 26]]], [2, 2, 2]));
   });
   it('3D, broadcast, gamma, beta', () => {
     const x = tensor3d([[[10, 20], [30, 40]], [[10, 20], [30, 40]]], [2, 2, 2]);
@@ -1638,87 +1517,87 @@ describeMathCPUAndGPU('batchNormalization', () => {
     const gamma = tensor1d([2, 4]);
     const beta = tensor1d([-1, -2]);
     expectTensorsClose(
-        K.batchNormalization(x, mean, variance, beta, gamma, 0),
-        tensor3d([[[4, 13], [24, 33]], [[4, 13], [24, 33]]], [2, 2, 2]));
+      K.batchNormalization(x, mean, variance, beta, gamma, 0),
+      tensor3d([[[4, 13], [24, 33]], [[4, 13], [24, 33]]], [2, 2, 2]));
   });
   it('4D, no broadcast, no gamma, no beta', () => {
     const x = tensor4d(
-        [
-          [[[10, 20], [30, 40]], [[10, 20], [30, 40]]],
-          [[[-10, -20], [-30, -40]], [[-10, -20], [-30, -40]]]
-        ],
-        [2, 2, 2, 2]);
+      [
+        [[[10, 20], [30, 40]], [[10, 20], [30, 40]]],
+        [[[-10, -20], [-30, -40]], [[-10, -20], [-30, -40]]]
+      ],
+      [2, 2, 2, 2]);
     const mean = tensor4d(
-        [
-          [[[5, 5], [5, 5]], [[5, 5], [5, 5]]],
-          [[[-5, -5], [-5, -5]], [[-5, -5], [-5, -5]]]
-        ],
-        [2, 2, 2, 2]);
+      [
+        [[[5, 5], [5, 5]], [[5, 5], [5, 5]]],
+        [[[-5, -5], [-5, -5]], [[-5, -5], [-5, -5]]]
+      ],
+      [2, 2, 2, 2]);
     const variance = tensor4d(
-        [
-          [[[4, 16], [4, 16]], [[16, 25], [16, 25]]],
-          [[[4, 16], [4, 16]], [[16, 25], [16, 25]]]
-        ],
-        [2, 2, 2, 2]);
+      [
+        [[[4, 16], [4, 16]], [[16, 25], [16, 25]]],
+        [[[4, 16], [4, 16]], [[16, 25], [16, 25]]]
+      ],
+      [2, 2, 2, 2]);
     expectTensorsClose(
-        K.batchNormalization(x, mean, variance, null, null, 0),
-        tensor4d(
-            [
-              [[[2.5, 3.75], [12.5, 8.75]], [[1.25, 3], [6.25, 7]]],
-              [[[-2.5, -3.75], [-12.5, -8.75]], [[-1.25, -3], [-6.25, -7]]]
-            ],
-            [2, 2, 2, 2]));
+      K.batchNormalization(x, mean, variance, null, null, 0),
+      tensor4d(
+        [
+          [[[2.5, 3.75], [12.5, 8.75]], [[1.25, 3], [6.25, 7]]],
+          [[[-2.5, -3.75], [-12.5, -8.75]], [[-1.25, -3], [-6.25, -7]]]
+        ],
+        [2, 2, 2, 2]));
   });
   it('4D, no broadcast, gamma, beta', () => {
     const x = tensor4d(
-        [
-          [[[10, 20], [30, 40]], [[10, 20], [30, 40]]],
-          [[[-10, -20], [-30, -40]], [[-10, -20], [-30, -40]]]
-        ],
-        [2, 2, 2, 2]);
+      [
+        [[[10, 20], [30, 40]], [[10, 20], [30, 40]]],
+        [[[-10, -20], [-30, -40]], [[-10, -20], [-30, -40]]]
+      ],
+      [2, 2, 2, 2]);
     const mean = tensor4d(
-        [
-          [[[5, 5], [5, 5]], [[5, 5], [5, 5]]],
-          [[[-5, -5], [-5, -5]], [[-5, -5], [-5, -5]]]
-        ],
-        [2, 2, 2, 2]);
+      [
+        [[[5, 5], [5, 5]], [[5, 5], [5, 5]]],
+        [[[-5, -5], [-5, -5]], [[-5, -5], [-5, -5]]]
+      ],
+      [2, 2, 2, 2]);
     const variance = tensor4d(
-        [
-          [[[4, 16], [4, 16]], [[16, 25], [16, 25]]],
-          [[[4, 16], [4, 16]], [[16, 25], [16, 25]]]
-        ],
-        [2, 2, 2, 2]);
+      [
+        [[[4, 16], [4, 16]], [[16, 25], [16, 25]]],
+        [[[4, 16], [4, 16]], [[16, 25], [16, 25]]]
+      ],
+      [2, 2, 2, 2]);
     const gamma = tensor4d(
-        [
-          [[[2, 2], [2, 2]], [[4, 4], [4, 4]]],
-          [[[2, 2], [2, 2]], [[4, 4], [4, 4]]]
-        ],
-        [2, 2, 2, 2]);
+      [
+        [[[2, 2], [2, 2]], [[4, 4], [4, 4]]],
+        [[[2, 2], [2, 2]], [[4, 4], [4, 4]]]
+      ],
+      [2, 2, 2, 2]);
     const beta = tensor4d(
-        [
-          [[[-1, -1], [-2, -2]], [[-1, -1], [-2, -2]]],
-          [[[1, 1], [2, 2]], [[1, 1], [2, 2]]]
-        ],
-        [2, 2, 2, 2]);
+      [
+        [[[-1, -1], [-2, -2]], [[-1, -1], [-2, -2]]],
+        [[[1, 1], [2, 2]], [[1, 1], [2, 2]]]
+      ],
+      [2, 2, 2, 2]);
     expectTensorsClose(
-        K.batchNormalization(x, mean, variance, beta, gamma, 0),
-        tensor4d(
-            [
-              [[[4, 6.5], [23, 15.5]], [[4, 11], [23, 26]]],
-              [[[-4, -6.5], [-23, -15.5]], [[-4, -11], [-23, -26]]]
-            ],
-            [2, 2, 2, 2]));
+      K.batchNormalization(x, mean, variance, beta, gamma, 0),
+      tensor4d(
+        [
+          [[[4, 6.5], [23, 15.5]], [[4, 11], [23, 26]]],
+          [[[-4, -6.5], [-23, -15.5]], [[-4, -11], [-23, -26]]]
+        ],
+        [2, 2, 2, 2]));
   });
   it('4D, broadcast, gamma, beta', () => {
     const x = tensor4d(
-        [[[[10, 20], [30, 40]]], [[[10, 20], [30, 40]]]], [2, 1, 2, 2]);
+      [[[[10, 20], [30, 40]]], [[[10, 20], [30, 40]]]], [2, 1, 2, 2]);
     const mean = tensor1d([5, 5]);
     const variance = tensor1d([4, 16]);
     const gamma = tensor1d([2, 4]);
     const beta = tensor1d([-1, -2]);
     expectTensorsClose(
-        K.batchNormalization(x, mean, variance, beta, gamma, 0),
-        tensor4d([[[[4, 13], [24, 33]]], [[[4, 13], [24, 33]]]], [2, 1, 2, 2]));
+      K.batchNormalization(x, mean, variance, beta, gamma, 0),
+      tensor4d([[[[4, 13], [24, 33]]], [[[4, 13], [24, 33]]]], [2, 1, 2, 2]));
   });
 });
 
@@ -1754,7 +1633,7 @@ describeMathCPUAndGPU('l2Normalize', () => {
     const x = tensor2d([[1, 2], [3, 4]], [2, 2]);
     const norm = Math.sqrt(1 * 1 + 2 * 2 + 3 * 3 + 4 * 4);
     const expected =
-        tensor2d([[1 / norm, 2 / norm], [3 / norm, 4 / norm]], [2, 2]);
+      tensor2d([[1 / norm, 2 / norm], [3 / norm, 4 / norm]], [2, 2]);
     const result = K.l2Normalize(x);
     expectTensorsClose(result, expected);
   });
@@ -1764,8 +1643,8 @@ describeMathCPUAndGPU('l2Normalize', () => {
     const firstNorm = Math.sqrt(1 * 1 + 2 * 2);
     const secondNorm = Math.sqrt(3 * 3 + 4 * 4);
     const expected = tensor2d(
-        [[1 / firstNorm, 2 / firstNorm], [3 / secondNorm, 4 / secondNorm]],
-        [2, 2]);
+      [[1 / firstNorm, 2 / firstNorm], [3 / secondNorm, 4 / secondNorm]],
+      [2, 2]);
     const result = K.l2Normalize(x, -1);
     expectTensorsClose(result, expected);
   });
@@ -1780,37 +1659,37 @@ describeMathCPUAndGPU('l2Normalize', () => {
 
 describeMathCPUAndGPU('biasAdd', () => {
   it('1D + 1D', () => {
-    const x = K.ones([2]);
+    const x = tfc.ones([2]);
     const y = tensor1d([-1, 1]);
     expectTensorsClose(K.biasAdd(x, y), tensor1d([0, 2]));
   });
   it('2D + 1D', () => {
-    const x = K.ones([2, 2]);
+    const x = tfc.ones([2, 2]);
     const y = tensor1d([-1, 1]);
     expectTensorsClose(K.biasAdd(x, y), tensor2d([[0, 2], [0, 2]], [2, 2]));
   });
   it('3D + 1D', () => {
-    const x = K.ones([2, 2, 2]);
+    const x = tfc.ones([2, 2, 2]);
     const y = tensor1d([-1, 1]);
     expectTensorsClose(
-        K.biasAdd(x, y),
-        tensor3d([[[0, 2], [0, 2]], [[0, 2], [0, 2]]], [2, 2, 2]));
+      K.biasAdd(x, y),
+      tensor3d([[[0, 2], [0, 2]], [[0, 2], [0, 2]]], [2, 2, 2]));
   });
   it('4D + 1D', () => {
-    const x = K.ones([1, 2, 2, 2]);
+    const x = tfc.ones([1, 2, 2, 2]);
     const y = tensor1d([-1, 1]);
     expectTensorsClose(
-        K.biasAdd(x, y),
-        tensor4d([[[[0, 2], [0, 2]], [[0, 2], [0, 2]]]], [1, 2, 2, 2]));
+      K.biasAdd(x, y),
+      tensor4d([[[[0, 2], [0, 2]], [[0, 2], [0, 2]]]], [1, 2, 2, 2]));
   });
   it('2D + 1D: Incompatible size', () => {
-    const x = K.ones([2, 2]);
+    const x = tfc.ones([2, 2]);
     const y = tensor1d([-1, 0, 1]);
     expect(() => K.biasAdd(x, y)).toThrowError();
   });
   it('3D + 2D leads to error', () => {
-    const x = K.ones([2, 2, 2]);
-    const y = K.ones([2, 2]);
+    const x = tfc.ones([2, 2, 2]);
+    const y = tfc.ones([2, 2]);
     expect(() => K.biasAdd(x, y)).toThrowError();
   });
 });
@@ -1819,8 +1698,8 @@ describeMathCPUAndGPU('elu', () => {
   it('elu', () => {
     const xData = [-1, 0, 1, -1];
     expectTensorsClose(
-        K.elu(tensor2d(xData, [2, 2])),
-        tensor2d(xData.map(x => x < 0 ? Math.exp(x) - 1 : x), [2, 2]));
+      K.elu(tensor2d(xData, [2, 2])),
+      tensor2d(xData.map(x => x < 0 ? Math.exp(x) - 1 : x), [2, 2]));
   });
 });
 
@@ -1828,8 +1707,8 @@ describeMathCPUAndGPU('softplus', () => {
   it('softplus', () => {
     const xData = [-1, 0, 1, -1];
     expectTensorsClose(
-        K.softplus(tensor2d(xData, [2, 2])),
-        tensor2d(xData.map(x => Math.log(Math.exp(x) + 1)), [2, 2]));
+      K.softplus(tensor2d(xData, [2, 2])),
+      tensor2d(xData.map(x => Math.log(Math.exp(x) + 1)), [2, 2]));
   });
 });
 
@@ -1837,8 +1716,8 @@ describeMathCPUAndGPU('softsign', () => {
   it('softsign', () => {
     const xData = [-1, 0, 1, -1];
     expectTensorsClose(
-        K.softsign(tensor2d(xData, [2, 2])),
-        tensor2d(xData.map(x => x / (Math.abs(x) + 1)), [2, 2]));
+      K.softsign(tensor2d(xData, [2, 2])),
+      tensor2d(xData.map(x => x / (Math.abs(x) + 1)), [2, 2]));
   });
 });
 
@@ -1853,7 +1732,7 @@ describeMathCPUAndGPU('conv1dWithBias', () => {
 
   const outChannelsArray = [1, 2];
   const dataFormats: DataFormat[] =
-      [undefined, 'channelsFirst', 'channelsLast'];
+    [undefined, 'channelsFirst', 'channelsLast'];
   const paddingModes: PaddingMode[] = [undefined, 'same', 'valid'];
   const stride = 1;
 
@@ -1861,7 +1740,7 @@ describeMathCPUAndGPU('conv1dWithBias', () => {
     for (const dataFormat of dataFormats) {
       for (const paddingMode of paddingModes) {
         const testTitle = `outChannels=${outChannels}, stride=${stride}, ` +
-            `${paddingMode}, ${dataFormat}`;
+          `${paddingMode}, ${dataFormat}`;
         it(testTitle, () => {
           let x: Tensor = tensor3d(xLength4Data, [1, 4, 1]);
           if (dataFormat === 'channelsFirst') {
@@ -1875,11 +1754,11 @@ describeMathCPUAndGPU('conv1dWithBias', () => {
             biasData = biasData.concat([biasScalarData + i]);
           }
           const kernel =
-          tfc.transpose(tensor3d(kernelData, [1, outChannels, 2]), [2, 0, 1]);
+            tfc.transpose(tensor3d(kernelData, [1, outChannels, 2]), [2, 0, 1]);
           const bias = tensor1d(biasData);
 
           const y = K.conv1dWithBias(
-              x, kernel, bias, stride, paddingMode, dataFormat);
+            x, kernel, bias, stride, paddingMode, dataFormat);
 
           let yExpectedShape: [number, number, number];
           let yExpectedData: number[];
@@ -1898,7 +1777,7 @@ describeMathCPUAndGPU('conv1dWithBias', () => {
             } else if (outChannels === 2) {
               yExpectedShape = [1, 4, 2];
               yExpectedData =
-                  [-7.8, -6.8, -17.8, -16.8, -37.8, -36.8, 82.2, 83.2];
+                [-7.8, -6.8, -17.8, -16.8, -37.8, -36.8, 82.2, 83.2];
             }
           }
           expectTensorsClose(y, tensor3d(yExpectedData, yExpectedShape));
@@ -1917,7 +1796,7 @@ describeMathCPUAndGPU('conv1d', () => {
   const dataFormat = 'channelsLast';
   const paddingMode = 'valid';
   const testTitle = `outChannels=${outChannels}, stride=${stride}, ` +
-      `${paddingMode}, ${dataFormat}`;
+    `${paddingMode}, ${dataFormat}`;
   it(testTitle, () => {
     const x = tensor3d(xLength4Data, [1, 4, 1]);
     let kernelData: number[] = [];
@@ -1925,7 +1804,7 @@ describeMathCPUAndGPU('conv1d', () => {
       kernelData = kernelData.concat(kernelLength2Data);
     }
     const kernel =
-    tfc.transpose(tensor3d(kernelData, [1, outChannels, 2]), [2, 0, 1]);
+      tfc.transpose(tensor3d(kernelData, [1, outChannels, 2]), [2, 0, 1]);
     const y = K.conv1d(x, kernel, stride, paddingMode, dataFormat);
     expectTensorsClose(y, tensor3d([-10, -10, -40, -40], [1, 2, 2]));
   });
@@ -1939,7 +1818,7 @@ describeMathCPUAndGPU('conv2d', () => {
   const kernel2by2Data = [1, 0, 0, -1];
 
   const dataFormats: DataFormat[] =
-      [undefined, 'channelsFirst', 'channelsLast'];
+    [undefined, 'channelsFirst', 'channelsLast'];
   const paddingModes: PaddingMode[] = [undefined, 'same', 'valid'];
   const stridesArray = [1, 2];
 
@@ -1947,7 +1826,7 @@ describeMathCPUAndGPU('conv2d', () => {
     for (const paddingMode of paddingModes) {
       for (const stride of stridesArray) {
         const testTitle = `stride=${stride}, ${paddingMode}, ` +
-            `${dataFormat}`;
+          `${dataFormat}`;
         it(testTitle, () => {
           let x: Tensor = tensor4d(x4by4Data, [1, 1, 4, 4]);
           if (dataFormat !== 'channelsFirst') {
@@ -1959,8 +1838,8 @@ describeMathCPUAndGPU('conv2d', () => {
           let yExpected: Tensor;
           if (stride === 1) {
             yExpected = tensor4d(
-                [[[[-30, -30, -30], [50, 90, 130], [30, 30, 30]]]],
-                [1, 1, 3, 3]);
+              [[[[-30, -30, -30], [50, 90, 130], [30, 30, 30]]]],
+              [1, 1, 3, 3]);
           } else if (stride === 2) {
             yExpected = tensor4d([[[[-30, -30], [30, 30]]]], [1, 1, 2, 2]);
           }
@@ -1984,7 +1863,7 @@ describeMathCPUAndGPU('conv2dWithBias', () => {
 
   const outChannelsArray = [2, 3];
   const dataFormats: DataFormat[] =
-      [undefined, 'channelsFirst', 'channelsLast'];
+    [undefined, 'channelsFirst', 'channelsLast'];
   const paddingModes: PaddingMode[] = [undefined, 'same', 'valid'];
   const stridesArray = [1, 2];
 
@@ -1993,7 +1872,7 @@ describeMathCPUAndGPU('conv2dWithBias', () => {
       for (const paddingMode of paddingModes) {
         for (const stride of stridesArray) {
           const testTitle = `outChannels=${outChannels}, stride=${stride}, ` +
-              `${paddingMode}, ${dataFormat}`;
+            `${paddingMode}, ${dataFormat}`;
           it(testTitle, () => {
             let x: Tensor = tensor4d(x4by4Data, [1, 1, 4, 4]);
             if (dataFormat !== 'channelsFirst') {
@@ -2007,18 +1886,18 @@ describeMathCPUAndGPU('conv2dWithBias', () => {
               biasData = biasData.concat(biasScalarData);
             }
             const kernel = tfc.transpose(
-                tensor4d(kernelData, [outChannels, 2, 2, 1]), [1, 2, 3, 0]);
+              tensor4d(kernelData, [outChannels, 2, 2, 1]), [1, 2, 3, 0]);
             const bias = tensor1d(biasData);
 
             const y = K.conv2dWithBias(
-                x, kernel, bias, [stride, stride], 'valid', dataFormat);
+              x, kernel, bias, [stride, stride], 'valid', dataFormat);
 
             let yExpectedShape: [number, number, number, number];
             let yExpectedDataPerChannel: number[];
             if (stride === 1) {
               yExpectedShape = [1, outChannels, 3, 3];
               yExpectedDataPerChannel =
-                  [-30, -30, -30, 50, 90, 130, 30, 30, 30];
+                [-30, -30, -30, 50, 90, 130, 30, 30, 30];
             } else if (stride === 2) {
               yExpectedShape = [1, outChannels, 2, 2];
               yExpectedDataPerChannel = [-30, -30, 30, 30];
@@ -2049,7 +1928,7 @@ describeMathCPUAndGPU('depthwiseConv2d', () => {
   ]]];
 
   const dataFormats: DataFormat[] =
-      [undefined, 'channelsFirst', 'channelsLast'];
+    [undefined, 'channelsFirst', 'channelsLast'];
   const paddingModes: PaddingMode[] = [undefined, 'same', 'valid'];
   const stridesArray = [1, 2];
   const depthMultipliers = [1, 2];
@@ -2059,7 +1938,7 @@ describeMathCPUAndGPU('depthwiseConv2d', () => {
       for (const stride of stridesArray) {
         for (const depthMultiplier of depthMultipliers) {
           const testTitle = `stride=${stride}, ${paddingMode}, ` +
-              `${dataFormat}, depthMultiplier=${depthMultiplier}`;
+            `${dataFormat}, depthMultiplier=${depthMultiplier}`;
           it(testTitle, () => {
             let x: Tensor = tensor4d(x4by4Data, [1, 1, 4, 4]);
             if (dataFormat !== 'channelsFirst') {
@@ -2075,29 +1954,29 @@ describeMathCPUAndGPU('depthwiseConv2d', () => {
               kernel = tensor4d([1, -1, 0, 0, 0, 0, -1, 1], [2, 2, 1, 2]);
             }
             const y = K.depthwiseConv2d(
-                x, kernel, [stride, stride], 'valid', dataFormat);
+              x, kernel, [stride, stride], 'valid', dataFormat);
 
             let yExpected: Tensor;
             if (stride === 1) {
               if (depthMultiplier === 1) {
                 yExpected = tensor4d(
-                    [[[[-30, -30, -30], [50, 90, 130], [30, 30, 30]]]],
-                    [1, 1, 3, 3]);
+                  [[[[-30, -30, -30], [50, 90, 130], [30, 30, 30]]]],
+                  [1, 1, 3, 3]);
               } else if (depthMultiplier === 2) {
                 yExpected = tensor4d(
-                    [[
-                      [[-30, -30, -30], [50, 90, 130], [30, 30, 30]],
-                      [[30, 30, 30], [-50, -90, -130], [-30, -30, -30]]
-                    ]],
-                    [1, 2, 3, 3]);
+                  [[
+                    [[-30, -30, -30], [50, 90, 130], [30, 30, 30]],
+                    [[30, 30, 30], [-50, -90, -130], [-30, -30, -30]]
+                  ]],
+                  [1, 2, 3, 3]);
               }
             } else if (stride === 2) {
               if (depthMultiplier === 1) {
                 yExpected = tensor4d([[[[-30, -30], [30, 30]]]], [1, 1, 2, 2]);
               } else if (depthMultiplier === 2) {
                 yExpected = tensor4d(
-                    [[[[-30, -30], [30, 30]], [[30, 30], [-30, -30]]]],
-                    [1, 2, 2, 2]);
+                  [[[[-30, -30], [30, 30]], [[30, 30], [-30, -30]]]],
+                  [1, 2, 2, 2]);
               }
             }
             if (dataFormat !== 'channelsFirst') {
@@ -2111,8 +1990,8 @@ describeMathCPUAndGPU('depthwiseConv2d', () => {
   }
 
   it('Non-4D kernel leads to exception', () => {
-    const x = K.zeros([1, 1, 4, 4]);
-    expect(() => K.depthwiseConv2d(x, K.zeros([1, 2, 2]), [
+    const x = tfc.zeros([1, 1, 4, 4]);
+    expect(() => K.depthwiseConv2d(x, tfc.zeros([1, 2, 2]), [
       1, 1
     ])).toThrowError(/.* is required to be 4-D, but is instead 3-D/);
   });
@@ -2130,13 +2009,13 @@ describeMathCPUAndGPU('pool2d', () => {
 
   const poolModes: PoolMode[] = [undefined, 'max', 'avg'];
   const dataFormats: DataFormat[] =
-      [undefined, 'channelsFirst', 'channelsLast'];
+    [undefined, 'channelsFirst', 'channelsLast'];
   const stridesArray = [1, 2];
   for (const poolMode of poolModes) {
     for (const dataFormat of dataFormats) {
       for (const stride of stridesArray) {
         const testTitle = `4x4, ${stride}, same, ${dataFormat}, ` +
-            `${poolMode}`;
+          `${poolMode}`;
         it(testTitle, () => {
           let x: Tensor = tensor4d(x4by4Data, [1, 1, 4, 4]);
           if (dataFormat !== 'channelsFirst') {
@@ -2146,22 +2025,22 @@ describeMathCPUAndGPU('pool2d', () => {
           if (poolMode === 'avg') {
             if (stride === 1) {
               yExpected = tensor4d(
-                  [[[
-                    [25, 45, 65, 75], [5, 5, 5, 5], [-25, -45, -65, -75],
-                    [-30, -50, -70, -80]
-                  ]]],
-                  [1, 1, 4, 4]);
+                [[[
+                  [25, 45, 65, 75], [5, 5, 5, 5], [-25, -45, -65, -75],
+                  [-30, -50, -70, -80]
+                ]]],
+                [1, 1, 4, 4]);
             } else {
               yExpected = tensor4d([[[[25, 65], [-25, -65]]]], [1, 1, 2, 2]);
             }
           } else {
             if (stride === 1) {
               yExpected = tensor4d(
-                  [[[
-                    [40, 60, 80, 80], [40, 60, 80, 80], [-10, -30, -50, -70],
-                    [-20, -40, -60, -80]
-                  ]]],
-                  [1, 1, 4, 4]);
+                [[[
+                  [40, 60, 80, 80], [40, 60, 80, 80], [-10, -30, -50, -70],
+                  [-20, -40, -60, -80]
+                ]]],
+                [1, 1, 4, 4]);
             } else if (stride === 2) {
               yExpected = tensor4d([[[[40, 80], [-10, -50]]]], [1, 1, 2, 2]);
             }
@@ -2170,7 +2049,7 @@ describeMathCPUAndGPU('pool2d', () => {
             yExpected = tfc.transpose(yExpected, [0, 2, 3, 1]);
           }
           const y = K.pool2d(
-              x, [2, 2], [stride, stride], 'same', dataFormat, poolMode);
+            x, [2, 2], [stride, stride], 'same', dataFormat, poolMode);
           expectTensorsClose(y, yExpected);
         });
       }
@@ -2183,14 +2062,14 @@ describeMathCPUAndGPU('pool2d', () => {
       let yExpected = tensor4d(x4by4Data, [1, 1, 4, 4]);
       if (poolMode === 'avg') {
         yExpected = tensor4d(
-            [[[[0.75, 4.5, 7.5], [-0.25, -2, -3.5], [-1, -5, -8]]]],
-            [1, 1, 3, 3]);
+          [[[[0.75, 4.5, 7.5], [-0.25, -2, -3.5], [-1, -5, -8]]]],
+          [1, 1, 3, 3]);
       } else {
         yExpected =
-            tensor4d([[[[2, 6, 8], [0, 0, 0], [0, -4, -8]]]], [1, 1, 3, 3]);
+          tensor4d([[[[2, 6, 8], [0, 0, 0], [0, -4, -8]]]], [1, 1, 3, 3]);
       }
       const y =
-          K.pool2d(x5by5, [2, 2], [2, 2], 'same', 'channelsFirst', poolMode);
+        K.pool2d(x5by5, [2, 2], [2, 2], 'same', 'channelsFirst', poolMode);
       expectTensorsClose(y, yExpected);
     });
   }
@@ -2198,7 +2077,7 @@ describeMathCPUAndGPU('pool2d', () => {
   for (const poolMode of poolModes) {
     it(`5x5, 2, valid, CHANNEL_LAST, ${poolMode}`, () => {
       const x5by5 =
-      tfc.transpose(tensor4d(x5by5Data, [1, 1, 5, 5]), [0, 2, 3, 1]);
+        tfc.transpose(tensor4d(x5by5Data, [1, 1, 5, 5]), [0, 2, 3, 1]);
       let yExpected: Tensor4D;
       if (poolMode === 'avg') {
         yExpected = tensor4d([[[[0.75, 4.5], [-0.25, -2]]]], [1, 1, 2, 2]);
@@ -2206,7 +2085,7 @@ describeMathCPUAndGPU('pool2d', () => {
         yExpected = tensor4d([[[[2, 6], [0, 0]]]], [1, 1, 2, 2]);
       }
       const y =
-          K.pool2d(x5by5, [2, 2], [2, 2], 'valid', 'channelsLast', poolMode);
+        K.pool2d(x5by5, [2, 2], [2, 2], 'valid', 'channelsLast', poolMode);
       expectTensorsClose(y, tfc.transpose(yExpected, [0, 2, 3, 1]));
     });
   }
@@ -2253,49 +2132,17 @@ describe('getUID ', () => {
   });
 });
 
-describeMathCPUAndGPU('Softmax ', () => {
-  it('1D', () => {
-    const initVals = new Float32Array([0, 1, 3, 9]);
-    const initX = tensor1d(initVals);
-    expectTensorsClose(
-        K.softmax(initX), tensor1d([0.000, 0.000, 0.002, 0.997]));
-  });
-  it('all equal', () => {
-    const initVals = new Float32Array([-1, -1, -1, -1]);
-    const initX = tensor1d(initVals);
-    expectTensorsClose(K.softmax(initX), tensor1d([0.25, 0.25, 0.25, 0.25]));
-  });
-  it('2D', () => {
-    const initVals = new Float32Array([0, 1, 3, 9, 0, 1, 3, 9]);
-    const initX = tensor2d(initVals, [2, 4]);
-    expectTensorsClose(
-        K.softmax(initX),
-        tensor2d(
-            [[0.000, 0.000, 0.002, 0.997], [0.000, 0.000, 0.002, 0.997]],
-            [2, 4]));
-  });
-  it('3D', () => {
-    const initVals = new Float32Array([0, 1, 3, 9, 0, 1, 3, 9]);
-    const initX = tensor3d(initVals, [1, 2, 4]);
-    expectTensorsClose(
-        K.softmax(initX),
-        tensor3d(
-            [[[0.000, 0.000, 0.002, 0.997], [0.000, 0.000, 0.002, 0.997]]],
-            [1, 2, 4]));
-  });
-});
-
 describeMathCPUAndGPU('categoricalCrossentropy ', () => {
   it('from logits', () => {
     const x = tensor2d([[1, 2], [3, 4]], [2, 2]);
     const target = tensor2d([[0.25, 0.75], [0.1, 0.9]], [2, 2]);
     const expected = tensor1d([
       -1 *
-          (Math.log(Math.exp(1) / (Math.exp(1) + Math.exp(2))) * 0.25 +
-           Math.log(Math.exp(2) / (Math.exp(1) + Math.exp(2))) * 0.75),
+      (Math.log(Math.exp(1) / (Math.exp(1) + Math.exp(2))) * 0.25 +
+        Math.log(Math.exp(2) / (Math.exp(1) + Math.exp(2))) * 0.75),
       -1 *
-          (Math.log(Math.exp(3) / (Math.exp(3) + Math.exp(4))) * 0.1 +
-           Math.log(Math.exp(4) / (Math.exp(3) + Math.exp(4))) * 0.9)
+      (Math.log(Math.exp(3) / (Math.exp(3) + Math.exp(4))) * 0.1 +
+        Math.log(Math.exp(4) / (Math.exp(3) + Math.exp(4))) * 0.9)
     ]);
     const result = K.categoricalCrossentropy(target, x, true);
     expectTensorsClose(result, expected);
@@ -2339,8 +2186,8 @@ describeMathCPUAndGPU('binaryCrossentropy', () => {
     const targetComplement = K.scalarPlusArray(scalar(1), tfc.neg(target));
     const outputComplement = K.scalarPlusArray(scalar(1), tfc.neg(output));
     return tfc.neg(tfc.add(
-        K.multiply(target, tfc.log(output)),
-        K.multiply(targetComplement, tfc.log(outputComplement))));
+      tfc.mul(target, tfc.log(output)),
+      tfc.mul(targetComplement, tfc.log(outputComplement))));
   }
 
   it('from logits', () => {
@@ -2369,8 +2216,8 @@ describeMathCPUAndGPU('sigmoidCrossEntropyWithLogits', () => {
     const sigmoidX = tfc.sigmoid(x);
     const sigmoidXComplement = K.scalarPlusArray(scalar(1), tfc.neg(sigmoidX));
     const expected = tfc.add(
-        K.multiply(target, tfc.neg(tfc.log(sigmoidX))),
-        K.multiply(targetComplement, tfc.neg(tfc.log(sigmoidXComplement))));
+      tfc.mul(target, tfc.neg(tfc.log(sigmoidX))),
+      tfc.mul(targetComplement, tfc.neg(tfc.log(sigmoidXComplement))));
     const result = K.sigmoidCrossEntropyWithLogits(target, x);
     expectTensorsClose(result, expected);
   });
@@ -2437,133 +2284,133 @@ function rnnStepForTest(inputs: Tensor, states: Tensor[]): [Tensor, Tensor[]] {
 describeMathCPUAndGPU('rnn', () => {
   it('Simple step function: 3D inputs, 1 state', () => {
     const inputs = tensor3d(
-        [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
-    const initialStates = [K.zeros([2, 4])];
+      [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
+    const initialStates = [tfc.zeros([2, 4])];
     const rnnOutputs = K.rnn(rnnStepForTest, inputs, initialStates);
     const lastOutput = rnnOutputs[0];
     const outputs = rnnOutputs[1];
     const newStates = rnnOutputs[2];
     expectTensorsClose(
-        lastOutput,
-        tensor2d(
-            [
-              [-57.75, -57.75, -57.75, -57.75],
-              [-57.75, -57.75, -57.75, -57.75]
-            ],
-            [2, 4]));
+      lastOutput,
+      tensor2d(
+        [
+          [-57.75, -57.75, -57.75, -57.75],
+          [-57.75, -57.75, -57.75, -57.75]
+        ],
+        [2, 4]));
     expectTensorsClose(
-        outputs,
-        tensor3d(
-            [
-              [
-                [-8.25, -8.25, -8.25, -8.25], [-27.5, -27.5, -27.5, -27.5],
-                [-57.75, -57.75, -57.75, -57.75]
-              ],
-              [
-                [-8.25, -8.25, -8.25, -8.25], [-27.5, -27.5, -27.5, -27.5],
-                [-57.75, -57.75, -57.75, -57.75]
-              ]
-            ],
-            [2, 3, 4]));
+      outputs,
+      tensor3d(
+        [
+          [
+            [-8.25, -8.25, -8.25, -8.25], [-27.5, -27.5, -27.5, -27.5],
+            [-57.75, -57.75, -57.75, -57.75]
+          ],
+          [
+            [-8.25, -8.25, -8.25, -8.25], [-27.5, -27.5, -27.5, -27.5],
+            [-57.75, -57.75, -57.75, -57.75]
+          ]
+        ],
+        [2, 3, 4]));
     expect(newStates.length).toEqual(1);
     expectTensorsClose(
-        newStates[0],
-        tensor2d(
-            [[57.75, 57.75, 57.75, 57.75], [57.75, 57.75, 57.75, 57.75]],
-            [2, 4]));
+      newStates[0],
+      tensor2d(
+        [[57.75, 57.75, 57.75, 57.75], [57.75, 57.75, 57.75, 57.75]],
+        [2, 4]));
   });
 
   it('Simple step function: 3D inputs, 2 states', () => {
     const inputs = tensor3d(
-        [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
+      [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
     // The two state tensors have different shapes.
-    const initialStates = [K.zeros([2, 4]), K.ones([2, 3])];
+    const initialStates = [tfc.zeros([2, 4]), tfc.ones([2, 3])];
     const rnnOutputs = K.rnn(rnnStepForTest, inputs, initialStates);
     const lastOutput = rnnOutputs[0];
     const outputs = rnnOutputs[1];
     const newStates = rnnOutputs[2];
     expectTensorsClose(
-        lastOutput,
-        tensor2d(
-            [
-              [-57.75, -57.75, -57.75, -57.75],
-              [-57.75, -57.75, -57.75, -57.75]
-            ],
-            [2, 4]));
+      lastOutput,
+      tensor2d(
+        [
+          [-57.75, -57.75, -57.75, -57.75],
+          [-57.75, -57.75, -57.75, -57.75]
+        ],
+        [2, 4]));
     expectTensorsClose(
-        outputs,
-        tensor3d(
-            [
-              [
-                [-8.25, -8.25, -8.25, -8.25], [-27.5, -27.5, -27.5, -27.5],
-                [-57.75, -57.75, -57.75, -57.75]
-              ],
-              [
-                [-8.25, -8.25, -8.25, -8.25], [-27.5, -27.5, -27.5, -27.5],
-                [-57.75, -57.75, -57.75, -57.75]
-              ]
-            ],
-            [2, 3, 4]));
+      outputs,
+      tensor3d(
+        [
+          [
+            [-8.25, -8.25, -8.25, -8.25], [-27.5, -27.5, -27.5, -27.5],
+            [-57.75, -57.75, -57.75, -57.75]
+          ],
+          [
+            [-8.25, -8.25, -8.25, -8.25], [-27.5, -27.5, -27.5, -27.5],
+            [-57.75, -57.75, -57.75, -57.75]
+          ]
+        ],
+        [2, 3, 4]));
     expect(newStates.length).toEqual(2);
     expectTensorsClose(
-        newStates[0],
-        tensor2d(
-            [[57.75, 57.75, 57.75, 57.75], [57.75, 57.75, 57.75, 57.75]],
-            [2, 4]));
+      newStates[0],
+      tensor2d(
+        [[57.75, 57.75, 57.75, 57.75], [57.75, 57.75, 57.75, 57.75]],
+        [2, 4]));
     expectTensorsClose(
-        newStates[1],
-        tensor2d([[58.75, 58.75, 58.75], [58.75, 58.75, 58.75]], [2, 3]));
+      newStates[1],
+      tensor2d([[58.75, 58.75, 58.75], [58.75, 58.75, 58.75]], [2, 3]));
   });
 
   it('Simple step function: 4D inputs, 2 states', () => {
     const inputs = tensor4d(
-        [
-          [[[1], [2]], [[3], [4]], [[5], [6]]],
-          [[[10], [20]], [[30], [40]], [[50], [60]]]
-        ],
-        [2, 3, 2, 1]);
+      [
+        [[[1], [2]], [[3], [4]], [[5], [6]]],
+        [[[10], [20]], [[30], [40]], [[50], [60]]]
+      ],
+      [2, 3, 2, 1]);
     // The two state tensors have different shapes.
-    const initialStates = [K.zeros([2, 4]), K.ones([2, 3])];
+    const initialStates = [tfc.zeros([2, 4]), tfc.ones([2, 3])];
     const rnnOutputs = K.rnn(rnnStepForTest, inputs, initialStates);
     const lastOutput = rnnOutputs[0];
     const outputs = rnnOutputs[1];
     const newStates = rnnOutputs[2];
     expectTensorsClose(
-        lastOutput,
-        tensor2d(
-            [
-              [-57.75, -57.75, -57.75, -57.75],
-              [-57.75, -57.75, -57.75, -57.75]
-            ],
-            [2, 4]));
+      lastOutput,
+      tensor2d(
+        [
+          [-57.75, -57.75, -57.75, -57.75],
+          [-57.75, -57.75, -57.75, -57.75]
+        ],
+        [2, 4]));
     expectTensorsClose(
-        outputs,
-        tensor3d(
-            [
-              [
-                [-8.25, -8.25, -8.25, -8.25], [-27.5, -27.5, -27.5, -27.5],
-                [-57.75, -57.75, -57.75, -57.75]
-              ],
-              [
-                [-8.25, -8.25, -8.25, -8.25], [-27.5, -27.5, -27.5, -27.5],
-                [-57.75, -57.75, -57.75, -57.75]
-              ]
-            ],
-            [2, 3, 4]));
+      outputs,
+      tensor3d(
+        [
+          [
+            [-8.25, -8.25, -8.25, -8.25], [-27.5, -27.5, -27.5, -27.5],
+            [-57.75, -57.75, -57.75, -57.75]
+          ],
+          [
+            [-8.25, -8.25, -8.25, -8.25], [-27.5, -27.5, -27.5, -27.5],
+            [-57.75, -57.75, -57.75, -57.75]
+          ]
+        ],
+        [2, 3, 4]));
     expect(newStates.length).toEqual(2);
     expectTensorsClose(
-        newStates[0],
-        tensor2d(
-            [[57.75, 57.75, 57.75, 57.75], [57.75, 57.75, 57.75, 57.75]],
-            [2, 4]));
+      newStates[0],
+      tensor2d(
+        [[57.75, 57.75, 57.75, 57.75], [57.75, 57.75, 57.75, 57.75]],
+        [2, 4]));
     expectTensorsClose(
-        newStates[1],
-        tensor2d([[58.75, 58.75, 58.75], [58.75, 58.75, 58.75]], [2, 3]));
+      newStates[1],
+      tensor2d([[58.75, 58.75, 58.75], [58.75, 58.75, 58.75]], [2, 3]));
   });
 
   it('Using inputs <3D leads to ValueError', () => {
     const inputs = tensor2d([[1, 2], [3, 4]], [2, 2]);
-    const initialStates = [K.zeros([4]), K.ones([3])];
+    const initialStates = [tfc.zeros([4]), tfc.ones([3])];
     expect(() => K.rnn(rnnStepForTest, inputs, initialStates)).toThrowError();
   });
 });
@@ -2571,21 +2418,21 @@ describeMathCPUAndGPU('rnn', () => {
 describeMathCPUAndGPU('gradients', () => {
   it('Simple mean: 1 variable', () => {
     const var1 =
-        new LayerVariable(K.scalarTimesArray(scalar(2.0), K.ones([2, 2])));
+      new LayerVariable(K.scalarTimesArray(scalar(2.0), tfc.ones([2, 2])));
     const gradients = K.gradients(() => K.mean(var1.read()) as Scalar, [var1]);
     expect(gradients.length).toEqual(1);
     expectTensorsClose(
-        tensor2d([[0.25, 0.25], [0.25, 0.25]], [2, 2]), gradients[0]);
+      tensor2d([[0.25, 0.25], [0.25, 0.25]], [2, 2]), gradients[0]);
   });
   it('Simple matmul and mean: 2 variables', () => {
     const var1 = new LayerVariable(tensor2d([[1, 0], [0, 0]], [2, 2]));
     const var2 = new LayerVariable(tensor2d([[1, 0], [0, 1]], [2, 2]));
     const gradients = K.gradients(
-        () => K.mean(K.dot(var1.read(), var2.read())) as Scalar, [var1, var2]);
+      () => K.mean(K.dot(var1.read(), var2.read())) as Scalar, [var1, var2]);
     expect(gradients.length).toEqual(2);
     // d(loss) / d(var1).
     expectTensorsClose(
-        tensor2d([[0.25, 0.25], [0.25, 0.25]], [2, 2]), gradients[0]);
+      tensor2d([[0.25, 0.25], [0.25, 0.25]], [2, 2]), gradients[0]);
     // d(loss) / d(var2).
     expectTensorsClose(tensor2d([[0.25, 0.25], [0, 0]], [2, 2]), gradients[1]);
   });

--- a/src/backend/tfjs_backend_test.ts
+++ b/src/backend/tfjs_backend_test.ts
@@ -14,13 +14,13 @@
 
 // tslint:disable:max-line-length
 import * as tfc from '@tensorflow/tfjs-core';
-import { Scalar, scalar, slice, Tensor, memory, tensor1d, tensor2d, tensor3d, tensor4d, Tensor4D, zeros } from '@tensorflow/tfjs-core';
+import {Scalar, scalar, slice, Tensor, memory, tensor1d, tensor2d, tensor3d, tensor4d, Tensor4D, zeros} from '@tensorflow/tfjs-core';
 
-import { DataFormat, PaddingMode, PoolMode } from '../common';
-import { DType, LayerVariable, SymbolicTensor } from '../types';
-import { unique } from '../utils/generic_utils';
-import { range } from '../utils/math_utils';
-import { describeMathCPU, describeMathCPUAndGPU, expectTensorsClose } from '../utils/test_utils';
+import {DataFormat, PaddingMode, PoolMode} from '../common';
+import {DType, LayerVariable, SymbolicTensor} from '../types';
+import {unique} from '../utils/generic_utils';
+import {range} from '../utils/math_utils';
+import {describeMathCPU, describeMathCPUAndGPU, expectTensorsClose} from '../utils/test_utils';
 
 import * as K from './tfjs_backend';
 

--- a/src/callbacks.ts
+++ b/src/callbacks.ts
@@ -10,10 +10,10 @@
 
 /* Original source: keras/callbacks.py */
 
-import { div, keep, mul, Scalar, Tensor, tidy } from '@tensorflow/tfjs-core';
+import {div, keep, mul, Scalar, Tensor, tidy} from '@tensorflow/tfjs-core';
 
 import * as K from './backend/tfjs_backend';
-import { Model } from './engine/training';
+import {Model} from './engine/training';
 import * as generic_utils from './utils/generic_utils';
 
 /**
@@ -22,7 +22,7 @@ import * as generic_utils from './utils/generic_utils';
  * Used internally.
  */
 export type UnresolvedLogs = {
-  [key: string]: number | Scalar;
+  [key: string]: number|Scalar;
 };
 
 
@@ -36,7 +36,7 @@ export type Logs = {
 };
 
 export type Params = {
-  [key: string]: number | string | boolean | number[] | string[] | boolean[];
+  [key: string]: number|string|boolean|number[]|string[]|boolean[];
 };
 
 /**
@@ -59,7 +59,7 @@ export type Params = {
  */
 export abstract class Callback {
   // TODO(michaelterry): This type is a best guess.
-  validationData: Tensor | Tensor[] = null;
+  validationData: Tensor|Tensor[] = null;
   /** Instance of `keras.models.Model`. Reference of the model being trained. */
   model: Model = null;
   /**
@@ -75,17 +75,17 @@ export abstract class Callback {
     this.model = model;
   }
 
-  async onEpochBegin(epoch: number, logs?: UnresolvedLogs) { }
+  async onEpochBegin(epoch: number, logs?: UnresolvedLogs) {}
 
-  async onEpochEnd(epoch: number, logs?: UnresolvedLogs) { }
+  async onEpochEnd(epoch: number, logs?: UnresolvedLogs) {}
 
-  async onBatchBegin(batch: number, logs?: UnresolvedLogs) { }
+  async onBatchBegin(batch: number, logs?: UnresolvedLogs) {}
 
-  async onBatchEnd(batch: number, logs?: UnresolvedLogs) { }
+  async onBatchEnd(batch: number, logs?: UnresolvedLogs) {}
 
-  async onTrainBegin(logs?: UnresolvedLogs) { }
+  async onTrainBegin(logs?: UnresolvedLogs) {}
 
-  async onTrainEnd(logs?: UnresolvedLogs) { }
+  async onTrainEnd(logs?: UnresolvedLogs) {}
 }
 
 /**
@@ -253,10 +253,9 @@ export class BaseLogger extends Callback {
         }
         // TODO(cais): Do not leak tidy from TensorFlow.js Core.
         tidy(() => {
-          this.totals[key] =
-            K.scalarPlusArray(
-              this.totals[key] as Scalar,
-              mul(value, K.getScalar(batchSize))) as Scalar;
+          this.totals[key] = K.scalarPlusArray(
+                                 this.totals[key] as Scalar,
+                                 mul(value, K.getScalar(batchSize))) as Scalar;
           keep(this.totals[key] as Scalar);
         });
       }
@@ -274,9 +273,9 @@ export class BaseLogger extends Callback {
         } else {
           tidy(() => {
             logs[key] =
-              K.scalarTimesArray(
-                div(K.getScalar(1), K.getScalar(this.seen)) as Scalar,
-                this.totals[key] as Scalar) as Scalar;
+                K.scalarTimesArray(
+                    div(K.getScalar(1), K.getScalar(this.seen)) as Scalar,
+                    this.totals[key] as Scalar) as Scalar;
             keep(logs[key] as Scalar);
           });
         }
@@ -294,7 +293,7 @@ export async function resolveScalarsInLogs(logs: UnresolvedLogs) {
   if (logs == null) {
     return;
   }
-  const promises: Array<Promise<Float32Array | Int32Array | Uint8Array>> = [];
+  const promises: Array<Promise<Float32Array|Int32Array|Uint8Array>> = [];
   const keys: string[] = [];
   for (const key in logs) {
     const value = logs[key];
@@ -335,7 +334,7 @@ export function disposeTensorsInLogs(logs: UnresolvedLogs) {
  */
 export class History extends Callback {
   epoch: number[];
-  history: { [key: string]: Array<number | Tensor> };
+  history: {[key: string]: Array<number|Tensor>};
 
   async onTrainBegin(logs?: UnresolvedLogs) {
     this.epoch = [];
@@ -359,7 +358,7 @@ export class History extends Callback {
    * Await the values of all losses and metrics.
    */
   async syncData() {
-    const promises: Array<Promise<Float32Array | Int32Array | Uint8Array>> = [];
+    const promises: Array<Promise<Float32Array|Int32Array|Uint8Array>> = [];
     const keys: string[] = [];
     const indices: number[] = [];
     for (const key in this.history) {
@@ -457,9 +456,9 @@ export class CustomCallback extends Callback {
 /**
  * Standardize callbacks or configurations of them to an Array of callbacks.
  */
-export function standardizeCallbacks(callbacks: Callback | Callback[] |
-  CustomCallbackConfig |
-  CustomCallbackConfig[]): Callback[] {
+export function standardizeCallbacks(callbacks: Callback|Callback[]|
+                                     CustomCallbackConfig|
+                                     CustomCallbackConfig[]): Callback[] {
   if (callbacks == null) {
     return null;
   }
@@ -471,7 +470,7 @@ export function standardizeCallbacks(callbacks: Callback | Callback[] |
   }
   // Convert custom callback configs to custom callback objects.
   const callbackConfigs =
-    generic_utils.toList(callbacks) as CustomCallbackConfig[];
+      generic_utils.toList(callbacks) as CustomCallbackConfig[];
   return callbackConfigs.map(
-    callbackConfig => new CustomCallback(callbackConfig));
+      callbackConfig => new CustomCallback(callbackConfig));
 }

--- a/src/callbacks.ts
+++ b/src/callbacks.ts
@@ -10,10 +10,10 @@
 
 /* Original source: keras/callbacks.py */
 
-import {keep, Scalar, Tensor, tidy} from '@tensorflow/tfjs-core';
+import { div, keep, mul, Scalar, Tensor, tidy } from '@tensorflow/tfjs-core';
 
 import * as K from './backend/tfjs_backend';
-import {Model} from './engine/training';
+import { Model } from './engine/training';
 import * as generic_utils from './utils/generic_utils';
 
 /**
@@ -22,7 +22,7 @@ import * as generic_utils from './utils/generic_utils';
  * Used internally.
  */
 export type UnresolvedLogs = {
-  [key: string]: number|Scalar;
+  [key: string]: number | Scalar;
 };
 
 
@@ -36,7 +36,7 @@ export type Logs = {
 };
 
 export type Params = {
-  [key: string]: number|string|boolean|number[]|string[]|boolean[];
+  [key: string]: number | string | boolean | number[] | string[] | boolean[];
 };
 
 /**
@@ -59,7 +59,7 @@ export type Params = {
  */
 export abstract class Callback {
   // TODO(michaelterry): This type is a best guess.
-  validationData: Tensor|Tensor[] = null;
+  validationData: Tensor | Tensor[] = null;
   /** Instance of `keras.models.Model`. Reference of the model being trained. */
   model: Model = null;
   /**
@@ -75,17 +75,17 @@ export abstract class Callback {
     this.model = model;
   }
 
-  async onEpochBegin(epoch: number, logs?: UnresolvedLogs) {}
+  async onEpochBegin(epoch: number, logs?: UnresolvedLogs) { }
 
-  async onEpochEnd(epoch: number, logs?: UnresolvedLogs) {}
+  async onEpochEnd(epoch: number, logs?: UnresolvedLogs) { }
 
-  async onBatchBegin(batch: number, logs?: UnresolvedLogs) {}
+  async onBatchBegin(batch: number, logs?: UnresolvedLogs) { }
 
-  async onBatchEnd(batch: number, logs?: UnresolvedLogs) {}
+  async onBatchEnd(batch: number, logs?: UnresolvedLogs) { }
 
-  async onTrainBegin(logs?: UnresolvedLogs) {}
+  async onTrainBegin(logs?: UnresolvedLogs) { }
 
-  async onTrainEnd(logs?: UnresolvedLogs) {}
+  async onTrainEnd(logs?: UnresolvedLogs) { }
 }
 
 /**
@@ -254,9 +254,9 @@ export class BaseLogger extends Callback {
         // TODO(cais): Do not leak tidy from TensorFlow.js Core.
         tidy(() => {
           this.totals[key] =
-              K.scalarPlusArray(
-                  this.totals[key] as Scalar,
-                  K.multiply(value, K.getScalar(batchSize))) as Scalar;
+            K.scalarPlusArray(
+              this.totals[key] as Scalar,
+              mul(value, K.getScalar(batchSize))) as Scalar;
           keep(this.totals[key] as Scalar);
         });
       }
@@ -274,9 +274,9 @@ export class BaseLogger extends Callback {
         } else {
           tidy(() => {
             logs[key] =
-                K.scalarTimesArray(
-                    K.divide(K.getScalar(1), K.getScalar(this.seen)) as Scalar,
-                    this.totals[key] as Scalar) as Scalar;
+              K.scalarTimesArray(
+                div(K.getScalar(1), K.getScalar(this.seen)) as Scalar,
+                this.totals[key] as Scalar) as Scalar;
             keep(logs[key] as Scalar);
           });
         }
@@ -294,7 +294,7 @@ export async function resolveScalarsInLogs(logs: UnresolvedLogs) {
   if (logs == null) {
     return;
   }
-  const promises: Array<Promise<Float32Array|Int32Array|Uint8Array>> = [];
+  const promises: Array<Promise<Float32Array | Int32Array | Uint8Array>> = [];
   const keys: string[] = [];
   for (const key in logs) {
     const value = logs[key];
@@ -335,7 +335,7 @@ export function disposeTensorsInLogs(logs: UnresolvedLogs) {
  */
 export class History extends Callback {
   epoch: number[];
-  history: {[key: string]: Array<number|Tensor>};
+  history: { [key: string]: Array<number | Tensor> };
 
   async onTrainBegin(logs?: UnresolvedLogs) {
     this.epoch = [];
@@ -359,7 +359,7 @@ export class History extends Callback {
    * Await the values of all losses and metrics.
    */
   async syncData() {
-    const promises: Array<Promise<Float32Array|Int32Array|Uint8Array>> = [];
+    const promises: Array<Promise<Float32Array | Int32Array | Uint8Array>> = [];
     const keys: string[] = [];
     const indices: number[] = [];
     for (const key in this.history) {
@@ -457,9 +457,9 @@ export class CustomCallback extends Callback {
 /**
  * Standardize callbacks or configurations of them to an Array of callbacks.
  */
-export function standardizeCallbacks(callbacks: Callback|Callback[]|
-                                     CustomCallbackConfig|
-                                     CustomCallbackConfig[]): Callback[] {
+export function standardizeCallbacks(callbacks: Callback | Callback[] |
+  CustomCallbackConfig |
+  CustomCallbackConfig[]): Callback[] {
   if (callbacks == null) {
     return null;
   }
@@ -471,7 +471,7 @@ export function standardizeCallbacks(callbacks: Callback|Callback[]|
   }
   // Convert custom callback configs to custom callback objects.
   const callbackConfigs =
-      generic_utils.toList(callbacks) as CustomCallbackConfig[];
+    generic_utils.toList(callbacks) as CustomCallbackConfig[];
   return callbackConfigs.map(
-      callbackConfig => new CustomCallback(callbackConfig));
+    callbackConfig => new CustomCallback(callbackConfig));
 }

--- a/src/constraints.ts
+++ b/src/constraints.ts
@@ -86,10 +86,10 @@ export class MaxNorm extends Constraint {
 
   apply(w: Tensor): Tensor {
     const norms = calcL2Norms(w, this.axis);
-    const desired = K.clip(norms, 0, this.maxValue);
-    return K.multiply(
+    const desired = tfc.clipByValue(norms, 0, this.maxValue);
+    return tfc.mul(
         w,
-        K.divide(desired, K.scalarPlusArray(K.getScalar(K.epsilon()), norms)));
+        tfc.div(desired, K.scalarPlusArray(K.getScalar(K.epsilon()), norms)));
   }
 
   getConfig(): serialization.ConfigDict {
@@ -129,7 +129,7 @@ export class UnitNorm extends Constraint {
   }
 
   apply(w: Tensor): Tensor {
-    return K.divide(
+    return tfc.div(
         w,
         K.scalarPlusArray(K.getScalar(K.epsilon()), calcL2Norms(w, this.axis)));
   }
@@ -211,11 +211,11 @@ export class MinMaxNorm extends Constraint {
     const desired = tfc.add(
         K.scalarTimesArray(
             K.getScalar(this.rate),
-            K.clip(norms, this.minValue, this.maxValue)),
+            tfc.clipByValue(norms, this.minValue, this.maxValue)),
         K.scalarTimesArray(K.getScalar(1.0 - this.rate), norms));
-    return K.multiply(
+    return tfc.mul(
         w,
-        K.divide(desired, K.scalarPlusArray(K.getScalar(K.epsilon()), norms)));
+        tfc.div(desired, K.scalarPlusArray(K.getScalar(K.epsilon()), norms)));
   }
 
   getConfig(): serialization.ConfigDict {

--- a/src/engine/executor_test.ts
+++ b/src/engine/executor_test.ts
@@ -13,9 +13,8 @@
  */
 
 // tslint:disable:max-line-length
-import {Tensor, tensor1d, tensor2d, tensor3d} from '@tensorflow/tfjs-core';
+import {ones, Tensor, tensor1d, tensor2d, tensor3d} from '@tensorflow/tfjs-core';
 
-import * as K from '../backend/tfjs_backend';
 import * as tfl from '../index';
 import {DType} from '../types';
 import {describeMathCPU, describeMathCPUAndGPU, expectTensorsClose} from '../utils/test_utils';
@@ -110,28 +109,28 @@ describeMathCPUAndGPU('Executor', () => {
     const w = denseLayer3.apply(v);
 
     it('Execute Input directly', () => {
-      const xValue = K.ones([2, 2]);
+      const xValue = ones([2, 2]);
       const feedDict = new FeedDict().add(x, xValue);
       expectTensorsClose(
           execute(x as tfl.SymbolicTensor, feedDict) as Tensor,
           tensor2d([1, 1, 1, 1], [2, 2]));
     });
     it('Input to Dense', () => {
-      const xValue = K.ones([2, 2]);
+      const xValue = ones([2, 2]);
       const feedDict = new FeedDict([{key: x, value: xValue}]);
       expectTensorsClose(
           execute(y as tfl.SymbolicTensor, feedDict) as Tensor,
           tensor2d([2, 2, 2, 2, 2, 2, 2, 2, 2, 2], [2, 5]));
     });
     it('Input to Dense1 to Dense2', () => {
-      const uValue = K.ones([2, 2]);
+      const uValue = ones([2, 2]);
       const feedDict = new FeedDict([{key: u, value: uValue}]);
       expectTensorsClose(
           execute(w as tfl.SymbolicTensor, feedDict) as Tensor,
           tensor2d([10, 10, 10, 10, 10, 10], [2, 3]));
     });
     it('Feed value to intermediate layers is supported', () => {
-      const vValue = K.ones([3, 5]);
+      const vValue = ones([3, 5]);
       const feedDict =
           new FeedDict([{key: v as tfl.SymbolicTensor, value: vValue}]);
       expectTensorsClose(
@@ -171,7 +170,7 @@ describeMathCPUAndGPU('Executor', () => {
     const z2 = denseLayer3.apply(y) as tfl.SymbolicTensor;
 
     it('Calling execute with two fetches and diamond graph works', () => {
-      const xValue = K.ones([2, 2]);
+      const xValue = ones([2, 2]);
       const feedDict = new FeedDict([{key: x, value: xValue}]);
       let callCounter = 0;
       denseLayer1.setCallHook(() => {

--- a/src/engine/topology_test.ts
+++ b/src/engine/topology_test.ts
@@ -9,7 +9,7 @@
  */
 
 // tslint:disable:max-line-length
-import {scalar, Tensor, tensor1d, tensor2d, zeros} from '@tensorflow/tfjs-core';
+import {ones, scalar, Tensor, tensor1d, tensor2d, zeros} from '@tensorflow/tfjs-core';
 import * as K from '../backend/tfjs_backend';
 import * as tfl from '../index';
 import * as initializers from '../initializers';
@@ -72,11 +72,11 @@ describe('Node', () => {
       [new tfl.SymbolicTensor(DType.float32, [1], null, [], {})];
   const outputTensors =
       [new tfl.SymbolicTensor(DType.float32, [2, 2], null, [], {})];
-  const inputMasks = [K.zeros([1])];
-  const outputMasks = [K.zeros([1])];
+  const inputMasks = [zeros([1])];
+  const outputMasks = [zeros([1])];
   const inputShapes = [[1]];
   const outputShapes = [[1], [1]];
-  const callArgs = {mask: K.zeros([1])};
+  const callArgs = {mask: zeros([1])};
   const node = new Node(
       {
         outboundLayer,
@@ -223,13 +223,13 @@ describeMathCPU('Layer', () => {
     it('throws exception if it doesn`t support masking and a ' +
            'mask is passed in.',
        () => {
-         const mask = K.ones([1]);
+         const mask = ones([1]);
          expect(() => defaultLayer.computeMask([], mask))
              .toThrowError(/does not support masking/);
        });
 
     it('returns the same mask passed in if it supports masking', () => {
-      const mask = K.ones([1]);
+      const mask = ones([1]);
       defaultLayer.supportsMasking = true;
       expect(defaultLayer.computeMask([], mask)).toEqual(mask);
     });
@@ -302,7 +302,7 @@ describeMathCPU('Layer', () => {
        });
 
     it('initializes initialWeights if present.', () => {
-      const weights = [K.zeros([1])];
+      const weights = [zeros([1])];
       const layer = new LayerForTest({weights});
       expect(layer.initialWeights).toEqual(weights);
     });
@@ -394,7 +394,7 @@ describeMathCPU('Layer', () => {
       (layer as any).assertInputCompatibility(inputs);
     }
     const testInputs = [
-      () => K.ones([1]), () => [K.ones([1])],
+      () => ones([1]), () => [ones([1])],
       () => new tfl.SymbolicTensor(DType.float32, [1], null, [], {}),
       () => [new tfl.SymbolicTensor(DType.float32, [1], null, [], {})]
     ];
@@ -582,7 +582,7 @@ describeMathCPU('Layer', () => {
       const inputs = [
         new tfl.SymbolicTensor(
             DType.float32, [1], null, [], {}, 'first_symbolic_tensor'),
-        K.ones([1])
+        ones([1])
       ];
       expect(() => layer.apply(inputs as Tensor[]))
           .toThrowError(/must be all SymbolicTensors or all Tensors/);
@@ -607,7 +607,7 @@ describeMathCPU('Layer', () => {
 
   describe('apply() passed 1+ Tensors', () => {
     it('returns new values for output if the same as the input.', () => {
-      const anArray = K.ones([1]);
+      const anArray = ones([1]);
       // Test with both an Tensor and an array of Tensors.
       for (const inputs of [anArray, [anArray, anArray]]) {
         const layer = new LayerForTest({});
@@ -634,7 +634,7 @@ describeMathCPU('Layer', () => {
   describe('initialized with weights at construction time', () => {
     it('sets those weights after calling apply().', () => {
       const initialWeights = K.eye(2);
-      const arrayInput = K.zeros([1]);
+      const arrayInput = zeros([1]);
       const symbolicInput =
           new tfl.SymbolicTensor(DType.float32, [1], null, [], {});
       // Test with symbolic and concrete input.
@@ -644,7 +644,7 @@ describeMathCPU('Layer', () => {
         // tslint:disable-next-line:no-any
         spyOn((layer as any), 'build').and.callFake(() => {
           layer.built = true;
-          layer.trainableWeights = [new LayerVariable(K.zeros([2, 2]))];
+          layer.trainableWeights = [new LayerVariable(zeros([2, 2]))];
         });
         expect(layer.weights.length).toEqual(0);
         layer.apply(inputs);
@@ -701,10 +701,10 @@ describeMathCPU('Layer', () => {
            'as existing weights',
        () => {
          const layer = new LayerForTest({});
-         layer.trainableWeights = [new LayerVariable(K.zeros([2, 2]))];
-         const ones = K.ones([1]);
+         layer.trainableWeights = [new LayerVariable(zeros([2, 2]))];
+         const onesTensor = ones([1]);
          expect(() => layer.setWeights([
-           ones, ones
+           onesTensor, onesTensor
          ])).toThrowError(/with a weight list of length/);
        });
 
@@ -712,18 +712,18 @@ describeMathCPU('Layer', () => {
            'as existing weights',
        () => {
          const layer = new LayerForTest({});
-         const ones = K.ones([1]);
-         layer.trainableWeights = [new LayerVariable(K.zeros([2, 2]))];
-         expect(() => layer.setWeights([ones]))
+         const onesTensor = ones([1]);
+         layer.trainableWeights = [new LayerVariable(zeros([2, 2]))];
+         expect(() => layer.setWeights([onesTensor]))
              .toThrowError(/not compatible with provided weight shape/);
        });
 
     it('updates weights.', () => {
       const layer = new LayerForTest({});
-      const ones = K.ones([1]);
-      layer.trainableWeights = [new LayerVariable(K.zeros([1]))];
-      layer.setWeights([ones]);
-      expectTensorsClose(layer.trainableWeights[0].read(), ones);
+      const onesTensor = ones([1]);
+      layer.trainableWeights = [new LayerVariable(zeros([1]))];
+      layer.setWeights([onesTensor]);
+      expectTensorsClose(layer.trainableWeights[0].read(), onesTensor);
     });
   });
 
@@ -962,7 +962,7 @@ describeMathCPU('InputLayer', () => {
          'was initialized to.',
      () => {
        const inputLayer = tfl.layers.inputLayer({inputShape: [1]});
-       const inputs = K.ones([2, 2]);
+       const inputs = ones([2, 2]);
        expect(() => inputLayer.apply(inputs)).toThrowError();
      });
 
@@ -1271,9 +1271,9 @@ describeMathCPUAndGPU('Container', () => {
 
     const container =
         new ContainerForTest({inputs: [inputLayer], outputs: [output]});
-    const result = container.call(K.ones([1, 1, 6]), {}) as Tensor[];
+    const result = container.call(ones([1, 1, 6]), {}) as Tensor[];
     const resultShape = [1].concat(finalShape);
-    expectTensorsClose(result[0], K.ones(resultShape));
+    expectTensorsClose(result[0], ones(resultShape));
   });
 
   it('apply() executes all layers with concrete tensors.', () => {
@@ -1287,9 +1287,9 @@ describeMathCPUAndGPU('Container', () => {
 
     const container =
         new ContainerForTest({inputs: [inputLayer], outputs: [output]});
-    const result = container.apply(K.ones([1, 1, 6])) as Tensor;
+    const result = container.apply(ones([1, 1, 6])) as Tensor;
     const resultShape = [1].concat(finalShape);
-    expectTensorsClose(result, K.ones(resultShape));
+    expectTensorsClose(result, ones(resultShape));
   });
 
   it('apply() executes all layers with symbolic tensors.', () => {
@@ -1309,9 +1309,9 @@ describeMathCPUAndGPU('Container', () => {
     expect(symbolicResult instanceof tfl.SymbolicTensor).toEqual(true);
     const concreteResult = execute(
         symbolicResult as tfl.SymbolicTensor,
-        new FeedDict([{key: newInput, value: K.ones([1, 1, 6])}]));
+        new FeedDict([{key: newInput, value: ones([1, 1, 6])}]));
     const resultShape = [1].concat(finalShape);
-    expectTensorsClose(concreteResult as Tensor, K.ones(resultShape));
+    expectTensorsClose(concreteResult as Tensor, ones(resultShape));
   });
 
   it('computeOutputShape() computes the correct outputShape', () => {

--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -1362,7 +1362,7 @@ export class Model extends Container {
         }
       }
       for (let i = 0; i < outs.length; ++i) {
-        outs[i] = K.divide(outs[i], K.getScalar(numSamples)) as Scalar;
+        outs[i] = tfc.div(outs[i], K.getScalar(numSamples)) as Scalar;
       }
     }
     return outs;

--- a/src/engine/training_test.ts
+++ b/src/engine/training_test.ts
@@ -13,7 +13,7 @@
  */
 
 // tslint:disable:max-line-length
-import {abs, mean, Scalar, scalar, SGDOptimizer, Tensor, tensor1d, tensor2d, tensor3d, test_util, zeros} from '@tensorflow/tfjs-core';
+import {abs, mean, ones, Scalar, scalar, SGDOptimizer, Tensor, tensor1d, tensor2d, tensor3d, test_util, zeros} from '@tensorflow/tfjs-core';
 
 import * as K from '../backend/tfjs_backend';
 import {CustomCallback, CustomCallbackConfig, Logs} from '../callbacks';
@@ -116,20 +116,20 @@ describeMathCPU('standardizeInputData', () => {
 
 describeMathCPU('checkArrayLengths', () => {
   it('Batch mismatch in inputs', () => {
-    const inputs = [K.zeros([2, 1]), K.zeros([3, 1])];
-    const targets = [K.zeros([2, 1]), K.zeros([2, 1])];
+    const inputs = [zeros([2, 1]), zeros([3, 1])];
+    const targets = [zeros([2, 1]), zeros([2, 1])];
     expect(() => checkArrayLengths(inputs, targets))
         .toThrowError(/All input .* should have the same number of samples/);
   });
   it('Batch mismatch in targets', () => {
-    const inputs = [K.zeros([2, 1]), K.zeros([2, 1])];
-    const targets = [K.zeros([2, 1]), K.zeros([3, 1])];
+    const inputs = [zeros([2, 1]), zeros([2, 1])];
+    const targets = [zeros([2, 1]), zeros([3, 1])];
     expect(() => checkArrayLengths(inputs, targets))
         .toThrowError(/All target .* should have the same number of samples/);
   });
   it('Batch mismatch between inputs and targets', () => {
-    const inputs = [K.zeros([2, 1]), K.zeros([2, 1])];
-    const targets = [K.zeros([3, 1]), K.zeros([3, 1])];
+    const inputs = [zeros([2, 1]), zeros([2, 1])];
+    const targets = [zeros([3, 1]), zeros([3, 1])];
     expect(() => checkArrayLengths(inputs, targets))
         .toThrowError(
             /Input Tensors should have the same number of samples as target/);
@@ -196,9 +196,9 @@ describeMathCPUAndGPU('Model.predict', () => {
     const output = layer.apply(inputTensor) as tfl.SymbolicTensor;
     const model = new tfl.Model(
         {inputs: [inputTensor], outputs: [output], name: 'model1x1'});
-    const xs = K.ones([10, 3, 4]);
+    const xs = ones([10, 3, 4]);
     const ys = model.predict(xs, {batchSize: 4}) as Tensor;
-    expectTensorsClose(ys, K.ones([10, 2, 6]));
+    expectTensorsClose(ys, ones([10, 2, 6]));
   });
 
   it('1 input, 1 output, tensor as input argument', () => {
@@ -208,9 +208,9 @@ describeMathCPUAndGPU('Model.predict', () => {
     const output = layer.apply(inputTensor) as tfl.SymbolicTensor;
     const model = new tfl.Model(
         {inputs: [inputTensor], outputs: [output], name: 'model1x1'});
-    const xs = K.ones([10, 3, 4]);
+    const xs = ones([10, 3, 4]);
     const ys = model.predict(xs) as Tensor;
-    expectTensorsClose(ys, K.ones([10, 2, 6]));
+    expectTensorsClose(ys, ones([10, 2, 6]));
   });
 
   it('1 input as Array, 1 output', () => {
@@ -220,9 +220,9 @@ describeMathCPUAndGPU('Model.predict', () => {
     const output = layer.apply(inputTensor) as tfl.SymbolicTensor;
     const model = new tfl.Model(
         {inputs: [inputTensor], outputs: [output], name: 'model1x1'});
-    const xs = K.ones([10, 3, 4]);
+    const xs = ones([10, 3, 4]);
     const ys = model.predict([xs], {batchSize: 4}) as Tensor;
-    expectTensorsClose(ys, K.ones([10, 2, 6]));
+    expectTensorsClose(ys, ones([10, 2, 6]));
   });
 
   it('1 input, 2 outputs', () => {
@@ -234,11 +234,11 @@ describeMathCPUAndGPU('Model.predict', () => {
     const output2 = layer2.apply(output1) as tfl.SymbolicTensor;
     const model = new tfl.Model(
         {inputs: [inputTensor], outputs: [output1, output2], name: 'model1x2'});
-    const xs = K.ones([10, 3, 4]);
+    const xs = ones([10, 3, 4]);
     const ys = model.predict(xs, {batchSize: 4}) as Tensor[];
     expect(ys.length).toEqual(2);
-    expectTensorsClose(ys[0], K.ones([10, 2, 6]));
-    expectTensorsClose(ys[1], K.ones([10, 12]));
+    expectTensorsClose(ys[0], ones([10, 2, 6]));
+    expectTensorsClose(ys[1], ones([10, 12]));
   });
 
   it('2 inputs, 2 outputs', () => {
@@ -255,12 +255,12 @@ describeMathCPUAndGPU('Model.predict', () => {
       outputs: [output1, output2],
       name: 'model2x2'
     });
-    const xs1 = K.ones([10, 3, 4]);
-    const xs2 = K.ones([10, 3, 3]);
+    const xs1 = ones([10, 3, 4]);
+    const xs2 = ones([10, 3, 3]);
     const ys = model.predict([xs1, xs2], {batchSize: 4}) as Tensor[];
     expect(ys.length).toEqual(2);
-    expectTensorsClose(ys[0], K.ones([10, 2, 6]));
-    expectTensorsClose(ys[1], K.ones([10, 9]));
+    expectTensorsClose(ys[0], ones([10, 2, 6]));
+    expectTensorsClose(ys[1], ones([10, 9]));
   });
 
   it('Incorrect number of inputs leads to exception: 1 vs 2', () => {
@@ -270,7 +270,7 @@ describeMathCPUAndGPU('Model.predict', () => {
     const output = layer.apply(inputTensor) as tfl.SymbolicTensor;
     const model = new tfl.Model(
         {inputs: [inputTensor], outputs: [output], name: 'model_inc_1x1'});
-    const xs1 = K.ones([10, 3, 4]);
+    const xs1 = ones([10, 3, 4]);
 
     expect(() => model.predict([
       xs1, xs1
@@ -291,7 +291,7 @@ describeMathCPUAndGPU('Model.predict', () => {
       outputs: [output1, output2],
       name: 'model_inc_2x2'
     });
-    const xs1 = K.ones([10, 3, 4]);
+    const xs1 = ones([10, 3, 4]);
 
     expect(() => model.predict([
       xs1, xs1, xs1
@@ -305,7 +305,7 @@ describeMathCPUAndGPU('Model.predict', () => {
     const output = layer.apply(inputTensor) as tfl.SymbolicTensor;
     const model = new tfl.Model(
         {inputs: [inputTensor], outputs: [output], name: 'model_inc_1x1'});
-    const xs1 = K.ones([2, 4, 3]);
+    const xs1 = ones([2, 4, 3]);
 
     expect(() => model.predict(xs1))
         .toThrowError(/.*expected.* shape \[null,3,4\].*but got.*\[2,4,3\]/);
@@ -346,8 +346,8 @@ describeMathCPUAndGPU('Model.fit', () => {
         {units: 1, useBias, kernelInitializer: 'ones', kernelRegularizer});
     const output = layer.apply(inputTensor) as tfl.SymbolicTensor;
     model = new tfl.Model({inputs: [inputTensor], outputs: [output]});
-    inputs = K.ones([numSamples, inputSize]);
-    targets = K.ones([numSamples, 1]);
+    inputs = ones([numSamples, inputSize]);
+    targets = ones([numSamples, 1]);
   }
 
   function createDenseCategoricalModelAndData(useBias = false): void {
@@ -355,8 +355,8 @@ describeMathCPUAndGPU('Model.fit', () => {
         tfl.layers.dense({units: 2, useBias, kernelInitializer: 'ones'});
     const output = layer.apply(inputTensor) as tfl.SymbolicTensor;
     model = new tfl.Model({inputs: [inputTensor], outputs: [output]});
-    inputs = K.ones([numSamples, inputSize]);
-    targets = K.oneHot(K.ones([numSamples]), 2);
+    inputs = ones([numSamples, inputSize]);
+    targets = K.oneHot(ones([numSamples]), 2);
   }
 
   function createTwoLayerDenseModelAndData(useBias = false): [Layer, Layer] {
@@ -367,8 +367,8 @@ describeMathCPUAndGPU('Model.fit', () => {
     const output =
         layer2.apply(layer1.apply(inputTensor)) as tfl.SymbolicTensor;
     model = new tfl.Model({inputs: [inputTensor], outputs: [output]});
-    inputs = K.ones([numSamples, inputSize]);
-    targets = K.ones([numSamples, 1]);
+    inputs = ones([numSamples, inputSize]);
+    targets = ones([numSamples, 1]);
     return [layer1, layer2];
   }
 
@@ -381,10 +381,10 @@ describeMathCPUAndGPU('Model.fit', () => {
     const output2 = layer2.apply(inputTensor2) as tfl.SymbolicTensor;
     twoOutputModel = new tfl.Model(
         {inputs: [inputTensor1, inputTensor2], outputs: [output1, output2]});
-    inputs1 = K.ones([numSamples, inputSize1]);
-    inputs2 = K.ones([numSamples, inputSize2]);
-    targets1 = K.ones([numSamples, 1]);
-    targets2 = K.ones([numSamples, 1]);
+    inputs1 = ones([numSamples, inputSize1]);
+    inputs2 = ones([numSamples, inputSize2]);
+    targets1 = ones([numSamples, 1]);
+    targets2 = ones([numSamples, 1]);
   }
 
   it('1 input, 1 output, dense, 1 weight, string optimizer, 1 batch',
@@ -516,8 +516,8 @@ describeMathCPUAndGPU('Model.fit', () => {
         dense2.apply(dropout.apply(dense1.apply(input))) as tfl.SymbolicTensor;
     const model = new tfl.Model({inputs: input, outputs: output});
     model.compile({loss: 'meanSquaredError', optimizer: 'sgd'});
-    const x = K.ones([batchSize, inputSize]);
-    const y = K.ones([batchSize, 1]);
+    const x = ones([batchSize, inputSize]);
+    const y = ones([batchSize, 1]);
     model.fit(x, y, {batchSize, epochs: 1}).then(history => {
       done();
     });
@@ -687,8 +687,8 @@ describeMathCPUAndGPU('Model.fit', () => {
       metrics: ['accuracy'],
     });
     const history = await model.fit(
-        K.ones([dataSize, sequenceLength, inputSize]),
-        K.ones([dataSize, sequenceLength, outputSize]), {
+        ones([dataSize, sequenceLength, inputSize]),
+        ones([dataSize, sequenceLength, outputSize]), {
           batchSize,
           epochs: 1,
           validationSplit,
@@ -801,10 +801,10 @@ describeMathCPUAndGPU('Model.fit', () => {
         valLosses as number[], [386.35848999023438, 1808.7342529296875]);
     expectTensorsClose(
         layer1.getWeights()[0],
-        K.scalarTimesArray(scalar(-0.61341441), K.ones([4, 10])));
+        K.scalarTimesArray(scalar(-0.61341441), ones([4, 10])));
     expectTensorsClose(
         layer2.getWeights()[0],
-        K.scalarTimesArray(scalar(-1.77405429), K.ones([10, 1])));
+        K.scalarTimesArray(scalar(-1.77405429), ones([10, 1])));
 
     // Freeze the 1st layer and compile the model again.
     layer1.trainable = false;
@@ -822,11 +822,11 @@ describeMathCPUAndGPU('Model.fit', () => {
     // Expect no change in the value of layer1's kernel, due to the freezing.
     expectTensorsClose(
         layer1.getWeights()[0],
-        K.scalarTimesArray(scalar(-0.61341441), K.ones([4, 10])));
+        K.scalarTimesArray(scalar(-0.61341441), ones([4, 10])));
     // Expect change in the value of layer2's kernel.
     expectTensorsClose(
         layer2.getWeights()[0],
-        K.scalarTimesArray(scalar(-0.11295), K.ones([10, 1])));
+        K.scalarTimesArray(scalar(-0.11295), ones([10, 1])));
     done();
   });
 
@@ -1140,8 +1140,8 @@ describeMathCPUAndGPU('Model.fit with training-sensitive layers', () => {
         layer2.apply(layer1.apply(inputTensor)) as tfl.SymbolicTensor;
     const model = new tfl.Model({inputs: [inputTensor], outputs: [output]});
     model.compile({optimizer: 'sgd', loss: 'meanSquaredError'});
-    const xs = K.ones([4, 1]);
-    const ys = K.ones([4, 1]);
+    const xs = ones([4, 1]);
+    const ys = ones([4, 1]);
 
     // 1. Call fit: Dropout layer should be called twice, with training as
     // true.
@@ -1183,8 +1183,8 @@ describeMathCPUAndGPU('Model.evaluate', () => {
     model = new tfl.Model({inputs: input, outputs: output});
   }
   function prepData() {
-    x = K.ones([numExamples, inputSize]);
-    y = K.ones([numExamples, outputSize]);
+    x = ones([numExamples, inputSize]);
+    y = ones([numExamples, outputSize]);
   }
 
   it('Calling evaluate before compile leads to error', () => {

--- a/src/initializers.ts
+++ b/src/initializers.ts
@@ -371,7 +371,7 @@ export class VarianceScaling extends Initializer {
       const stddev = Math.sqrt(scale);
       if (dtype === DType.bool) {
         throw new NotImplementedError(
-            `truncatedNormal does not support dType bool.`);
+            `${this.getClassName()} does not support dType bool.`);
       }
       return truncatedNormal(shape, 0, stddev, dtype, this.seed);
     } else {

--- a/src/initializers.ts
+++ b/src/initializers.ts
@@ -9,7 +9,7 @@
  */
 
 // tslint:disable:max-line-length
-import {doc, scalar, Scalar, serialization, Tensor, Tensor2D} from '@tensorflow/tfjs-core';
+import {doc, ones, randomUniform, scalar, Scalar, serialization, Tensor, Tensor2D, truncatedNormal, zeros} from '@tensorflow/tfjs-core';
 
 import * as K from './backend/tfjs_backend';
 import {checkDataFormat, DataFormat} from './common';
@@ -63,7 +63,7 @@ export class Zeros extends Initializer {
   static className = 'Zeros';
 
   apply(shape: Shape, dtype?: DType): Tensor {
-    return K.zeros(shape, dtype);
+    return zeros(shape, dtype);
   }
 }
 serialization.SerializationMap.register(Zeros);
@@ -75,7 +75,7 @@ export class Ones extends Initializer {
   static className = 'Ones';
 
   apply(shape: Shape, dtype?: DType): Tensor {
-    return K.ones(shape, dtype);
+    return ones(shape, dtype);
   }
 }
 serialization.SerializationMap.register(Ones);
@@ -97,7 +97,7 @@ export class Constant extends Initializer {
   }
 
   apply(shape: Shape, dtype?: DType): Tensor {
-    return K.scalarTimesArray(scalar(this.value), K.ones(shape, dtype));
+    return K.scalarTimesArray(scalar(this.value), ones(shape, dtype));
   }
 
   getConfig(): serialization.ConfigDict {
@@ -140,7 +140,7 @@ export class RandomUniform extends Initializer {
   }
 
   apply(shape: Shape, dtype?: DType): Tensor {
-    return K.randomUniform(shape, this.minval, this.maxval, dtype, this.seed);
+    return randomUniform(shape, this.minval, this.maxval, dtype);
   }
 
   getConfig(): serialization.ConfigDict {
@@ -221,7 +221,11 @@ export class TruncatedNormal extends Initializer {
   }
 
   apply(shape: Shape, dtype?: DType): Tensor {
-    return K.truncatedNormal(shape, this.mean, this.stddev, dtype, this.seed);
+    if (dtype === DType.bool) {
+      throw new NotImplementedError(
+          `truncatedNormal does not support dType bool.`);
+    }
+    return truncatedNormal(shape, this.mean, this.stddev, dtype, this.seed);
   }
 
   getConfig(): serialization.ConfigDict {
@@ -365,10 +369,14 @@ export class VarianceScaling extends Initializer {
 
     if (this.distribution === 'normal') {
       const stddev = Math.sqrt(scale);
-      return K.truncatedNormal(shape, 0, stddev, dtype, this.seed);
+      if (dtype === DType.bool) {
+        throw new NotImplementedError(
+            `truncatedNormal does not support dType bool.`);
+      }
+      return truncatedNormal(shape, 0, stddev, dtype, this.seed);
     } else {
       const limit = Math.sqrt(3 * scale);
-      return K.randomUniform(shape, -limit, limit, dtype, this.seed);
+      return randomUniform(shape, -limit, limit, dtype);
     }
   }
 

--- a/src/layers/core_test.ts
+++ b/src/layers/core_test.ts
@@ -13,7 +13,7 @@
  */
 
 // tslint:disable:max-line-length
-import {scalar, Tensor, tensor2d, tensor3d, tensor4d} from '@tensorflow/tfjs-core';
+import {ones, scalar, Tensor, tensor2d, tensor3d, tensor4d, zeros} from '@tensorflow/tfjs-core';
 
 import {ActivationIdentifier} from '../activations';
 import * as K from '../backend/tfjs_backend';
@@ -66,7 +66,7 @@ describeMathCPUAndGPU('Dropout Layer', () => {
           const testTitle = `training=${training}, dropoutRate=${rate}, ` +
               `noiseShape=${JSON.stringify(noiseShape)}`;
           it(testTitle, () => {
-            const x = K.ones(inputShape);
+            const x = ones(inputShape);
             const dropoutLayer = tfl.layers.dropout({rate, noiseShape});
             const y = dropoutLayer.apply(x, {training}) as Tensor;
             expect(x.dtype).toEqual(y.dtype);
@@ -218,7 +218,7 @@ describeMathCPUAndGPU('Dense Layer: Tensor', () => {
                  `activation=${activation}, ` +
                  `inputLastDim=${JSON.stringify(inputLastDim)}`,
              () => {
-               const input = K.ones([2, inputLastDim]);
+               const input = ones([2, inputLastDim]);
                const denseLayer = tfl.layers.dense({
                  units,
                  useBias,
@@ -253,9 +253,9 @@ describeMathCPUAndGPU('Dense Layer: Tensor', () => {
   }
 
   it('Calling apply again with incompatible shape leads to error', () => {
-    const input1 = K.ones([2, 2]);  // First call.
-    const input2 = K.ones([3, 2]);  // Okay.
-    const input3 = K.ones([3, 3]);  // Leads to error.
+    const input1 = ones([2, 2]);  // First call.
+    const input2 = ones([3, 2]);  // Okay.
+    const input3 = ones([3, 3]);  // Leads to error.
 
     const denseLayer = tfl.layers.dense({units: 4, kernelInitializer: 'ones'});
     expectTensorsClose(
@@ -268,7 +268,7 @@ describeMathCPUAndGPU('Dense Layer: Tensor', () => {
   });
   it('Calling apply with compatible symbolic input after Tensor input works',
      () => {
-       const concreteInput = K.ones([2, 2]);
+       const concreteInput = ones([2, 2]);
        const symbolicInput =
            new tfl.SymbolicTensor(DType.float32, [2, 2], null, [], null);
        const denseLayer =
@@ -285,7 +285,7 @@ describeMathCPUAndGPU('Dense Layer: Tensor', () => {
        expect(symbolicOuptut.inputs).toEqual([symbolicInput]);
      });
   it('Calling apply with incompatible symbolic input after Tensor', () => {
-    const concreteInput = K.ones([2, 2]);
+    const concreteInput = ones([2, 2]);
     const symbolicInput =
         new tfl.SymbolicTensor(DType.float32, [2, 3], null, [], null);
     const denseLayer = tfl.layers.dense({units: 4, kernelInitializer: 'ones'});
@@ -382,15 +382,15 @@ describeMathCPUAndGPU('Activation Layer: Tensor', () => {
   const inputShape = [1];
 
   it('linear', () => {
-    const x = K.scalarTimesArray(scalar(10), K.ones(inputShape));
+    const x = K.scalarTimesArray(scalar(10), ones(inputShape));
     const layer = new Activation({activation: 'linear'});
     const output = layer.apply(x) as Tensor;
     expectTensorsClose(output, x);
   });
 
   it('relu', () => {
-    const x = K.scalarTimesArray(scalar(-5), K.ones(inputShape));
-    const expectedValue = K.zeros(inputShape);
+    const x = K.scalarTimesArray(scalar(-5), ones(inputShape));
+    const expectedValue = zeros(inputShape);
     const layer = new Activation({activation: 'relu'});
     const output = layer.apply(x) as Tensor;
     expectTensorsClose(output, expectedValue);
@@ -398,17 +398,17 @@ describeMathCPUAndGPU('Activation Layer: Tensor', () => {
 
   it('sigmoid', () => {
     const val = 10;
-    const x = K.scalarTimesArray(scalar(val), K.ones(inputShape));
+    const x = K.scalarTimesArray(scalar(val), ones(inputShape));
     const expectedValue = K.scalarTimesArray(
-        scalar(1 / (1 + Math.exp(-1 * val))), K.ones(inputShape));
+        scalar(1 / (1 + Math.exp(-1 * val))), ones(inputShape));
     const layer = new Activation({activation: 'sigmoid'});
     const output = layer.apply(x) as Tensor;
     expectTensorsClose(output, expectedValue);
   });
 
   it('softmax', () => {
-    const x = K.scalarTimesArray(scalar(10), K.ones(inputShape));
-    const expectedValue = K.ones(inputShape);
+    const x = K.scalarTimesArray(scalar(10), ones(inputShape));
+    const expectedValue = ones(inputShape);
     const layer = new Activation({activation: 'softmax'});
     const output = layer.apply(x) as Tensor;
     expectTensorsClose(output, expectedValue);

--- a/src/layers/merge.ts
+++ b/src/layers/merge.ts
@@ -157,13 +157,13 @@ export abstract class Merge extends Layer {
             const newShape = xShape.slice(1).concat([batchSize]);
             let xTransposed = K.reshape(
                 x, [batchSize].concat(mathUtils.arrayProd(xShape.slice(1))));
-            xTransposed = K.permuteDimensions(xTransposed, [1, 0]);
+            xTransposed = tfc.transpose(xTransposed, [1, 0]);
             xTransposed = K.reshape(xTransposed, newShape);
             reshapedInputs.push(xTransposed);
             transposed = true;
           } else if (xNDim > 1) {
             const dims = mathUtils.range(1, xNDim).concat([0]);
-            reshapedInputs.push(K.permuteDimensions(x, dims));
+            reshapedInputs.push(tfc.transpose(x, dims));
             transposed = true;
           } else {
             // We don't transpose inputs if they are 1D vectors or scalars.
@@ -182,11 +182,10 @@ export abstract class Merge extends Layer {
             const newShape =
                 [batchSize].concat(yShape.slice(0, yShape.length - 1));
             y = K.reshape(
-                K.permuteDimensions(K.reshape(y, [-1, batchSize]), [1, 0]),
-                newShape);
+                tfc.transpose(K.reshape(y, [-1, batchSize]), [1, 0]), newShape);
           } else if (yNDim > 1) {
             const dims = [yNDim - 1].concat(mathUtils.range(0, yNDim - 1));
-            y = K.permuteDimensions(y, dims);
+            y = tfc.transpose(y, dims);
           }
         }
         return y;
@@ -252,7 +251,7 @@ export class Add extends Merge {
   }
 
   protected mergeFunction(inputs: Tensor[]): Tensor {
-    let output = K.zeros(inputs[0].shape);
+    let output = tfc.zeros(inputs[0].shape);
     for (const input of inputs) {
       output = tfc.add(output, input);
     }
@@ -342,9 +341,9 @@ export class Multiply extends Merge {
   }
 
   protected mergeFunction(inputs: Tensor[]): Tensor {
-    let output = K.ones(inputs[0].shape);
+    let output = tfc.ones(inputs[0].shape);
     for (const input of inputs) {
-      output = K.multiply(output, input);
+      output = tfc.mul(output, input);
     }
     return output;
   }
@@ -431,7 +430,7 @@ export class Average extends Merge {
   }
 
   protected mergeFunction(inputs: Tensor[]): Tensor {
-    let output = K.zeros(inputs[0].shape);
+    let output = tfc.zeros(inputs[0].shape);
     for (const input of inputs) {
       output = tfc.add(output, input);
     }

--- a/src/layers/pooling.ts
+++ b/src/layers/pooling.ts
@@ -13,7 +13,7 @@
  */
 
 // tslint:disable:max-line-length
-import {max, serialization, Tensor} from '@tensorflow/tfjs-core';
+import {max, serialization, squeeze, Tensor} from '@tensorflow/tfjs-core';
 
 import * as K from '../backend/tfjs_backend';
 import {checkDataFormat, checkPaddingMode, DataFormat, PaddingMode} from '../common';
@@ -86,7 +86,7 @@ export abstract class Pooling1D extends Layer {
         generic_utils.getExactlyOneTensor(inputs), [this.poolSize[0], 1],
         [this.strides[0], 1], this.padding, 'channelsLast');
     // Remove dummy last dimension.
-    return K.squeeze(output, 2);
+    return squeeze(output, [2]);
   }
 
   getConfig(): serialization.ConfigDict {

--- a/src/layers/recurrent_test.ts
+++ b/src/layers/recurrent_test.ts
@@ -81,67 +81,67 @@ describeMathCPU('RNN-Layer', () => {
   });
 
   it('computeOutputShape: 1 state, returnSequences=false, returnState=false',
-    () => {
-      const cell = new RNNCellForTest(5);
-      const rnn = tfl.layers.rnn({cell});
-      const inputShape = [4, 3, 2];
-      expect(rnn.computeOutputShape(inputShape)).toEqual([4, 5]);
-    });
+     () => {
+       const cell = new RNNCellForTest(5);
+       const rnn = tfl.layers.rnn({cell});
+       const inputShape = [4, 3, 2];
+       expect(rnn.computeOutputShape(inputShape)).toEqual([4, 5]);
+     });
 
   it('computeOutputShape: 1 state, returnSequences=true, returnState=false',
-    () => {
-      const cell = new RNNCellForTest([5, 6]);
-      const rnn = tfl.layers.rnn({cell, returnSequences: true});
-      const inputShape = [4, 3, 2];
-      expect(rnn.computeOutputShape(inputShape)).toEqual([4, 3, 5]);
-    });
+     () => {
+       const cell = new RNNCellForTest([5, 6]);
+       const rnn = tfl.layers.rnn({cell, returnSequences: true});
+       const inputShape = [4, 3, 2];
+       expect(rnn.computeOutputShape(inputShape)).toEqual([4, 3, 5]);
+     });
 
   it('computeOutputShape: 1 state, returnSequences=true, returnState=true',
-    () => {
-      const cell = new RNNCellForTest(6);
-      const rnn =
-        tfl.layers.rnn({cell, returnSequences: true, returnState: true});
-      const inputShape = [4, 3, 2];
-      expect(rnn.computeOutputShape(inputShape)).toEqual([[4, 3, 6], [4, 6]]);
-    });
+     () => {
+       const cell = new RNNCellForTest(6);
+       const rnn =
+           tfl.layers.rnn({cell, returnSequences: true, returnState: true});
+       const inputShape = [4, 3, 2];
+       expect(rnn.computeOutputShape(inputShape)).toEqual([[4, 3, 6], [4, 6]]);
+     });
 
   it('computeOutputShape: 2 states, returnSequences=true, returnState=true',
-    () => {
-      const cell = new RNNCellForTest([5, 6]);
-      const rnn =
-        tfl.layers.rnn({cell, returnSequences: true, returnState: true});
-      const inputShape = [4, 3, 2];
-      expect(rnn.computeOutputShape(inputShape)).toEqual([
-        [4, 3, 5], [4, 5], [4, 6]
-      ]);
-    });
+     () => {
+       const cell = new RNNCellForTest([5, 6]);
+       const rnn =
+           tfl.layers.rnn({cell, returnSequences: true, returnState: true});
+       const inputShape = [4, 3, 2];
+       expect(rnn.computeOutputShape(inputShape)).toEqual([
+         [4, 3, 5], [4, 5], [4, 6]
+       ]);
+     });
 
   it('apply: Symbolic: 1 state, returnSequences=false, returnState=false',
-    () => {
-      const cell = new RNNCellForTest(6);
-      const rnn = tfl.layers.rnn({cell});
-      const input =
-        new tfl.SymbolicTensor(DType.float32, [16, 10, 8], null, [], null);
-      const output = rnn.apply(input) as tfl.SymbolicTensor;
-      expect(output.shape).toEqual([16, 6]);
-    });
+     () => {
+       const cell = new RNNCellForTest(6);
+       const rnn = tfl.layers.rnn({cell});
+       const input =
+           new tfl.SymbolicTensor(DType.float32, [16, 10, 8], null, [], null);
+       const output = rnn.apply(input) as tfl.SymbolicTensor;
+       expect(output.shape).toEqual([16, 6]);
+     });
 
   it('apply: Symbolic: 1 state, returnSequences=true, returnState=false',
-    () => {
-      const cell = new RNNCellForTest(6);
-      const rnn = tfl.layers.rnn({cell, returnSequences: true});
-      const input =
-        new tfl.SymbolicTensor(DType.float32, [16, 10, 8], null, [], null);
-      const output = rnn.apply(input) as tfl.SymbolicTensor;
-      expect(output.shape).toEqual([16, 10, 6]);
-    });
+     () => {
+       const cell = new RNNCellForTest(6);
+       const rnn = tfl.layers.rnn({cell, returnSequences: true});
+       const input =
+           new tfl.SymbolicTensor(DType.float32, [16, 10, 8], null, [], null);
+       const output = rnn.apply(input) as tfl.SymbolicTensor;
+       expect(output.shape).toEqual([16, 10, 6]);
+     });
 
   it('apply: Symbolic: 1 state, returnSequences=true, returnState=true', () => {
     const cell = new RNNCellForTest(6);
     const rnn =
-      tfl.layers.rnn({cell, returnSequences: true, returnState: true});
+        tfl.layers.rnn({cell, returnSequences: true, returnState: true});
     const input =
-      new tfl.SymbolicTensor(DType.float32, [16, 10, 8], null, [], null);
+        new tfl.SymbolicTensor(DType.float32, [16, 10, 8], null, [], null);
     const output = rnn.apply(input) as tfl.SymbolicTensor[];
     expect(output.length).toEqual(2);
     expect(output[0].shape).toEqual([16, 10, 6]);
@@ -149,31 +149,31 @@ describeMathCPU('RNN-Layer', () => {
   });
 
   it('apply: Symbolic: 1 state, returnSequences=false, returnState=true',
-    () => {
-      const cell = new RNNCellForTest(6);
-      const rnn =
-        tfl.layers.rnn({cell, returnSequences: false, returnState: true});
-      const input =
-        new tfl.SymbolicTensor(DType.float32, [16, 10, 8], null, [], null);
-      const output = rnn.apply(input) as tfl.SymbolicTensor[];
-      expect(output.length).toEqual(2);
-      expect(output[0].shape).toEqual([16, 6]);
-      expect(output[1].shape).toEqual([16, 6]);
-    });
+     () => {
+       const cell = new RNNCellForTest(6);
+       const rnn =
+           tfl.layers.rnn({cell, returnSequences: false, returnState: true});
+       const input =
+           new tfl.SymbolicTensor(DType.float32, [16, 10, 8], null, [], null);
+       const output = rnn.apply(input) as tfl.SymbolicTensor[];
+       expect(output.length).toEqual(2);
+       expect(output[0].shape).toEqual([16, 6]);
+       expect(output[1].shape).toEqual([16, 6]);
+     });
 
   it('apply: Symbolic: 2 states, returnSequences=true, returnState=true',
-    () => {
-      const cell = new RNNCellForTest([5, 6]);
-      const rnn =
-        tfl.layers.rnn({cell, returnSequences: true, returnState: true});
-      const input =
-        new tfl.SymbolicTensor(DType.float32, [16, 10, 8], null, [], null);
-      const output = rnn.apply(input) as tfl.SymbolicTensor[];
-      expect(output.length).toEqual(3);
-      expect(output[0].shape).toEqual([16, 10, 5]);
-      expect(output[1].shape).toEqual([16, 5]);
-      expect(output[2].shape).toEqual([16, 6]);
-    });
+     () => {
+       const cell = new RNNCellForTest([5, 6]);
+       const rnn =
+           tfl.layers.rnn({cell, returnSequences: true, returnState: true});
+       const input =
+           new tfl.SymbolicTensor(DType.float32, [16, 10, 8], null, [], null);
+       const output = rnn.apply(input) as tfl.SymbolicTensor[];
+       expect(output.length).toEqual(3);
+       expect(output[0].shape).toEqual([16, 10, 5]);
+       expect(output[1].shape).toEqual([16, 5]);
+       expect(output[2].shape).toEqual([16, 6]);
+     });
 });
 
 describeMathCPUAndGPU('RNN-Layer-Math', () => {
@@ -200,127 +200,127 @@ describeMathCPUAndGPU('RNN-Layer-Math', () => {
     const cell = new RNNCellForTest(4);
     const rnn = tfl.layers.rnn({cell});
     const inputs = tensor3d(
-      [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
+        [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
     const outputs = rnn.apply(inputs) as Tensor;
     expectTensorsClose(
-      outputs, K.scalarTimesArray(scalar(-57.75), ones([2, 4])));
+        outputs, K.scalarTimesArray(scalar(-57.75), ones([2, 4])));
   });
 
   it('apply: 1 state: returnSequences=true, returnState=false', () => {
     const cell = new RNNCellForTest(3);
     const rnn = tfl.layers.rnn({cell, returnSequences: true});
     const inputs = tensor3d(
-      [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
+        [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
     const outputs = rnn.apply(inputs) as Tensor;
     expectTensorsClose(
-      outputs,
-      tensor3d(
-        [
-          [
-            [-8.25, -8.25, -8.25], [-27.5, -27.5, -27.5],
-            [-57.75, -57.75, -57.75]
-          ],
-          [
-            [-8.25, -8.25, -8.25], [-27.5, -27.5, -27.5],
-            [-57.75, -57.75, -57.75]
-          ],
-        ],
-        [2, 3, 3]));
+        outputs,
+        tensor3d(
+            [
+              [
+                [-8.25, -8.25, -8.25], [-27.5, -27.5, -27.5],
+                [-57.75, -57.75, -57.75]
+              ],
+              [
+                [-8.25, -8.25, -8.25], [-27.5, -27.5, -27.5],
+                [-57.75, -57.75, -57.75]
+              ],
+            ],
+            [2, 3, 3]));
   });
 
   it('apply: 1 state: returnSequences=true, returnState=true', () => {
     const cell = new RNNCellForTest(3);
     const rnn =
-      tfl.layers.rnn({cell, returnSequences: true, returnState: true});
+        tfl.layers.rnn({cell, returnSequences: true, returnState: true});
     const inputs = tensor3d(
-      [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
+        [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
     const outputs = rnn.apply(inputs) as Tensor[];
     expect(outputs.length).toEqual(2);
     expectTensorsClose(
-      outputs[0],
-      tensor3d(
-        [
-          [
-            [-8.25, -8.25, -8.25], [-27.5, -27.5, -27.5],
-            [-57.75, -57.75, -57.75]
-          ],
-          [
-            [-8.25, -8.25, -8.25], [-27.5, -27.5, -27.5],
-            [-57.75, -57.75, -57.75]
-          ],
-        ],
-        [2, 3, 3]));
+        outputs[0],
+        tensor3d(
+            [
+              [
+                [-8.25, -8.25, -8.25], [-27.5, -27.5, -27.5],
+                [-57.75, -57.75, -57.75]
+              ],
+              [
+                [-8.25, -8.25, -8.25], [-27.5, -27.5, -27.5],
+                [-57.75, -57.75, -57.75]
+              ],
+            ],
+            [2, 3, 3]));
     expectTensorsClose(
-      outputs[1],
-      tensor2d([[57.75, 57.75, 57.75], [57.75, 57.75, 57.75]], [2, 3]));
+        outputs[1],
+        tensor2d([[57.75, 57.75, 57.75], [57.75, 57.75, 57.75]], [2, 3]));
   });
 
   it('apply: 2 states: returnSequences=true, returnState=true', () => {
     const cell = new RNNCellForTest([3, 4]);
     const rnn =
-      tfl.layers.rnn({cell, returnSequences: true, returnState: true});
+        tfl.layers.rnn({cell, returnSequences: true, returnState: true});
     const inputs = tensor3d(
-      [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
+        [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
     const outputs = rnn.apply(inputs) as Tensor[];
     expect(outputs.length).toEqual(3);
     expectTensorsClose(
-      outputs[0],
-      tensor3d(
-        [
-          [
-            [-8.25, -8.25, -8.25], [-27.5, -27.5, -27.5],
-            [-57.75, -57.75, -57.75]
-          ],
-          [
-            [-8.25, -8.25, -8.25], [-27.5, -27.5, -27.5],
-            [-57.75, -57.75, -57.75]
-          ],
-        ],
-        [2, 3, 3]));
+        outputs[0],
+        tensor3d(
+            [
+              [
+                [-8.25, -8.25, -8.25], [-27.5, -27.5, -27.5],
+                [-57.75, -57.75, -57.75]
+              ],
+              [
+                [-8.25, -8.25, -8.25], [-27.5, -27.5, -27.5],
+                [-57.75, -57.75, -57.75]
+              ],
+            ],
+            [2, 3, 3]));
     expectTensorsClose(
-      outputs[1],
-      tensor2d([[57.75, 57.75, 57.75], [57.75, 57.75, 57.75]], [2, 3]));
+        outputs[1],
+        tensor2d([[57.75, 57.75, 57.75], [57.75, 57.75, 57.75]], [2, 3]));
     expectTensorsClose(
-      outputs[2],
-      tensor2d(
-        [[57.75, 57.75, 57.75, 57.75], [57.75, 57.75, 57.75, 57.75]],
-        [2, 4]));
+        outputs[2],
+        tensor2d(
+            [[57.75, 57.75, 57.75, 57.75], [57.75, 57.75, 57.75, 57.75]],
+            [2, 4]));
   });
 
   it('call: with 1 initialState', () => {
     const cell = new RNNCellForTest(4);
     const rnn = tfl.layers.rnn({cell});
     const inputs = tensor3d(
-      [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
+        [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
     const outputs =
-      rnn.apply(inputs, { 'initialState': [ones([2, 4])] }) as Tensor;
+        rnn.apply(inputs, {'initialState': [ones([2, 4])]}) as Tensor;
     expectTensorsClose(
-      outputs, K.scalarTimesArray(scalar(-58.75), ones([2, 4])));
+        outputs, K.scalarTimesArray(scalar(-58.75), ones([2, 4])));
   });
 
   it('call: with 2 initialStates', () => {
     const cell = new RNNCellForTest([4, 5]);
     const rnn = tfl.layers.rnn({cell, returnState: true});
     const inputs = tensor3d(
-      [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
+        [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
     const outputs = rnn.apply(inputs, {
       'initialState':
-        [ones([2, 4]), K.scalarTimesArray(scalar(2), ones([2, 5]))]
+          [ones([2, 4]), K.scalarTimesArray(scalar(2), ones([2, 5]))]
     }) as Tensor[];
     expect(outputs.length).toEqual(3);
     expectTensorsClose(
-      outputs[0], K.scalarTimesArray(scalar(-58.75), ones([2, 4])));
+        outputs[0], K.scalarTimesArray(scalar(-58.75), ones([2, 4])));
     expectTensorsClose(
-      outputs[1], K.scalarTimesArray(scalar(58.75), ones([2, 4])));
+        outputs[1], K.scalarTimesArray(scalar(58.75), ones([2, 4])));
     expectTensorsClose(
-      outputs[2], K.scalarTimesArray(scalar(59.75), ones([2, 5])));
+        outputs[2], K.scalarTimesArray(scalar(59.75), ones([2, 5])));
   });
 
   it('call with incorrect number of initialStates leads to ValueError', () => {
     const cell = new RNNCellForTest([4, 5]);
     const rnn = tfl.layers.rnn({cell, returnState: true});
     const inputs = tensor3d(
-      [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
+        [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
     expect(() => rnn.apply(inputs, {
       'initialState': [ones([2, 4])]
     })).toThrowError(/An initialState was passed that is not compatible with/);
@@ -330,7 +330,7 @@ describeMathCPUAndGPU('RNN-Layer-Math', () => {
 describeMathCPU('SimpleRNN Symbolic', () => {
   it('returnSequences=false, returnState=false', () => {
     const input =
-      new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
+        new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
     const simpleRNN = tfl.layers.simpleRNN({units: 5});
     const output = simpleRNN.apply(input) as tfl.SymbolicTensor;
     expect(output.shape).toEqual([9, 5]);
@@ -338,7 +338,7 @@ describeMathCPU('SimpleRNN Symbolic', () => {
 
   it('returnSequences=false, returnState=true', () => {
     const input =
-      new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
+        new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
     const simpleRNN = tfl.layers.simpleRNN({units: 5, returnState: true});
     const output = simpleRNN.apply(input) as tfl.SymbolicTensor[];
     expect(output.length).toEqual(2);
@@ -348,7 +348,7 @@ describeMathCPU('SimpleRNN Symbolic', () => {
 
   it('returnSequences=true, returnState=false', () => {
     const input =
-      new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
+        new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
     const simpleRNN = tfl.layers.simpleRNN({units: 5, returnSequences: true});
     const output = simpleRNN.apply(input) as tfl.SymbolicTensor;
     expect(output.shape).toEqual([9, 10, 5]);
@@ -356,7 +356,7 @@ describeMathCPU('SimpleRNN Symbolic', () => {
 
   it('returnSequences=true, returnState=true', () => {
     const input =
-      new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
+        new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
     const simpleRNN = tfl.layers.simpleRNN({
       units: 5,
       returnSequences: true,
@@ -381,7 +381,7 @@ describeMathCPUAndGPU('SimpleRNN Tensor', () => {
   const activations = ['linear', 'tanh'];
   for (const activation of activations) {
     const testTitle =
-      `returnSequences=false, returnState=false, useBias=true, ${activation}`;
+        `returnSequences=false, returnState=false, useBias=true, ${activation}`;
     it(testTitle, () => {
       const timeSteps = 1;
       const simpleRNN = tfl.layers.simpleRNN({
@@ -398,16 +398,16 @@ describeMathCPUAndGPU('SimpleRNN Tensor', () => {
         expectedElementValue = Math.tanh(expectedElementValue);
       }
       expectTensorsClose(
-        output,
-        K.scalarTimesArray(
-          scalar(expectedElementValue), ones([batchSize, units])));
+          output,
+          K.scalarTimesArray(
+              scalar(expectedElementValue), ones([batchSize, units])));
     });
   }
 
   const returnStateValues = [false, true];
   for (const returnState of returnStateValues) {
     const testTitle = `returnSequences=true, ` +
-      `returnState=${returnState}, useBias=true, linear`;
+        `returnState=${returnState}, useBias=true, linear`;
     it(testTitle, () => {
       const timeSteps = 2;
       const simpleRNN = tfl.layers.simpleRNN({
@@ -436,14 +436,14 @@ describeMathCPUAndGPU('SimpleRNN Tensor', () => {
       const outputT0 = K.sliceAlongFirstAxis(timeMajorOutput, 0, 1);
       const outputT1 = K.sliceAlongFirstAxis(timeMajorOutput, 1, 1);
       expectTensorsClose(
-        outputT0,
-        K.scalarTimesArray(
-          scalar(inputSize + 1), ones([1, batchSize, units])));
+          outputT0,
+          K.scalarTimesArray(
+              scalar(inputSize + 1), ones([1, batchSize, units])));
       expectTensorsClose(
-        outputT1,
-        K.scalarTimesArray(
-          scalar((inputSize + 1) * (units + 1)),
-          ones([1, batchSize, units])));
+          outputT1,
+          K.scalarTimesArray(
+              scalar((inputSize + 1) * (units + 1)),
+              ones([1, batchSize, units])));
       if (returnState) {
         expectTensorsClose(finalState, outputT1.reshape([batchSize, units]));
       }
@@ -502,27 +502,27 @@ describeMathCPUAndGPU('SimpleRNN Tensor', () => {
     dense.apply(simpleRNN.apply(x));
     const lossFn = () => {
       return K.mean(metrics.mse(y, dense.apply(simpleRNN.apply(x)) as Tensor))
-        .asScalar();
+          .asScalar();
     };
     for (let i = 0; i < 2; ++i) {
       sgd.minimize(lossFn);
     }
     expectTensorsClose(
-      simpleRNN.getWeights()[0],
-      K.scalarTimesArray(scalar(0.8484658), ones([4, 1])));
+        simpleRNN.getWeights()[0],
+        K.scalarTimesArray(scalar(0.8484658), ones([4, 1])));
     expectTensorsClose(
-      simpleRNN.getWeights()[1],
-      K.scalarTimesArray(scalar(0.8484799), ones([1, 1])));
+        simpleRNN.getWeights()[1],
+        K.scalarTimesArray(scalar(0.8484799), ones([1, 1])));
     expectTensorsClose(
-      dense.getWeights()[0],
-      K.scalarTimesArray(scalar(80.967026), ones([1, 1])));
+        dense.getWeights()[0],
+        K.scalarTimesArray(scalar(80.967026), ones([1, 1])));
   });
 });
 
 describeMathCPU('GRU Symbolic', () => {
   it('returnSequences=false, returnState=false', () => {
     const input =
-      new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
+        new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
     const gru = tfl.layers.gru({units: 5});
     const output = gru.apply(input) as tfl.SymbolicTensor;
     expect(output.shape).toEqual([9, 5]);
@@ -530,7 +530,7 @@ describeMathCPU('GRU Symbolic', () => {
 
   it('returnSequences=false, returnState=true', () => {
     const input =
-      new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
+        new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
     const gru = tfl.layers.gru({units: 5, returnState: true});
     const output = gru.apply(input) as tfl.SymbolicTensor[];
     expect(output.length).toEqual(2);
@@ -540,7 +540,7 @@ describeMathCPU('GRU Symbolic', () => {
 
   it('returnSequences=true, returnState=false', () => {
     const input =
-      new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
+        new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
     const gru = tfl.layers.gru({units: 5, returnSequences: true});
     const output = gru.apply(input) as tfl.SymbolicTensor;
     expect(output.shape).toEqual([9, 10, 5]);
@@ -548,7 +548,7 @@ describeMathCPU('GRU Symbolic', () => {
 
   it('returnSequences=true, returnState=true', () => {
     const input =
-      new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
+        new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
     const gru = tfl.layers.gru({
       units: 5,
       returnSequences: true,
@@ -561,17 +561,17 @@ describeMathCPU('GRU Symbolic', () => {
   });
 
   it('trainableWeights, nonTrainableWeights and weights give correct outputs',
-    () => {
-      const input =
-        new tfl.SymbolicTensor(DType.float32, [2, 3, 4], null, [], null);
-      const gru = tfl.layers.gru({units: 5, returnState: true});
-      gru.apply(input);
-      expect(gru.trainable).toEqual(true);
-      // Trainable weights: kernel, recurrent kernel and bias.
-      expect(gru.trainableWeights.length).toEqual(3);
-      expect(gru.nonTrainableWeights.length).toEqual(0);
-      expect(gru.weights.length).toEqual(3);
-    });
+     () => {
+       const input =
+           new tfl.SymbolicTensor(DType.float32, [2, 3, 4], null, [], null);
+       const gru = tfl.layers.gru({units: 5, returnState: true});
+       gru.apply(input);
+       expect(gru.trainable).toEqual(true);
+       // Trainable weights: kernel, recurrent kernel and bias.
+       expect(gru.trainableWeights.length).toEqual(3);
+       expect(gru.nonTrainableWeights.length).toEqual(0);
+       expect(gru.weights.length).toEqual(3);
+     });
 });
 
 describeMathCPUAndGPU('GRU Tensor', () => {
@@ -621,8 +621,8 @@ describeMathCPUAndGPU('GRU Tensor', () => {
     for (const returnState of returnStateValues) {
       for (const returnSequences of returnSequencesValues) {
         const testTitle = `implementation=${implementation}, ` +
-          `returnSequences=${returnSequences}, ` +
-          `returnState=${returnState}`;
+            `returnSequences=${returnSequences}, ` +
+            `returnState=${returnState}`;
         it(testTitle, () => {
           const gru = tfl.layers.gru({
             units,
@@ -637,31 +637,31 @@ describeMathCPUAndGPU('GRU Tensor', () => {
           let output = gru.apply(input);
 
           const goldenOutputElementValueFinal =
-            goldenOutputElementValues[goldenOutputElementValues.length - 1];
+              goldenOutputElementValues[goldenOutputElementValues.length - 1];
 
           let expectedOutput: Tensor;
           if (returnSequences) {
             const outputs = goldenOutputElementValues.map(
-              value => K.scalarTimesArray(
-                scalar(value), ones([1, batchSize, units])));
+                value => K.scalarTimesArray(
+                    scalar(value), ones([1, batchSize, units])));
             expectedOutput = transpose(
-              K.concatAlongFirstAxis(
-                K.concatAlongFirstAxis(outputs[0], outputs[1]), outputs[2]),
-              [1, 0, 2]);
+                K.concatAlongFirstAxis(
+                    K.concatAlongFirstAxis(outputs[0], outputs[1]), outputs[2]),
+                [1, 0, 2]);
           } else {
             expectedOutput = K.scalarTimesArray(
-              scalar(goldenOutputElementValueFinal),
-              ones([batchSize, units]));
+                scalar(goldenOutputElementValueFinal),
+                ones([batchSize, units]));
           }
           if (returnState) {
             output = output as Tensor[];
             expect(output.length).toEqual(2);
             expectTensorsClose(output[0], expectedOutput);
             expectTensorsClose(
-              output[1],
-              K.scalarTimesArray(
-                scalar(goldenOutputElementValueFinal),
-                ones([batchSize, units])));
+                output[1],
+                K.scalarTimesArray(
+                    scalar(goldenOutputElementValueFinal),
+                    ones([batchSize, units])));
           } else {
             output = output as Tensor;
             expectTensorsClose(output, expectedOutput);
@@ -712,7 +712,7 @@ describeMathCPUAndGPU('GRU Tensor', () => {
       useBias: false
     });
     const dense =
-      tfl.layers.dense({units: 1, kernelInitializer: 'ones', useBias: false});
+        tfl.layers.dense({units: 1, kernelInitializer: 'ones', useBias: false});
 
     const sgd = train.sgd(1);
     const x = ones([batchSize, sequenceLength, inputSize]);
@@ -720,17 +720,17 @@ describeMathCPUAndGPU('GRU Tensor', () => {
     dense.apply(gru.apply(x));
     const lossFn = () => {
       return K.mean(metrics.mse(y, dense.apply(gru.apply(x)) as Tensor))
-        .asScalar();
+          .asScalar();
     };
     for (let i = 0; i < 2; ++i) {
       sgd.minimize(lossFn);
     }
     expectTensorsClose(
-      gru.getWeights()[0],
-      K.tile(tensor2d([[-0.03750037, 0, 1.7500007]], [1, 3]), [4, 1]));
+        gru.getWeights()[0],
+        K.tile(tensor2d([[-0.03750037, 0, 1.7500007]], [1, 3]), [4, 1]));
     expectTensorsClose(
-      gru.getWeights()[1],
-      tensor2d([[-1.562513e-02, 0, 2.086183e-07]], [1, 3]));
+        gru.getWeights()[1],
+        tensor2d([[-1.562513e-02, 0, 2.086183e-07]], [1, 3]));
     expectTensorsClose(dense.getWeights()[0], tensor2d([[1.2187521]], [1, 1]));
   });
 });
@@ -738,7 +738,7 @@ describeMathCPUAndGPU('GRU Tensor', () => {
 describeMathCPU('LSTM Symbolic', () => {
   it('returnSequences=false, returnState=false', () => {
     const input =
-      new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
+        new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
     const lstm = tfl.layers.lstm({units: 5});
     const output = lstm.apply(input) as tfl.SymbolicTensor;
     expect(output.shape).toEqual([9, 5]);
@@ -746,7 +746,7 @@ describeMathCPU('LSTM Symbolic', () => {
 
   it('returnSequences=false, returnState=true', () => {
     const input =
-      new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
+        new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
     const lstm = tfl.layers.lstm({units: 5, returnState: true});
     const output = lstm.apply(input) as tfl.SymbolicTensor[];
     expect(output.length).toEqual(3);
@@ -757,7 +757,7 @@ describeMathCPU('LSTM Symbolic', () => {
 
   it('returnSequences=true, returnState=false', () => {
     const input =
-      new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
+        new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
     const lstm = tfl.layers.lstm({units: 5, returnSequences: true});
     const output = lstm.apply(input) as tfl.SymbolicTensor;
     expect(output.shape).toEqual([9, 10, 5]);
@@ -765,7 +765,7 @@ describeMathCPU('LSTM Symbolic', () => {
 
   it('returnSequences=true, returnState=true', () => {
     const input =
-      new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
+        new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
     const lstm = tfl.layers.lstm({
       units: 5,
       returnSequences: true,
@@ -779,17 +779,17 @@ describeMathCPU('LSTM Symbolic', () => {
   });
 
   it('trainableWeights, nonTrainableWeights and weights give correct outputs',
-    () => {
-      const input =
-        new tfl.SymbolicTensor(DType.float32, [2, 3, 4], null, [], null);
-      const lstm = tfl.layers.lstm({units: 5, returnState: true});
-      lstm.apply(input);
-      expect(lstm.trainable).toEqual(true);
-      // Trainable weights: kernel, recurrent kernel and bias.
-      expect(lstm.trainableWeights.length).toEqual(3);
-      expect(lstm.nonTrainableWeights.length).toEqual(0);
-      expect(lstm.weights.length).toEqual(3);
-    });
+     () => {
+       const input =
+           new tfl.SymbolicTensor(DType.float32, [2, 3, 4], null, [], null);
+       const lstm = tfl.layers.lstm({units: 5, returnState: true});
+       lstm.apply(input);
+       expect(lstm.trainable).toEqual(true);
+       // Trainable weights: kernel, recurrent kernel and bias.
+       expect(lstm.trainableWeights.length).toEqual(3);
+       expect(lstm.nonTrainableWeights.length).toEqual(0);
+       expect(lstm.weights.length).toEqual(3);
+     });
 });
 
 describeMathCPUAndGPU('LSTM Tensor', () => {
@@ -839,8 +839,8 @@ describeMathCPUAndGPU('LSTM Tensor', () => {
     for (const returnState of returnStateValues) {
       for (const returnSequences of returnSequencesValues) {
         const testTitle = `implementation=${implementation}, ` +
-          `returnSequences=${returnSequences}, ` +
-          `returnState=${returnState}`;
+            `returnSequences=${returnSequences}, ` +
+            `returnState=${returnState}`;
         it(testTitle, () => {
           const lstm = tfl.layers.lstm({
             units,
@@ -864,32 +864,31 @@ describeMathCPUAndGPU('LSTM Tensor', () => {
           let expectedOutput: Tensor;
           if (returnSequences) {
             const outputAtT0 = K.scalarTimesArray(
-              scalar(goldenOutputElementValueAtT0),
-              ones([1, batchSize, units]));
+                scalar(goldenOutputElementValueAtT0),
+                ones([1, batchSize, units]));
             const outputAtT1 = K.scalarTimesArray(
-              scalar(goldenOutputElementValueAtT1),
-              ones([1, batchSize, units]));
+                scalar(goldenOutputElementValueAtT1),
+                ones([1, batchSize, units]));
             expectedOutput = transpose(
-              K.concatAlongFirstAxis(outputAtT0, outputAtT1), [1, 0, 2]);
+                K.concatAlongFirstAxis(outputAtT0, outputAtT1), [1, 0, 2]);
           } else {
             expectedOutput = K.scalarTimesArray(
-              scalar(goldenOutputElementValueAtT1),
-              ones([batchSize, units]));
+                scalar(goldenOutputElementValueAtT1), ones([batchSize, units]));
           }
           if (returnState) {
             output = output as Tensor[];
             expect(output.length).toEqual(3);
             expectTensorsClose(output[0], expectedOutput);
             expectTensorsClose(
-              output[1],
-              K.scalarTimesArray(
-                scalar(goldenHStateElementValue),
-                ones([batchSize, units])));
+                output[1],
+                K.scalarTimesArray(
+                    scalar(goldenHStateElementValue),
+                    ones([batchSize, units])));
             expectTensorsClose(
-              output[2],
-              K.scalarTimesArray(
-                scalar(goldenCStateElementValue),
-                ones([batchSize, units])));
+                output[2],
+                K.scalarTimesArray(
+                    scalar(goldenCStateElementValue),
+                    ones([batchSize, units])));
           } else {
             output = output as Tensor;
             expectTensorsClose(output, expectedOutput);
@@ -950,22 +949,22 @@ describeMathCPUAndGPU('LSTM Tensor', () => {
       dense.apply(lstm.apply(x));
       const lossFn = () => {
         return K.mean(metrics.mse(y, dense.apply(lstm.apply(x)) as Tensor))
-          .asScalar();
+            .asScalar();
       };
       for (let i = 0; i < 2; ++i) {
         sgd.minimize(lossFn);
       }
       expectTensorsClose(
-        lstm.getWeights()[0],
-        K.tile(
-          tensor2d(
-            [[0.11455188, 0.06545822, 0.8760446, 0.18237013]], [1, 4]),
-          [4, 1]));
+          lstm.getWeights()[0],
+          K.tile(
+              tensor2d(
+                  [[0.11455188, 0.06545822, 0.8760446, 0.18237013]], [1, 4]),
+              [4, 1]));
       expectTensorsClose(
-        lstm.getWeights()[1],
-        tensor2d([[0.02831176, 0.01934617, 0.00025817, 0.05784169]], [1, 4]));
+          lstm.getWeights()[1],
+          tensor2d([[0.02831176, 0.01934617, 0.00025817, 0.05784169]], [1, 4]));
       expectTensorsClose(
-        dense.getWeights()[0], tensor2d([[1.4559253]], [1, 1]));
+          dense.getWeights()[0], tensor2d([[1.4559253]], [1, 1]));
     });
   }
 });
@@ -973,15 +972,15 @@ describeMathCPUAndGPU('LSTM Tensor', () => {
 describeMathCPU('LSTM-deserialization', () => {
   it('modelFromConfig', async done => {
     modelFromJSON(fakeLSTMModel)
-      .then(model => {
-        const encoderInputs = zeros([1, 3, 71], DType.float32);
-        const decoderInputs = zeros([1, 3, 94], DType.float32);
-        const outputs =
-          model.predict([encoderInputs, decoderInputs]) as Tensor;
-        expect(outputs.shape).toEqual([1, 3, 94]);
-        done();
-      })
-      .catch(done.fail);
+        .then(model => {
+          const encoderInputs = zeros([1, 3, 71], DType.float32);
+          const decoderInputs = zeros([1, 3, 94], DType.float32);
+          const outputs =
+              model.predict([encoderInputs, decoderInputs]) as Tensor;
+          expect(outputs.shape).toEqual([1, 3, 94]);
+          done();
+        })
+        .catch(done.fail);
   });
 });
 
@@ -1032,7 +1031,7 @@ const fakeLSTMModel: ModelAndWeightsConfig = {
             'return_state': true,
             'unroll': false,
             'activation': 'tanh',
-            'bias_initializer': { 'class_name': 'Zeros', 'config': {} },
+            'bias_initializer': {'class_name': 'Zeros', 'config': {}},
             'units': 256,
             'unit_forget_bias': true,
             'activity_regularizer': null,
@@ -1080,7 +1079,7 @@ const fakeLSTMModel: ModelAndWeightsConfig = {
             'return_state': true,
             'unroll': false,
             'activation': 'tanh',
-            'bias_initializer': { 'class_name': 'Zeros', 'config': {} },
+            'bias_initializer': {'class_name': 'Zeros', 'config': {}},
             'units': 256,
             'unit_forget_bias': true,
             'activity_regularizer': null,
@@ -1130,7 +1129,7 @@ const fakeLSTMModel: ModelAndWeightsConfig = {
             'activation': 'softmax',
             'trainable': true,
             'kernel_regularizer': null,
-            'bias_initializer': { 'class_name': 'Zeros', 'config': {} },
+            'bias_initializer': {'class_name': 'Zeros', 'config': {}},
             'units': 94,
             'use_bias': true,
             'activity_regularizer': null
@@ -1153,14 +1152,14 @@ describeMathCPU('StackedRNNCells Symbolic', () => {
       cell: tfl.layers.stackedRNNCells({
         cells: [
           tfl.layers.simpleRNNCell(
-            { units: 3, recurrentInitializer: 'glorotNormal' }),
+              {units: 3, recurrentInitializer: 'glorotNormal'}),
           tfl.layers.simpleRNNCell(
-            { units: 2, recurrentInitializer: 'glorotNormal' })
+              {units: 2, recurrentInitializer: 'glorotNormal'})
         ],
       })
     });
     const input =
-      new tfl.SymbolicTensor(DType.float32, [16, 10, 7], null, [], null);
+        new tfl.SymbolicTensor(DType.float32, [16, 10, 7], null, [], null);
     const output = stackedRNN.apply(input) as tfl.SymbolicTensor;
     expect(output.shape).toEqual([16, 2]);
 
@@ -1182,12 +1181,13 @@ describeMathCPU('StackedRNNCells Symbolic', () => {
       cell: tfl.layers.stackedRNNCells({
         cells: [
           tfl.layers.lstmCell({units: 3, recurrentInitializer: 'glorotNormal'}),
-          tfl.layers.lstmCell({units: 2, recurrentInitializer: 'glorotNormal'})
+          tfl.layers.lstmCell(
+              {units: 2, recurrentInitializer: 'glorotNormal'})
         ],
       })
     });
     const input =
-      new tfl.SymbolicTensor(DType.float32, [16, 10, 7], null, [], null);
+        new tfl.SymbolicTensor(DType.float32, [16, 10, 7], null, [], null);
     const output = stackedRNN.apply(input) as tfl.SymbolicTensor;
     expect(output.shape).toEqual([16, 2]);
 
@@ -1208,12 +1208,12 @@ describeMathCPU('StackedRNNCells Symbolic', () => {
   it('RNN with cell array creates StackedRNNCell', () => {
     const stackedRNN = tfl.layers.rnn({
       cell: [
-        tfl.layers.gruCell({units: 3, recurrentInitializer: 'glorotNormal' }),
-        tfl.layers.gruCell({units: 2, recurrentInitializer: 'glorotNormal' }),
+        tfl.layers.gruCell({units: 3, recurrentInitializer: 'glorotNormal'}),
+        tfl.layers.gruCell({units: 2, recurrentInitializer: 'glorotNormal'}),
       ],
     });
     const input =
-      new tfl.SymbolicTensor(DType.float32, [16, 10, 7], null, [], null);
+        new tfl.SymbolicTensor(DType.float32, [16, 10, 7], null, [], null);
     const output = stackedRNN.apply(input) as tfl.SymbolicTensor;
     expect(output.shape).toEqual([16, 2]);
 
@@ -1304,19 +1304,19 @@ describeMathGPU('StackedRNNCells Tensor', () => {
       })
     });
     const input = tensor3d(
-      [
         [
-          [0.1, -0.1, 0.2, -0.2], [-0.1, 0.1, -0.2, 0.2],
-          [0.1, 0.1, -0.2, -0.2]
+          [
+            [0.1, -0.1, 0.2, -0.2], [-0.1, 0.1, -0.2, 0.2],
+            [0.1, 0.1, -0.2, -0.2]
+          ],
+          [
+            [0.05, -0.05, 0.1, -0.1], [-0.05, 0.05, -0.1, 0.1],
+            [0.05, 0.05, -0.1, -0.1]
+          ]
         ],
-        [
-          [0.05, -0.05, 0.1, -0.1], [-0.05, 0.05, -0.1, 0.1],
-          [0.05, 0.05, -0.1, -0.1]
-        ]
-      ],
-      [2, 3, 4]);
+        [2, 3, 4]);
     const output = stackedRNN.apply(input) as Tensor;
     expectTensorsClose(
-      output, tensor2d([[-0.07715216], [-0.05906887]], [2, 1]));
+        output, tensor2d([[-0.07715216], [-0.05906887]], [2, 1]));
   });
 });

--- a/src/layers/recurrent_test.ts
+++ b/src/layers/recurrent_test.ts
@@ -13,16 +13,16 @@
  */
 
 // tslint:disable:max-line-length
-import { neg, ones, Scalar, scalar, Tensor, tensor2d, tensor3d, train, transpose, zeros } from '@tensorflow/tfjs-core';
+import {neg, ones, Scalar, scalar, Tensor, tensor2d, tensor3d, train, transpose, zeros} from '@tensorflow/tfjs-core';
 
 import * as K from '../backend/tfjs_backend';
 import * as tfl from '../index';
 import * as metrics from '../metrics';
-import { ModelAndWeightsConfig, modelFromJSON } from '../models';
-import { DType, Kwargs } from '../types';
-import { describeMathCPU, describeMathCPUAndGPU, describeMathGPU, expectTensorsClose } from '../utils/test_utils';
+import {ModelAndWeightsConfig, modelFromJSON} from '../models';
+import {DType, Kwargs} from '../types';
+import {describeMathCPU, describeMathCPUAndGPU, describeMathGPU, expectTensorsClose} from '../utils/test_utils';
 
-import { RNN, RNNCell } from './recurrent';
+import {RNN, RNNCell} from './recurrent';
 // tslint:enable:max-line-length
 
 /**
@@ -36,12 +36,12 @@ import { RNN, RNNCell } from './recurrent';
  */
 class RNNCellForTest extends RNNCell {
   static className = 'RNNCellForTest';
-  constructor(stateSizes: number | number[]) {
+  constructor(stateSizes: number|number[]) {
     super({});
     this.stateSize = stateSizes;
   }
 
-  call(inputs: Tensor | Tensor[], kwargs: Kwargs): Tensor | Tensor[] {
+  call(inputs: Tensor|Tensor[], kwargs: Kwargs): Tensor|Tensor[] {
     inputs = inputs as Tensor[];
     const dataInputs = inputs[0];
     const states = inputs.slice(1);
@@ -61,7 +61,7 @@ describeMathCPU('RNN-Layer', () => {
 
   it('constructor: only cell', () => {
     const cell = new RNNCellForTest(5);
-    const rnn = tfl.layers.rnn({ cell }) as RNN;
+    const rnn = tfl.layers.rnn({cell}) as RNN;
     expect(rnn.returnSequences).toEqual(false);
     expect(rnn.returnState).toEqual(false);
     expect(rnn.goBackwards).toEqual(false);
@@ -83,7 +83,7 @@ describeMathCPU('RNN-Layer', () => {
   it('computeOutputShape: 1 state, returnSequences=false, returnState=false',
     () => {
       const cell = new RNNCellForTest(5);
-      const rnn = tfl.layers.rnn({ cell });
+      const rnn = tfl.layers.rnn({cell});
       const inputShape = [4, 3, 2];
       expect(rnn.computeOutputShape(inputShape)).toEqual([4, 5]);
     });
@@ -91,7 +91,7 @@ describeMathCPU('RNN-Layer', () => {
   it('computeOutputShape: 1 state, returnSequences=true, returnState=false',
     () => {
       const cell = new RNNCellForTest([5, 6]);
-      const rnn = tfl.layers.rnn({ cell, returnSequences: true });
+      const rnn = tfl.layers.rnn({cell, returnSequences: true});
       const inputShape = [4, 3, 2];
       expect(rnn.computeOutputShape(inputShape)).toEqual([4, 3, 5]);
     });
@@ -100,7 +100,7 @@ describeMathCPU('RNN-Layer', () => {
     () => {
       const cell = new RNNCellForTest(6);
       const rnn =
-        tfl.layers.rnn({ cell, returnSequences: true, returnState: true });
+        tfl.layers.rnn({cell, returnSequences: true, returnState: true});
       const inputShape = [4, 3, 2];
       expect(rnn.computeOutputShape(inputShape)).toEqual([[4, 3, 6], [4, 6]]);
     });
@@ -109,7 +109,7 @@ describeMathCPU('RNN-Layer', () => {
     () => {
       const cell = new RNNCellForTest([5, 6]);
       const rnn =
-        tfl.layers.rnn({ cell, returnSequences: true, returnState: true });
+        tfl.layers.rnn({cell, returnSequences: true, returnState: true});
       const inputShape = [4, 3, 2];
       expect(rnn.computeOutputShape(inputShape)).toEqual([
         [4, 3, 5], [4, 5], [4, 6]
@@ -119,7 +119,7 @@ describeMathCPU('RNN-Layer', () => {
   it('apply: Symbolic: 1 state, returnSequences=false, returnState=false',
     () => {
       const cell = new RNNCellForTest(6);
-      const rnn = tfl.layers.rnn({ cell });
+      const rnn = tfl.layers.rnn({cell});
       const input =
         new tfl.SymbolicTensor(DType.float32, [16, 10, 8], null, [], null);
       const output = rnn.apply(input) as tfl.SymbolicTensor;
@@ -129,7 +129,7 @@ describeMathCPU('RNN-Layer', () => {
   it('apply: Symbolic: 1 state, returnSequences=true, returnState=false',
     () => {
       const cell = new RNNCellForTest(6);
-      const rnn = tfl.layers.rnn({ cell, returnSequences: true });
+      const rnn = tfl.layers.rnn({cell, returnSequences: true});
       const input =
         new tfl.SymbolicTensor(DType.float32, [16, 10, 8], null, [], null);
       const output = rnn.apply(input) as tfl.SymbolicTensor;
@@ -139,7 +139,7 @@ describeMathCPU('RNN-Layer', () => {
   it('apply: Symbolic: 1 state, returnSequences=true, returnState=true', () => {
     const cell = new RNNCellForTest(6);
     const rnn =
-      tfl.layers.rnn({ cell, returnSequences: true, returnState: true });
+      tfl.layers.rnn({cell, returnSequences: true, returnState: true});
     const input =
       new tfl.SymbolicTensor(DType.float32, [16, 10, 8], null, [], null);
     const output = rnn.apply(input) as tfl.SymbolicTensor[];
@@ -152,7 +152,7 @@ describeMathCPU('RNN-Layer', () => {
     () => {
       const cell = new RNNCellForTest(6);
       const rnn =
-        tfl.layers.rnn({ cell, returnSequences: false, returnState: true });
+        tfl.layers.rnn({cell, returnSequences: false, returnState: true});
       const input =
         new tfl.SymbolicTensor(DType.float32, [16, 10, 8], null, [], null);
       const output = rnn.apply(input) as tfl.SymbolicTensor[];
@@ -165,7 +165,7 @@ describeMathCPU('RNN-Layer', () => {
     () => {
       const cell = new RNNCellForTest([5, 6]);
       const rnn =
-        tfl.layers.rnn({ cell, returnSequences: true, returnState: true });
+        tfl.layers.rnn({cell, returnSequences: true, returnState: true});
       const input =
         new tfl.SymbolicTensor(DType.float32, [16, 10, 8], null, [], null);
       const output = rnn.apply(input) as tfl.SymbolicTensor[];
@@ -180,7 +180,7 @@ describeMathCPUAndGPU('RNN-Layer-Math', () => {
   it('getInitialState: 1 state', () => {
     const cell = new RNNCellForTest(5);
     const inputs = zeros([4, 3, 2]);
-    const rnn = tfl.layers.rnn({ cell }) as RNN;
+    const rnn = tfl.layers.rnn({cell}) as RNN;
     const initialStates = rnn.getInitialState(inputs);
     expect(initialStates.length).toEqual(1);
     expectTensorsClose(initialStates[0], zeros([4, 5]));
@@ -189,7 +189,7 @@ describeMathCPUAndGPU('RNN-Layer-Math', () => {
   it('getInitialState: 2 states', () => {
     const cell = new RNNCellForTest([5, 6]);
     const inputs = zeros([4, 3, 2]);
-    const rnn = tfl.layers.rnn({ cell }) as RNN;
+    const rnn = tfl.layers.rnn({cell}) as RNN;
     const initialStates = rnn.getInitialState(inputs);
     expect(initialStates.length).toEqual(2);
     expectTensorsClose(initialStates[0], zeros([4, 5]));
@@ -198,7 +198,7 @@ describeMathCPUAndGPU('RNN-Layer-Math', () => {
 
   it('call: 1 state: returnSequences=false, returnState=false', () => {
     const cell = new RNNCellForTest(4);
-    const rnn = tfl.layers.rnn({ cell });
+    const rnn = tfl.layers.rnn({cell});
     const inputs = tensor3d(
       [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
     const outputs = rnn.apply(inputs) as Tensor;
@@ -208,7 +208,7 @@ describeMathCPUAndGPU('RNN-Layer-Math', () => {
 
   it('apply: 1 state: returnSequences=true, returnState=false', () => {
     const cell = new RNNCellForTest(3);
-    const rnn = tfl.layers.rnn({ cell, returnSequences: true });
+    const rnn = tfl.layers.rnn({cell, returnSequences: true});
     const inputs = tensor3d(
       [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
     const outputs = rnn.apply(inputs) as Tensor;
@@ -231,7 +231,7 @@ describeMathCPUAndGPU('RNN-Layer-Math', () => {
   it('apply: 1 state: returnSequences=true, returnState=true', () => {
     const cell = new RNNCellForTest(3);
     const rnn =
-      tfl.layers.rnn({ cell, returnSequences: true, returnState: true });
+      tfl.layers.rnn({cell, returnSequences: true, returnState: true});
     const inputs = tensor3d(
       [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
     const outputs = rnn.apply(inputs) as Tensor[];
@@ -258,7 +258,7 @@ describeMathCPUAndGPU('RNN-Layer-Math', () => {
   it('apply: 2 states: returnSequences=true, returnState=true', () => {
     const cell = new RNNCellForTest([3, 4]);
     const rnn =
-      tfl.layers.rnn({ cell, returnSequences: true, returnState: true });
+      tfl.layers.rnn({cell, returnSequences: true, returnState: true});
     const inputs = tensor3d(
       [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
     const outputs = rnn.apply(inputs) as Tensor[];
@@ -289,7 +289,7 @@ describeMathCPUAndGPU('RNN-Layer-Math', () => {
 
   it('call: with 1 initialState', () => {
     const cell = new RNNCellForTest(4);
-    const rnn = tfl.layers.rnn({ cell });
+    const rnn = tfl.layers.rnn({cell});
     const inputs = tensor3d(
       [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
     const outputs =
@@ -300,7 +300,7 @@ describeMathCPUAndGPU('RNN-Layer-Math', () => {
 
   it('call: with 2 initialStates', () => {
     const cell = new RNNCellForTest([4, 5]);
-    const rnn = tfl.layers.rnn({ cell, returnState: true });
+    const rnn = tfl.layers.rnn({cell, returnState: true});
     const inputs = tensor3d(
       [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
     const outputs = rnn.apply(inputs, {
@@ -318,7 +318,7 @@ describeMathCPUAndGPU('RNN-Layer-Math', () => {
 
   it('call with incorrect number of initialStates leads to ValueError', () => {
     const cell = new RNNCellForTest([4, 5]);
-    const rnn = tfl.layers.rnn({ cell, returnState: true });
+    const rnn = tfl.layers.rnn({cell, returnState: true});
     const inputs = tensor3d(
       [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
     expect(() => rnn.apply(inputs, {
@@ -331,7 +331,7 @@ describeMathCPU('SimpleRNN Symbolic', () => {
   it('returnSequences=false, returnState=false', () => {
     const input =
       new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
-    const simpleRNN = tfl.layers.simpleRNN({ units: 5 });
+    const simpleRNN = tfl.layers.simpleRNN({units: 5});
     const output = simpleRNN.apply(input) as tfl.SymbolicTensor;
     expect(output.shape).toEqual([9, 5]);
   });
@@ -339,7 +339,7 @@ describeMathCPU('SimpleRNN Symbolic', () => {
   it('returnSequences=false, returnState=true', () => {
     const input =
       new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
-    const simpleRNN = tfl.layers.simpleRNN({ units: 5, returnState: true });
+    const simpleRNN = tfl.layers.simpleRNN({units: 5, returnState: true});
     const output = simpleRNN.apply(input) as tfl.SymbolicTensor[];
     expect(output.length).toEqual(2);
     expect(output[0].shape).toEqual([9, 5]);
@@ -349,7 +349,7 @@ describeMathCPU('SimpleRNN Symbolic', () => {
   it('returnSequences=true, returnState=false', () => {
     const input =
       new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
-    const simpleRNN = tfl.layers.simpleRNN({ units: 5, returnSequences: true });
+    const simpleRNN = tfl.layers.simpleRNN({units: 5, returnSequences: true});
     const output = simpleRNN.apply(input) as tfl.SymbolicTensor;
     expect(output.shape).toEqual([9, 10, 5]);
   });
@@ -523,7 +523,7 @@ describeMathCPU('GRU Symbolic', () => {
   it('returnSequences=false, returnState=false', () => {
     const input =
       new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
-    const gru = tfl.layers.gru({ units: 5 });
+    const gru = tfl.layers.gru({units: 5});
     const output = gru.apply(input) as tfl.SymbolicTensor;
     expect(output.shape).toEqual([9, 5]);
   });
@@ -531,7 +531,7 @@ describeMathCPU('GRU Symbolic', () => {
   it('returnSequences=false, returnState=true', () => {
     const input =
       new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
-    const gru = tfl.layers.gru({ units: 5, returnState: true });
+    const gru = tfl.layers.gru({units: 5, returnState: true});
     const output = gru.apply(input) as tfl.SymbolicTensor[];
     expect(output.length).toEqual(2);
     expect(output[0].shape).toEqual([9, 5]);
@@ -541,7 +541,7 @@ describeMathCPU('GRU Symbolic', () => {
   it('returnSequences=true, returnState=false', () => {
     const input =
       new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
-    const gru = tfl.layers.gru({ units: 5, returnSequences: true });
+    const gru = tfl.layers.gru({units: 5, returnSequences: true});
     const output = gru.apply(input) as tfl.SymbolicTensor;
     expect(output.shape).toEqual([9, 10, 5]);
   });
@@ -564,7 +564,7 @@ describeMathCPU('GRU Symbolic', () => {
     () => {
       const input =
         new tfl.SymbolicTensor(DType.float32, [2, 3, 4], null, [], null);
-      const gru = tfl.layers.gru({ units: 5, returnState: true });
+      const gru = tfl.layers.gru({units: 5, returnState: true});
       gru.apply(input);
       expect(gru.trainable).toEqual(true);
       // Trainable weights: kernel, recurrent kernel and bias.
@@ -712,7 +712,7 @@ describeMathCPUAndGPU('GRU Tensor', () => {
       useBias: false
     });
     const dense =
-      tfl.layers.dense({ units: 1, kernelInitializer: 'ones', useBias: false });
+      tfl.layers.dense({units: 1, kernelInitializer: 'ones', useBias: false});
 
     const sgd = train.sgd(1);
     const x = ones([batchSize, sequenceLength, inputSize]);
@@ -739,7 +739,7 @@ describeMathCPU('LSTM Symbolic', () => {
   it('returnSequences=false, returnState=false', () => {
     const input =
       new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
-    const lstm = tfl.layers.lstm({ units: 5 });
+    const lstm = tfl.layers.lstm({units: 5});
     const output = lstm.apply(input) as tfl.SymbolicTensor;
     expect(output.shape).toEqual([9, 5]);
   });
@@ -747,7 +747,7 @@ describeMathCPU('LSTM Symbolic', () => {
   it('returnSequences=false, returnState=true', () => {
     const input =
       new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
-    const lstm = tfl.layers.lstm({ units: 5, returnState: true });
+    const lstm = tfl.layers.lstm({units: 5, returnState: true});
     const output = lstm.apply(input) as tfl.SymbolicTensor[];
     expect(output.length).toEqual(3);
     expect(output[0].shape).toEqual([9, 5]);
@@ -758,7 +758,7 @@ describeMathCPU('LSTM Symbolic', () => {
   it('returnSequences=true, returnState=false', () => {
     const input =
       new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
-    const lstm = tfl.layers.lstm({ units: 5, returnSequences: true });
+    const lstm = tfl.layers.lstm({units: 5, returnSequences: true});
     const output = lstm.apply(input) as tfl.SymbolicTensor;
     expect(output.shape).toEqual([9, 10, 5]);
   });
@@ -782,7 +782,7 @@ describeMathCPU('LSTM Symbolic', () => {
     () => {
       const input =
         new tfl.SymbolicTensor(DType.float32, [2, 3, 4], null, [], null);
-      const lstm = tfl.layers.lstm({ units: 5, returnState: true });
+      const lstm = tfl.layers.lstm({units: 5, returnState: true});
       lstm.apply(input);
       expect(lstm.trainable).toEqual(true);
       // Trainable weights: kernel, recurrent kernel and bias.
@@ -1208,8 +1208,8 @@ describeMathCPU('StackedRNNCells Symbolic', () => {
   it('RNN with cell array creates StackedRNNCell', () => {
     const stackedRNN = tfl.layers.rnn({
       cell: [
-        tfl.layers.gruCell({ units: 3, recurrentInitializer: 'glorotNormal' }),
-        tfl.layers.gruCell({ units: 2, recurrentInitializer: 'glorotNormal' }),
+        tfl.layers.gruCell({units: 3, recurrentInitializer: 'glorotNormal' }),
+        tfl.layers.gruCell({units: 2, recurrentInitializer: 'glorotNormal' }),
       ],
     });
     const input =

--- a/src/layers/recurrent_test.ts
+++ b/src/layers/recurrent_test.ts
@@ -13,16 +13,16 @@
  */
 
 // tslint:disable:max-line-length
-import {neg, Scalar, scalar, Tensor, tensor2d, tensor3d, train, transpose} from '@tensorflow/tfjs-core';
+import { neg, ones, Scalar, scalar, Tensor, tensor2d, tensor3d, train, transpose, zeros } from '@tensorflow/tfjs-core';
 
 import * as K from '../backend/tfjs_backend';
 import * as tfl from '../index';
 import * as metrics from '../metrics';
-import {ModelAndWeightsConfig, modelFromJSON} from '../models';
-import {DType, Kwargs} from '../types';
-import {describeMathCPU, describeMathCPUAndGPU, describeMathGPU, expectTensorsClose} from '../utils/test_utils';
+import { ModelAndWeightsConfig, modelFromJSON } from '../models';
+import { DType, Kwargs } from '../types';
+import { describeMathCPU, describeMathCPUAndGPU, describeMathGPU, expectTensorsClose } from '../utils/test_utils';
 
-import {RNN, RNNCell} from './recurrent';
+import { RNN, RNNCell } from './recurrent';
 // tslint:enable:max-line-length
 
 /**
@@ -36,12 +36,12 @@ import {RNN, RNNCell} from './recurrent';
  */
 class RNNCellForTest extends RNNCell {
   static className = 'RNNCellForTest';
-  constructor(stateSizes: number|number[]) {
+  constructor(stateSizes: number | number[]) {
     super({});
     this.stateSize = stateSizes;
   }
 
-  call(inputs: Tensor|Tensor[], kwargs: Kwargs): Tensor|Tensor[] {
+  call(inputs: Tensor | Tensor[], kwargs: Kwargs): Tensor | Tensor[] {
     inputs = inputs as Tensor[];
     const dataInputs = inputs[0];
     const states = inputs.slice(1);
@@ -61,7 +61,7 @@ describeMathCPU('RNN-Layer', () => {
 
   it('constructor: only cell', () => {
     const cell = new RNNCellForTest(5);
-    const rnn = tfl.layers.rnn({cell}) as RNN;
+    const rnn = tfl.layers.rnn({ cell }) as RNN;
     expect(rnn.returnSequences).toEqual(false);
     expect(rnn.returnState).toEqual(false);
     expect(rnn.goBackwards).toEqual(false);
@@ -81,67 +81,67 @@ describeMathCPU('RNN-Layer', () => {
   });
 
   it('computeOutputShape: 1 state, returnSequences=false, returnState=false',
-     () => {
-       const cell = new RNNCellForTest(5);
-       const rnn = tfl.layers.rnn({cell});
-       const inputShape = [4, 3, 2];
-       expect(rnn.computeOutputShape(inputShape)).toEqual([4, 5]);
-     });
+    () => {
+      const cell = new RNNCellForTest(5);
+      const rnn = tfl.layers.rnn({ cell });
+      const inputShape = [4, 3, 2];
+      expect(rnn.computeOutputShape(inputShape)).toEqual([4, 5]);
+    });
 
   it('computeOutputShape: 1 state, returnSequences=true, returnState=false',
-     () => {
-       const cell = new RNNCellForTest([5, 6]);
-       const rnn = tfl.layers.rnn({cell, returnSequences: true});
-       const inputShape = [4, 3, 2];
-       expect(rnn.computeOutputShape(inputShape)).toEqual([4, 3, 5]);
-     });
+    () => {
+      const cell = new RNNCellForTest([5, 6]);
+      const rnn = tfl.layers.rnn({ cell, returnSequences: true });
+      const inputShape = [4, 3, 2];
+      expect(rnn.computeOutputShape(inputShape)).toEqual([4, 3, 5]);
+    });
 
   it('computeOutputShape: 1 state, returnSequences=true, returnState=true',
-     () => {
-       const cell = new RNNCellForTest(6);
-       const rnn =
-           tfl.layers.rnn({cell, returnSequences: true, returnState: true});
-       const inputShape = [4, 3, 2];
-       expect(rnn.computeOutputShape(inputShape)).toEqual([[4, 3, 6], [4, 6]]);
-     });
+    () => {
+      const cell = new RNNCellForTest(6);
+      const rnn =
+        tfl.layers.rnn({ cell, returnSequences: true, returnState: true });
+      const inputShape = [4, 3, 2];
+      expect(rnn.computeOutputShape(inputShape)).toEqual([[4, 3, 6], [4, 6]]);
+    });
 
   it('computeOutputShape: 2 states, returnSequences=true, returnState=true',
-     () => {
-       const cell = new RNNCellForTest([5, 6]);
-       const rnn =
-           tfl.layers.rnn({cell, returnSequences: true, returnState: true});
-       const inputShape = [4, 3, 2];
-       expect(rnn.computeOutputShape(inputShape)).toEqual([
-         [4, 3, 5], [4, 5], [4, 6]
-       ]);
-     });
+    () => {
+      const cell = new RNNCellForTest([5, 6]);
+      const rnn =
+        tfl.layers.rnn({ cell, returnSequences: true, returnState: true });
+      const inputShape = [4, 3, 2];
+      expect(rnn.computeOutputShape(inputShape)).toEqual([
+        [4, 3, 5], [4, 5], [4, 6]
+      ]);
+    });
 
   it('apply: Symbolic: 1 state, returnSequences=false, returnState=false',
-     () => {
-       const cell = new RNNCellForTest(6);
-       const rnn = tfl.layers.rnn({cell});
-       const input =
-           new tfl.SymbolicTensor(DType.float32, [16, 10, 8], null, [], null);
-       const output = rnn.apply(input) as tfl.SymbolicTensor;
-       expect(output.shape).toEqual([16, 6]);
-     });
+    () => {
+      const cell = new RNNCellForTest(6);
+      const rnn = tfl.layers.rnn({ cell });
+      const input =
+        new tfl.SymbolicTensor(DType.float32, [16, 10, 8], null, [], null);
+      const output = rnn.apply(input) as tfl.SymbolicTensor;
+      expect(output.shape).toEqual([16, 6]);
+    });
 
   it('apply: Symbolic: 1 state, returnSequences=true, returnState=false',
-     () => {
-       const cell = new RNNCellForTest(6);
-       const rnn = tfl.layers.rnn({cell, returnSequences: true});
-       const input =
-           new tfl.SymbolicTensor(DType.float32, [16, 10, 8], null, [], null);
-       const output = rnn.apply(input) as tfl.SymbolicTensor;
-       expect(output.shape).toEqual([16, 10, 6]);
-     });
+    () => {
+      const cell = new RNNCellForTest(6);
+      const rnn = tfl.layers.rnn({ cell, returnSequences: true });
+      const input =
+        new tfl.SymbolicTensor(DType.float32, [16, 10, 8], null, [], null);
+      const output = rnn.apply(input) as tfl.SymbolicTensor;
+      expect(output.shape).toEqual([16, 10, 6]);
+    });
 
   it('apply: Symbolic: 1 state, returnSequences=true, returnState=true', () => {
     const cell = new RNNCellForTest(6);
     const rnn =
-        tfl.layers.rnn({cell, returnSequences: true, returnState: true});
+      tfl.layers.rnn({ cell, returnSequences: true, returnState: true });
     const input =
-        new tfl.SymbolicTensor(DType.float32, [16, 10, 8], null, [], null);
+      new tfl.SymbolicTensor(DType.float32, [16, 10, 8], null, [], null);
     const output = rnn.apply(input) as tfl.SymbolicTensor[];
     expect(output.length).toEqual(2);
     expect(output[0].shape).toEqual([16, 10, 6]);
@@ -149,180 +149,180 @@ describeMathCPU('RNN-Layer', () => {
   });
 
   it('apply: Symbolic: 1 state, returnSequences=false, returnState=true',
-     () => {
-       const cell = new RNNCellForTest(6);
-       const rnn =
-           tfl.layers.rnn({cell, returnSequences: false, returnState: true});
-       const input =
-           new tfl.SymbolicTensor(DType.float32, [16, 10, 8], null, [], null);
-       const output = rnn.apply(input) as tfl.SymbolicTensor[];
-       expect(output.length).toEqual(2);
-       expect(output[0].shape).toEqual([16, 6]);
-       expect(output[1].shape).toEqual([16, 6]);
-     });
+    () => {
+      const cell = new RNNCellForTest(6);
+      const rnn =
+        tfl.layers.rnn({ cell, returnSequences: false, returnState: true });
+      const input =
+        new tfl.SymbolicTensor(DType.float32, [16, 10, 8], null, [], null);
+      const output = rnn.apply(input) as tfl.SymbolicTensor[];
+      expect(output.length).toEqual(2);
+      expect(output[0].shape).toEqual([16, 6]);
+      expect(output[1].shape).toEqual([16, 6]);
+    });
 
   it('apply: Symbolic: 2 states, returnSequences=true, returnState=true',
-     () => {
-       const cell = new RNNCellForTest([5, 6]);
-       const rnn =
-           tfl.layers.rnn({cell, returnSequences: true, returnState: true});
-       const input =
-           new tfl.SymbolicTensor(DType.float32, [16, 10, 8], null, [], null);
-       const output = rnn.apply(input) as tfl.SymbolicTensor[];
-       expect(output.length).toEqual(3);
-       expect(output[0].shape).toEqual([16, 10, 5]);
-       expect(output[1].shape).toEqual([16, 5]);
-       expect(output[2].shape).toEqual([16, 6]);
-     });
+    () => {
+      const cell = new RNNCellForTest([5, 6]);
+      const rnn =
+        tfl.layers.rnn({ cell, returnSequences: true, returnState: true });
+      const input =
+        new tfl.SymbolicTensor(DType.float32, [16, 10, 8], null, [], null);
+      const output = rnn.apply(input) as tfl.SymbolicTensor[];
+      expect(output.length).toEqual(3);
+      expect(output[0].shape).toEqual([16, 10, 5]);
+      expect(output[1].shape).toEqual([16, 5]);
+      expect(output[2].shape).toEqual([16, 6]);
+    });
 });
 
 describeMathCPUAndGPU('RNN-Layer-Math', () => {
   it('getInitialState: 1 state', () => {
     const cell = new RNNCellForTest(5);
-    const inputs = K.zeros([4, 3, 2]);
-    const rnn = tfl.layers.rnn({cell}) as RNN;
+    const inputs = zeros([4, 3, 2]);
+    const rnn = tfl.layers.rnn({ cell }) as RNN;
     const initialStates = rnn.getInitialState(inputs);
     expect(initialStates.length).toEqual(1);
-    expectTensorsClose(initialStates[0], K.zeros([4, 5]));
+    expectTensorsClose(initialStates[0], zeros([4, 5]));
   });
 
   it('getInitialState: 2 states', () => {
     const cell = new RNNCellForTest([5, 6]);
-    const inputs = K.zeros([4, 3, 2]);
-    const rnn = tfl.layers.rnn({cell}) as RNN;
+    const inputs = zeros([4, 3, 2]);
+    const rnn = tfl.layers.rnn({ cell }) as RNN;
     const initialStates = rnn.getInitialState(inputs);
     expect(initialStates.length).toEqual(2);
-    expectTensorsClose(initialStates[0], K.zeros([4, 5]));
-    expectTensorsClose(initialStates[1], K.zeros([4, 6]));
+    expectTensorsClose(initialStates[0], zeros([4, 5]));
+    expectTensorsClose(initialStates[1], zeros([4, 6]));
   });
 
   it('call: 1 state: returnSequences=false, returnState=false', () => {
     const cell = new RNNCellForTest(4);
-    const rnn = tfl.layers.rnn({cell});
+    const rnn = tfl.layers.rnn({ cell });
     const inputs = tensor3d(
-        [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
+      [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
     const outputs = rnn.apply(inputs) as Tensor;
     expectTensorsClose(
-        outputs, K.scalarTimesArray(scalar(-57.75), K.ones([2, 4])));
+      outputs, K.scalarTimesArray(scalar(-57.75), ones([2, 4])));
   });
 
   it('apply: 1 state: returnSequences=true, returnState=false', () => {
     const cell = new RNNCellForTest(3);
-    const rnn = tfl.layers.rnn({cell, returnSequences: true});
+    const rnn = tfl.layers.rnn({ cell, returnSequences: true });
     const inputs = tensor3d(
-        [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
+      [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
     const outputs = rnn.apply(inputs) as Tensor;
     expectTensorsClose(
-        outputs,
-        tensor3d(
-            [
-              [
-                [-8.25, -8.25, -8.25], [-27.5, -27.5, -27.5],
-                [-57.75, -57.75, -57.75]
-              ],
-              [
-                [-8.25, -8.25, -8.25], [-27.5, -27.5, -27.5],
-                [-57.75, -57.75, -57.75]
-              ],
-            ],
-            [2, 3, 3]));
+      outputs,
+      tensor3d(
+        [
+          [
+            [-8.25, -8.25, -8.25], [-27.5, -27.5, -27.5],
+            [-57.75, -57.75, -57.75]
+          ],
+          [
+            [-8.25, -8.25, -8.25], [-27.5, -27.5, -27.5],
+            [-57.75, -57.75, -57.75]
+          ],
+        ],
+        [2, 3, 3]));
   });
 
   it('apply: 1 state: returnSequences=true, returnState=true', () => {
     const cell = new RNNCellForTest(3);
     const rnn =
-        tfl.layers.rnn({cell, returnSequences: true, returnState: true});
+      tfl.layers.rnn({ cell, returnSequences: true, returnState: true });
     const inputs = tensor3d(
-        [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
+      [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
     const outputs = rnn.apply(inputs) as Tensor[];
     expect(outputs.length).toEqual(2);
     expectTensorsClose(
-        outputs[0],
-        tensor3d(
-            [
-              [
-                [-8.25, -8.25, -8.25], [-27.5, -27.5, -27.5],
-                [-57.75, -57.75, -57.75]
-              ],
-              [
-                [-8.25, -8.25, -8.25], [-27.5, -27.5, -27.5],
-                [-57.75, -57.75, -57.75]
-              ],
-            ],
-            [2, 3, 3]));
+      outputs[0],
+      tensor3d(
+        [
+          [
+            [-8.25, -8.25, -8.25], [-27.5, -27.5, -27.5],
+            [-57.75, -57.75, -57.75]
+          ],
+          [
+            [-8.25, -8.25, -8.25], [-27.5, -27.5, -27.5],
+            [-57.75, -57.75, -57.75]
+          ],
+        ],
+        [2, 3, 3]));
     expectTensorsClose(
-        outputs[1],
-        tensor2d([[57.75, 57.75, 57.75], [57.75, 57.75, 57.75]], [2, 3]));
+      outputs[1],
+      tensor2d([[57.75, 57.75, 57.75], [57.75, 57.75, 57.75]], [2, 3]));
   });
 
   it('apply: 2 states: returnSequences=true, returnState=true', () => {
     const cell = new RNNCellForTest([3, 4]);
     const rnn =
-        tfl.layers.rnn({cell, returnSequences: true, returnState: true});
+      tfl.layers.rnn({ cell, returnSequences: true, returnState: true });
     const inputs = tensor3d(
-        [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
+      [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
     const outputs = rnn.apply(inputs) as Tensor[];
     expect(outputs.length).toEqual(3);
     expectTensorsClose(
-        outputs[0],
-        tensor3d(
-            [
-              [
-                [-8.25, -8.25, -8.25], [-27.5, -27.5, -27.5],
-                [-57.75, -57.75, -57.75]
-              ],
-              [
-                [-8.25, -8.25, -8.25], [-27.5, -27.5, -27.5],
-                [-57.75, -57.75, -57.75]
-              ],
-            ],
-            [2, 3, 3]));
+      outputs[0],
+      tensor3d(
+        [
+          [
+            [-8.25, -8.25, -8.25], [-27.5, -27.5, -27.5],
+            [-57.75, -57.75, -57.75]
+          ],
+          [
+            [-8.25, -8.25, -8.25], [-27.5, -27.5, -27.5],
+            [-57.75, -57.75, -57.75]
+          ],
+        ],
+        [2, 3, 3]));
     expectTensorsClose(
-        outputs[1],
-        tensor2d([[57.75, 57.75, 57.75], [57.75, 57.75, 57.75]], [2, 3]));
+      outputs[1],
+      tensor2d([[57.75, 57.75, 57.75], [57.75, 57.75, 57.75]], [2, 3]));
     expectTensorsClose(
-        outputs[2],
-        tensor2d(
-            [[57.75, 57.75, 57.75, 57.75], [57.75, 57.75, 57.75, 57.75]],
-            [2, 4]));
+      outputs[2],
+      tensor2d(
+        [[57.75, 57.75, 57.75, 57.75], [57.75, 57.75, 57.75, 57.75]],
+        [2, 4]));
   });
 
   it('call: with 1 initialState', () => {
     const cell = new RNNCellForTest(4);
-    const rnn = tfl.layers.rnn({cell});
+    const rnn = tfl.layers.rnn({ cell });
     const inputs = tensor3d(
-        [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
+      [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
     const outputs =
-        rnn.apply(inputs, {'initialState': [K.ones([2, 4])]}) as Tensor;
+      rnn.apply(inputs, { 'initialState': [ones([2, 4])] }) as Tensor;
     expectTensorsClose(
-        outputs, K.scalarTimesArray(scalar(-58.75), K.ones([2, 4])));
+      outputs, K.scalarTimesArray(scalar(-58.75), ones([2, 4])));
   });
 
   it('call: with 2 initialStates', () => {
     const cell = new RNNCellForTest([4, 5]);
-    const rnn = tfl.layers.rnn({cell, returnState: true});
+    const rnn = tfl.layers.rnn({ cell, returnState: true });
     const inputs = tensor3d(
-        [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
+      [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
     const outputs = rnn.apply(inputs, {
       'initialState':
-          [K.ones([2, 4]), K.scalarTimesArray(scalar(2), K.ones([2, 5]))]
+        [ones([2, 4]), K.scalarTimesArray(scalar(2), ones([2, 5]))]
     }) as Tensor[];
     expect(outputs.length).toEqual(3);
     expectTensorsClose(
-        outputs[0], K.scalarTimesArray(scalar(-58.75), K.ones([2, 4])));
+      outputs[0], K.scalarTimesArray(scalar(-58.75), ones([2, 4])));
     expectTensorsClose(
-        outputs[1], K.scalarTimesArray(scalar(58.75), K.ones([2, 4])));
+      outputs[1], K.scalarTimesArray(scalar(58.75), ones([2, 4])));
     expectTensorsClose(
-        outputs[2], K.scalarTimesArray(scalar(59.75), K.ones([2, 5])));
+      outputs[2], K.scalarTimesArray(scalar(59.75), ones([2, 5])));
   });
 
   it('call with incorrect number of initialStates leads to ValueError', () => {
     const cell = new RNNCellForTest([4, 5]);
-    const rnn = tfl.layers.rnn({cell, returnState: true});
+    const rnn = tfl.layers.rnn({ cell, returnState: true });
     const inputs = tensor3d(
-        [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
+      [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
     expect(() => rnn.apply(inputs, {
-      'initialState': [K.ones([2, 4])]
+      'initialState': [ones([2, 4])]
     })).toThrowError(/An initialState was passed that is not compatible with/);
   });
 });
@@ -330,16 +330,16 @@ describeMathCPUAndGPU('RNN-Layer-Math', () => {
 describeMathCPU('SimpleRNN Symbolic', () => {
   it('returnSequences=false, returnState=false', () => {
     const input =
-        new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
-    const simpleRNN = tfl.layers.simpleRNN({units: 5});
+      new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
+    const simpleRNN = tfl.layers.simpleRNN({ units: 5 });
     const output = simpleRNN.apply(input) as tfl.SymbolicTensor;
     expect(output.shape).toEqual([9, 5]);
   });
 
   it('returnSequences=false, returnState=true', () => {
     const input =
-        new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
-    const simpleRNN = tfl.layers.simpleRNN({units: 5, returnState: true});
+      new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
+    const simpleRNN = tfl.layers.simpleRNN({ units: 5, returnState: true });
     const output = simpleRNN.apply(input) as tfl.SymbolicTensor[];
     expect(output.length).toEqual(2);
     expect(output[0].shape).toEqual([9, 5]);
@@ -348,15 +348,15 @@ describeMathCPU('SimpleRNN Symbolic', () => {
 
   it('returnSequences=true, returnState=false', () => {
     const input =
-        new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
-    const simpleRNN = tfl.layers.simpleRNN({units: 5, returnSequences: true});
+      new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
+    const simpleRNN = tfl.layers.simpleRNN({ units: 5, returnSequences: true });
     const output = simpleRNN.apply(input) as tfl.SymbolicTensor;
     expect(output.shape).toEqual([9, 10, 5]);
   });
 
   it('returnSequences=true, returnState=true', () => {
     const input =
-        new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
+      new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
     const simpleRNN = tfl.layers.simpleRNN({
       units: 5,
       returnSequences: true,
@@ -381,7 +381,7 @@ describeMathCPUAndGPU('SimpleRNN Tensor', () => {
   const activations = ['linear', 'tanh'];
   for (const activation of activations) {
     const testTitle =
-        `returnSequences=false, returnState=false, useBias=true, ${activation}`;
+      `returnSequences=false, returnState=false, useBias=true, ${activation}`;
     it(testTitle, () => {
       const timeSteps = 1;
       const simpleRNN = tfl.layers.simpleRNN({
@@ -391,23 +391,23 @@ describeMathCPUAndGPU('SimpleRNN Tensor', () => {
         biasInitializer: 'ones',
         activation
       });
-      const input = K.ones([batchSize, timeSteps, inputSize]);
+      const input = ones([batchSize, timeSteps, inputSize]);
       const output = simpleRNN.apply(input) as Tensor;
       let expectedElementValue = inputSize + 1;
       if (activation === 'tanh') {
         expectedElementValue = Math.tanh(expectedElementValue);
       }
       expectTensorsClose(
-          output,
-          K.scalarTimesArray(
-              scalar(expectedElementValue), K.ones([batchSize, units])));
+        output,
+        K.scalarTimesArray(
+          scalar(expectedElementValue), ones([batchSize, units])));
     });
   }
 
   const returnStateValues = [false, true];
   for (const returnState of returnStateValues) {
     const testTitle = `returnSequences=true, ` +
-        `returnState=${returnState}, useBias=true, linear`;
+      `returnState=${returnState}, useBias=true, linear`;
     it(testTitle, () => {
       const timeSteps = 2;
       const simpleRNN = tfl.layers.simpleRNN({
@@ -419,7 +419,7 @@ describeMathCPUAndGPU('SimpleRNN Tensor', () => {
         biasInitializer: 'ones',
         activation: 'linear'
       });
-      const input = K.ones([batchSize, timeSteps, inputSize]);
+      const input = ones([batchSize, timeSteps, inputSize]);
       let output = simpleRNN.apply(input);
       let finalState: Tensor;
       if (returnState) {
@@ -436,14 +436,14 @@ describeMathCPUAndGPU('SimpleRNN Tensor', () => {
       const outputT0 = K.sliceAlongFirstAxis(timeMajorOutput, 0, 1);
       const outputT1 = K.sliceAlongFirstAxis(timeMajorOutput, 1, 1);
       expectTensorsClose(
-          outputT0,
-          K.scalarTimesArray(
-              scalar(inputSize + 1), K.ones([1, batchSize, units])));
+        outputT0,
+        K.scalarTimesArray(
+          scalar(inputSize + 1), ones([1, batchSize, units])));
       expectTensorsClose(
-          outputT1,
-          K.scalarTimesArray(
-              scalar((inputSize + 1) * (units + 1)),
-              K.ones([1, batchSize, units])));
+        outputT1,
+        K.scalarTimesArray(
+          scalar((inputSize + 1) * (units + 1)),
+          ones([1, batchSize, units])));
       if (returnState) {
         expectTensorsClose(finalState, outputT1.reshape([batchSize, units]));
       }
@@ -497,41 +497,41 @@ describeMathCPUAndGPU('SimpleRNN Tensor', () => {
     });
 
     const sgd = train.sgd(5);
-    const x = K.ones([batchSize, sequenceLength, inputSize]);
-    const y = K.zeros([batchSize, 1]);
+    const x = ones([batchSize, sequenceLength, inputSize]);
+    const y = zeros([batchSize, 1]);
     dense.apply(simpleRNN.apply(x));
     const lossFn = () => {
       return K.mean(metrics.mse(y, dense.apply(simpleRNN.apply(x)) as Tensor))
-          .asScalar();
+        .asScalar();
     };
     for (let i = 0; i < 2; ++i) {
       sgd.minimize(lossFn);
     }
     expectTensorsClose(
-        simpleRNN.getWeights()[0],
-        K.scalarTimesArray(scalar(0.8484658), K.ones([4, 1])));
+      simpleRNN.getWeights()[0],
+      K.scalarTimesArray(scalar(0.8484658), ones([4, 1])));
     expectTensorsClose(
-        simpleRNN.getWeights()[1],
-        K.scalarTimesArray(scalar(0.8484799), K.ones([1, 1])));
+      simpleRNN.getWeights()[1],
+      K.scalarTimesArray(scalar(0.8484799), ones([1, 1])));
     expectTensorsClose(
-        dense.getWeights()[0],
-        K.scalarTimesArray(scalar(80.967026), K.ones([1, 1])));
+      dense.getWeights()[0],
+      K.scalarTimesArray(scalar(80.967026), ones([1, 1])));
   });
 });
 
 describeMathCPU('GRU Symbolic', () => {
   it('returnSequences=false, returnState=false', () => {
     const input =
-        new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
-    const gru = tfl.layers.gru({units: 5});
+      new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
+    const gru = tfl.layers.gru({ units: 5 });
     const output = gru.apply(input) as tfl.SymbolicTensor;
     expect(output.shape).toEqual([9, 5]);
   });
 
   it('returnSequences=false, returnState=true', () => {
     const input =
-        new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
-    const gru = tfl.layers.gru({units: 5, returnState: true});
+      new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
+    const gru = tfl.layers.gru({ units: 5, returnState: true });
     const output = gru.apply(input) as tfl.SymbolicTensor[];
     expect(output.length).toEqual(2);
     expect(output[0].shape).toEqual([9, 5]);
@@ -540,15 +540,15 @@ describeMathCPU('GRU Symbolic', () => {
 
   it('returnSequences=true, returnState=false', () => {
     const input =
-        new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
-    const gru = tfl.layers.gru({units: 5, returnSequences: true});
+      new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
+    const gru = tfl.layers.gru({ units: 5, returnSequences: true });
     const output = gru.apply(input) as tfl.SymbolicTensor;
     expect(output.shape).toEqual([9, 10, 5]);
   });
 
   it('returnSequences=true, returnState=true', () => {
     const input =
-        new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
+      new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
     const gru = tfl.layers.gru({
       units: 5,
       returnSequences: true,
@@ -561,17 +561,17 @@ describeMathCPU('GRU Symbolic', () => {
   });
 
   it('trainableWeights, nonTrainableWeights and weights give correct outputs',
-     () => {
-       const input =
-           new tfl.SymbolicTensor(DType.float32, [2, 3, 4], null, [], null);
-       const gru = tfl.layers.gru({units: 5, returnState: true});
-       gru.apply(input);
-       expect(gru.trainable).toEqual(true);
-       // Trainable weights: kernel, recurrent kernel and bias.
-       expect(gru.trainableWeights.length).toEqual(3);
-       expect(gru.nonTrainableWeights.length).toEqual(0);
-       expect(gru.weights.length).toEqual(3);
-     });
+    () => {
+      const input =
+        new tfl.SymbolicTensor(DType.float32, [2, 3, 4], null, [], null);
+      const gru = tfl.layers.gru({ units: 5, returnState: true });
+      gru.apply(input);
+      expect(gru.trainable).toEqual(true);
+      // Trainable weights: kernel, recurrent kernel and bias.
+      expect(gru.trainableWeights.length).toEqual(3);
+      expect(gru.nonTrainableWeights.length).toEqual(0);
+      expect(gru.weights.length).toEqual(3);
+    });
 });
 
 describeMathCPUAndGPU('GRU Tensor', () => {
@@ -621,8 +621,8 @@ describeMathCPUAndGPU('GRU Tensor', () => {
     for (const returnState of returnStateValues) {
       for (const returnSequences of returnSequencesValues) {
         const testTitle = `implementation=${implementation}, ` +
-            `returnSequences=${returnSequences}, ` +
-            `returnState=${returnState}`;
+          `returnSequences=${returnSequences}, ` +
+          `returnState=${returnState}`;
         it(testTitle, () => {
           const gru = tfl.layers.gru({
             units,
@@ -633,35 +633,35 @@ describeMathCPUAndGPU('GRU Tensor', () => {
             returnSequences,
             implementation
           });
-          const input = K.zeros([batchSize, timeSteps, inputSize]);
+          const input = zeros([batchSize, timeSteps, inputSize]);
           let output = gru.apply(input);
 
           const goldenOutputElementValueFinal =
-              goldenOutputElementValues[goldenOutputElementValues.length - 1];
+            goldenOutputElementValues[goldenOutputElementValues.length - 1];
 
           let expectedOutput: Tensor;
           if (returnSequences) {
             const outputs = goldenOutputElementValues.map(
-                value => K.scalarTimesArray(
-                    scalar(value), K.ones([1, batchSize, units])));
+              value => K.scalarTimesArray(
+                scalar(value), ones([1, batchSize, units])));
             expectedOutput = transpose(
-                K.concatAlongFirstAxis(
-                    K.concatAlongFirstAxis(outputs[0], outputs[1]), outputs[2]),
-                [1, 0, 2]);
+              K.concatAlongFirstAxis(
+                K.concatAlongFirstAxis(outputs[0], outputs[1]), outputs[2]),
+              [1, 0, 2]);
           } else {
             expectedOutput = K.scalarTimesArray(
-                scalar(goldenOutputElementValueFinal),
-                K.ones([batchSize, units]));
+              scalar(goldenOutputElementValueFinal),
+              ones([batchSize, units]));
           }
           if (returnState) {
             output = output as Tensor[];
             expect(output.length).toEqual(2);
             expectTensorsClose(output[0], expectedOutput);
             expectTensorsClose(
-                output[1],
-                K.scalarTimesArray(
-                    scalar(goldenOutputElementValueFinal),
-                    K.ones([batchSize, units])));
+              output[1],
+              K.scalarTimesArray(
+                scalar(goldenOutputElementValueFinal),
+                ones([batchSize, units])));
           } else {
             output = output as Tensor;
             expectTensorsClose(output, expectedOutput);
@@ -712,25 +712,25 @@ describeMathCPUAndGPU('GRU Tensor', () => {
       useBias: false
     });
     const dense =
-        tfl.layers.dense({units: 1, kernelInitializer: 'ones', useBias: false});
+      tfl.layers.dense({ units: 1, kernelInitializer: 'ones', useBias: false });
 
     const sgd = train.sgd(1);
-    const x = K.ones([batchSize, sequenceLength, inputSize]);
-    const y = K.ones([batchSize, 1]);
+    const x = ones([batchSize, sequenceLength, inputSize]);
+    const y = ones([batchSize, 1]);
     dense.apply(gru.apply(x));
     const lossFn = () => {
       return K.mean(metrics.mse(y, dense.apply(gru.apply(x)) as Tensor))
-          .asScalar();
+        .asScalar();
     };
     for (let i = 0; i < 2; ++i) {
       sgd.minimize(lossFn);
     }
     expectTensorsClose(
-        gru.getWeights()[0],
-        K.tile(tensor2d([[-0.03750037, 0, 1.7500007]], [1, 3]), [4, 1]));
+      gru.getWeights()[0],
+      K.tile(tensor2d([[-0.03750037, 0, 1.7500007]], [1, 3]), [4, 1]));
     expectTensorsClose(
-        gru.getWeights()[1],
-        tensor2d([[-1.562513e-02, 0, 2.086183e-07]], [1, 3]));
+      gru.getWeights()[1],
+      tensor2d([[-1.562513e-02, 0, 2.086183e-07]], [1, 3]));
     expectTensorsClose(dense.getWeights()[0], tensor2d([[1.2187521]], [1, 1]));
   });
 });
@@ -738,16 +738,16 @@ describeMathCPUAndGPU('GRU Tensor', () => {
 describeMathCPU('LSTM Symbolic', () => {
   it('returnSequences=false, returnState=false', () => {
     const input =
-        new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
-    const lstm = tfl.layers.lstm({units: 5});
+      new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
+    const lstm = tfl.layers.lstm({ units: 5 });
     const output = lstm.apply(input) as tfl.SymbolicTensor;
     expect(output.shape).toEqual([9, 5]);
   });
 
   it('returnSequences=false, returnState=true', () => {
     const input =
-        new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
-    const lstm = tfl.layers.lstm({units: 5, returnState: true});
+      new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
+    const lstm = tfl.layers.lstm({ units: 5, returnState: true });
     const output = lstm.apply(input) as tfl.SymbolicTensor[];
     expect(output.length).toEqual(3);
     expect(output[0].shape).toEqual([9, 5]);
@@ -757,15 +757,15 @@ describeMathCPU('LSTM Symbolic', () => {
 
   it('returnSequences=true, returnState=false', () => {
     const input =
-        new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
-    const lstm = tfl.layers.lstm({units: 5, returnSequences: true});
+      new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
+    const lstm = tfl.layers.lstm({ units: 5, returnSequences: true });
     const output = lstm.apply(input) as tfl.SymbolicTensor;
     expect(output.shape).toEqual([9, 10, 5]);
   });
 
   it('returnSequences=true, returnState=true', () => {
     const input =
-        new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
+      new tfl.SymbolicTensor(DType.float32, [9, 10, 8], null, [], null);
     const lstm = tfl.layers.lstm({
       units: 5,
       returnSequences: true,
@@ -779,17 +779,17 @@ describeMathCPU('LSTM Symbolic', () => {
   });
 
   it('trainableWeights, nonTrainableWeights and weights give correct outputs',
-     () => {
-       const input =
-           new tfl.SymbolicTensor(DType.float32, [2, 3, 4], null, [], null);
-       const lstm = tfl.layers.lstm({units: 5, returnState: true});
-       lstm.apply(input);
-       expect(lstm.trainable).toEqual(true);
-       // Trainable weights: kernel, recurrent kernel and bias.
-       expect(lstm.trainableWeights.length).toEqual(3);
-       expect(lstm.nonTrainableWeights.length).toEqual(0);
-       expect(lstm.weights.length).toEqual(3);
-     });
+    () => {
+      const input =
+        new tfl.SymbolicTensor(DType.float32, [2, 3, 4], null, [], null);
+      const lstm = tfl.layers.lstm({ units: 5, returnState: true });
+      lstm.apply(input);
+      expect(lstm.trainable).toEqual(true);
+      // Trainable weights: kernel, recurrent kernel and bias.
+      expect(lstm.trainableWeights.length).toEqual(3);
+      expect(lstm.nonTrainableWeights.length).toEqual(0);
+      expect(lstm.weights.length).toEqual(3);
+    });
 });
 
 describeMathCPUAndGPU('LSTM Tensor', () => {
@@ -839,8 +839,8 @@ describeMathCPUAndGPU('LSTM Tensor', () => {
     for (const returnState of returnStateValues) {
       for (const returnSequences of returnSequencesValues) {
         const testTitle = `implementation=${implementation}, ` +
-            `returnSequences=${returnSequences}, ` +
-            `returnState=${returnState}`;
+          `returnSequences=${returnSequences}, ` +
+          `returnState=${returnState}`;
         it(testTitle, () => {
           const lstm = tfl.layers.lstm({
             units,
@@ -851,7 +851,7 @@ describeMathCPUAndGPU('LSTM Tensor', () => {
             returnSequences,
             implementation
           });
-          const input = K.ones([batchSize, timeSteps, inputSize]);
+          const input = ones([batchSize, timeSteps, inputSize]);
           let output = lstm.apply(input);
 
           // See comments at the beginning of this describe() block on how these
@@ -864,32 +864,32 @@ describeMathCPUAndGPU('LSTM Tensor', () => {
           let expectedOutput: Tensor;
           if (returnSequences) {
             const outputAtT0 = K.scalarTimesArray(
-                scalar(goldenOutputElementValueAtT0),
-                K.ones([1, batchSize, units]));
+              scalar(goldenOutputElementValueAtT0),
+              ones([1, batchSize, units]));
             const outputAtT1 = K.scalarTimesArray(
-                scalar(goldenOutputElementValueAtT1),
-                K.ones([1, batchSize, units]));
+              scalar(goldenOutputElementValueAtT1),
+              ones([1, batchSize, units]));
             expectedOutput = transpose(
-                K.concatAlongFirstAxis(outputAtT0, outputAtT1), [1, 0, 2]);
+              K.concatAlongFirstAxis(outputAtT0, outputAtT1), [1, 0, 2]);
           } else {
             expectedOutput = K.scalarTimesArray(
-                scalar(goldenOutputElementValueAtT1),
-                K.ones([batchSize, units]));
+              scalar(goldenOutputElementValueAtT1),
+              ones([batchSize, units]));
           }
           if (returnState) {
             output = output as Tensor[];
             expect(output.length).toEqual(3);
             expectTensorsClose(output[0], expectedOutput);
             expectTensorsClose(
-                output[1],
-                K.scalarTimesArray(
-                    scalar(goldenHStateElementValue),
-                    K.ones([batchSize, units])));
+              output[1],
+              K.scalarTimesArray(
+                scalar(goldenHStateElementValue),
+                ones([batchSize, units])));
             expectTensorsClose(
-                output[2],
-                K.scalarTimesArray(
-                    scalar(goldenCStateElementValue),
-                    K.ones([batchSize, units])));
+              output[2],
+              K.scalarTimesArray(
+                scalar(goldenCStateElementValue),
+                ones([batchSize, units])));
           } else {
             output = output as Tensor;
             expectTensorsClose(output, expectedOutput);
@@ -945,27 +945,27 @@ describeMathCPUAndGPU('LSTM Tensor', () => {
       });
 
       const sgd = train.sgd(1);
-      const x = K.ones([batchSize, sequenceLength, inputSize]);
-      const y = K.ones([batchSize, 1]);
+      const x = ones([batchSize, sequenceLength, inputSize]);
+      const y = ones([batchSize, 1]);
       dense.apply(lstm.apply(x));
       const lossFn = () => {
         return K.mean(metrics.mse(y, dense.apply(lstm.apply(x)) as Tensor))
-            .asScalar();
+          .asScalar();
       };
       for (let i = 0; i < 2; ++i) {
         sgd.minimize(lossFn);
       }
       expectTensorsClose(
-          lstm.getWeights()[0],
-          K.tile(
-              tensor2d(
-                  [[0.11455188, 0.06545822, 0.8760446, 0.18237013]], [1, 4]),
-              [4, 1]));
+        lstm.getWeights()[0],
+        K.tile(
+          tensor2d(
+            [[0.11455188, 0.06545822, 0.8760446, 0.18237013]], [1, 4]),
+          [4, 1]));
       expectTensorsClose(
-          lstm.getWeights()[1],
-          tensor2d([[0.02831176, 0.01934617, 0.00025817, 0.05784169]], [1, 4]));
+        lstm.getWeights()[1],
+        tensor2d([[0.02831176, 0.01934617, 0.00025817, 0.05784169]], [1, 4]));
       expectTensorsClose(
-          dense.getWeights()[0], tensor2d([[1.4559253]], [1, 1]));
+        dense.getWeights()[0], tensor2d([[1.4559253]], [1, 1]));
     });
   }
 });
@@ -973,15 +973,15 @@ describeMathCPUAndGPU('LSTM Tensor', () => {
 describeMathCPU('LSTM-deserialization', () => {
   it('modelFromConfig', async done => {
     modelFromJSON(fakeLSTMModel)
-        .then(model => {
-          const encoderInputs = K.zeros([1, 3, 71], DType.float32);
-          const decoderInputs = K.zeros([1, 3, 94], DType.float32);
-          const outputs =
-              model.predict([encoderInputs, decoderInputs]) as Tensor;
-          expect(outputs.shape).toEqual([1, 3, 94]);
-          done();
-        })
-        .catch(done.fail);
+      .then(model => {
+        const encoderInputs = zeros([1, 3, 71], DType.float32);
+        const decoderInputs = zeros([1, 3, 94], DType.float32);
+        const outputs =
+          model.predict([encoderInputs, decoderInputs]) as Tensor;
+        expect(outputs.shape).toEqual([1, 3, 94]);
+        done();
+      })
+      .catch(done.fail);
   });
 });
 
@@ -1032,7 +1032,7 @@ const fakeLSTMModel: ModelAndWeightsConfig = {
             'return_state': true,
             'unroll': false,
             'activation': 'tanh',
-            'bias_initializer': {'class_name': 'Zeros', 'config': {}},
+            'bias_initializer': { 'class_name': 'Zeros', 'config': {} },
             'units': 256,
             'unit_forget_bias': true,
             'activity_regularizer': null,
@@ -1080,7 +1080,7 @@ const fakeLSTMModel: ModelAndWeightsConfig = {
             'return_state': true,
             'unroll': false,
             'activation': 'tanh',
-            'bias_initializer': {'class_name': 'Zeros', 'config': {}},
+            'bias_initializer': { 'class_name': 'Zeros', 'config': {} },
             'units': 256,
             'unit_forget_bias': true,
             'activity_regularizer': null,
@@ -1130,7 +1130,7 @@ const fakeLSTMModel: ModelAndWeightsConfig = {
             'activation': 'softmax',
             'trainable': true,
             'kernel_regularizer': null,
-            'bias_initializer': {'class_name': 'Zeros', 'config': {}},
+            'bias_initializer': { 'class_name': 'Zeros', 'config': {} },
             'units': 94,
             'use_bias': true,
             'activity_regularizer': null
@@ -1160,7 +1160,7 @@ describeMathCPU('StackedRNNCells Symbolic', () => {
       })
     });
     const input =
-        new tfl.SymbolicTensor(DType.float32, [16, 10, 7], null, [], null);
+      new tfl.SymbolicTensor(DType.float32, [16, 10, 7], null, [], null);
     const output = stackedRNN.apply(input) as tfl.SymbolicTensor;
     expect(output.shape).toEqual([16, 2]);
 
@@ -1187,7 +1187,7 @@ describeMathCPU('StackedRNNCells Symbolic', () => {
       })
     });
     const input =
-        new tfl.SymbolicTensor(DType.float32, [16, 10, 7], null, [], null);
+      new tfl.SymbolicTensor(DType.float32, [16, 10, 7], null, [], null);
     const output = stackedRNN.apply(input) as tfl.SymbolicTensor;
     expect(output.shape).toEqual([16, 2]);
 
@@ -1208,12 +1208,12 @@ describeMathCPU('StackedRNNCells Symbolic', () => {
   it('RNN with cell array creates StackedRNNCell', () => {
     const stackedRNN = tfl.layers.rnn({
       cell: [
-        tfl.layers.gruCell({units: 3, recurrentInitializer: 'glorotNormal'}),
-        tfl.layers.gruCell({units: 2, recurrentInitializer: 'glorotNormal'}),
+        tfl.layers.gruCell({ units: 3, recurrentInitializer: 'glorotNormal' }),
+        tfl.layers.gruCell({ units: 2, recurrentInitializer: 'glorotNormal' }),
       ],
     });
     const input =
-        new tfl.SymbolicTensor(DType.float32, [16, 10, 7], null, [], null);
+      new tfl.SymbolicTensor(DType.float32, [16, 10, 7], null, [], null);
     const output = stackedRNN.apply(input) as tfl.SymbolicTensor;
     expect(output.shape).toEqual([16, 2]);
 
@@ -1304,19 +1304,19 @@ describeMathGPU('StackedRNNCells Tensor', () => {
       })
     });
     const input = tensor3d(
+      [
         [
-          [
-            [0.1, -0.1, 0.2, -0.2], [-0.1, 0.1, -0.2, 0.2],
-            [0.1, 0.1, -0.2, -0.2]
-          ],
-          [
-            [0.05, -0.05, 0.1, -0.1], [-0.05, 0.05, -0.1, 0.1],
-            [0.05, 0.05, -0.1, -0.1]
-          ]
+          [0.1, -0.1, 0.2, -0.2], [-0.1, 0.1, -0.2, 0.2],
+          [0.1, 0.1, -0.2, -0.2]
         ],
-        [2, 3, 4]);
+        [
+          [0.05, -0.05, 0.1, -0.1], [-0.05, 0.05, -0.1, 0.1],
+          [0.05, 0.05, -0.1, -0.1]
+        ]
+      ],
+      [2, 3, 4]);
     const output = stackedRNN.apply(input) as Tensor;
     expectTensorsClose(
-        output, tensor2d([[-0.07715216], [-0.05906887]], [2, 1]));
+      output, tensor2d([[-0.07715216], [-0.05906887]], [2, 1]));
   });
 });

--- a/src/layers/wrappers.ts
+++ b/src/layers/wrappers.ts
@@ -13,7 +13,7 @@
  */
 
 // tslint:disable:max-line-length
-import {add, reverse, serialization, Tensor} from '@tensorflow/tfjs-core';
+import {add, mul, reverse, serialization, Tensor} from '@tensorflow/tfjs-core';
 
 import * as K from '../backend/tfjs_backend';
 import {Layer, LayerConfig} from '../engine/topology';
@@ -418,7 +418,7 @@ export class Bidirectional extends Wrapper {
       output = K.scalarTimesArray(
           K.getScalar(0.5), add(y as Tensor, yRev as Tensor));
     } else if (this.mergeMode === 'mul') {
-      output = K.multiply(y as Tensor, yRev as Tensor);
+      output = mul(y as Tensor, yRev as Tensor);
     } else if (this.mergeMode == null) {
       output = [y as Tensor, yRev as Tensor];
     }

--- a/src/models_test.ts
+++ b/src/models_test.ts
@@ -11,7 +11,6 @@
 // tslint:disable:max-line-length
 import {io, ones, Scalar, scalar, serialization, sum, Tensor, tensor1d, tensor2d, zeros} from '@tensorflow/tfjs-core';
 
-import * as K from './backend/tfjs_backend';
 import {Model} from './engine/training';
 import * as tfl from './index';
 import {Reshape} from './layers/core';
@@ -83,7 +82,7 @@ describeMathCPU('model_from_json', () => {
         .then(model => {
           expect(model.name).toEqual('mnist');
           expect(model.layers.length).toEqual(9);
-          const prediction = model.predict(K.zeros([1, 28, 28, 1])) as Tensor;
+          const prediction = model.predict(zeros([1, 28, 28, 1])) as Tensor;
           expect(prediction.shape).toEqual([1, 10]);
           expect(sum(prediction).dataSync()).toBeCloseTo(1);
           done();
@@ -112,7 +111,7 @@ describeMathCPU('model_from_json', () => {
 
     modelFromJSON(fakeMnistModel).then(async model => {
       expect(model.layers.length).toEqual(8);
-      const prediction = model.predict(K.zeros([1, 28, 28, 1])) as Tensor;
+      const prediction = model.predict(zeros([1, 28, 28, 1])) as Tensor;
       expect(prediction.shape).toEqual([1, 10]);
       expect(sum(prediction).dataSync()).toBeCloseTo(1);
       done();
@@ -466,11 +465,11 @@ describeMathCPUAndGPU('Sequential', () => {
   ];
 
   function getInputs(): Tensor {
-    return K.ones(batchInputShape);
+    return ones(batchInputShape);
   }
 
   function getExpectedOutputs(): Tensor {
-    return K.ones([1].concat(secondReshape));
+    return ones([1].concat(secondReshape));
   }
 
   it('throws an exception if the first layer is not an input layer', () => {
@@ -526,8 +525,8 @@ describeMathCPUAndGPU('Sequential', () => {
       new Reshape({targetShape: firstReshape, batchInputShape, name: 'layer1'}),
       new Reshape({targetShape: secondReshape, name: 'layer2'})
     ];
-    const inputBatch = K.ones([batchSize].concat(inputShape));
-    const expectedOutput = K.ones([batchSize].concat(secondReshape));
+    const inputBatch = ones([batchSize].concat(inputShape));
+    const expectedOutput = ones([batchSize].concat(secondReshape));
     const model = tfl.sequential({layers});
     expectTensorsClose(
         model.predictOnBatch(inputBatch) as Tensor, expectedOutput);
@@ -536,8 +535,8 @@ describeMathCPUAndGPU('Sequential', () => {
   it('compile() and fit()', async () => {
     const batchSize = 5;
     const inputSize = 4;
-    const xs = K.ones([batchSize, inputSize]);
-    const ys = K.ones([batchSize, 1]);
+    const xs = ones([batchSize, inputSize]);
+    const ys = ones([batchSize, 1]);
     const denseLayer1 = tfl.layers.dense({
       units: 3,
       useBias: false,
@@ -559,8 +558,8 @@ describeMathCPUAndGPU('Sequential', () => {
     const inputSize = 4;
     const denseLayer1 = tfl.layers.dense({units: 3, inputShape: [inputSize]});
     const model = tfl.sequential({layers: [denseLayer1]});
-    const xs = K.ones([batchSize, inputSize]);
-    const ys = K.ones([batchSize, 1]);
+    const xs = ones([batchSize, inputSize]);
+    const ys = ones([batchSize, 1]);
     expect(() => model.evaluate(xs, ys))
         .toThrowError(/needs to be compiled before/);
   });
@@ -568,8 +567,8 @@ describeMathCPUAndGPU('Sequential', () => {
   it('compile() and evaluate()', () => {
     const batchSize = 5;
     const inputSize = 4;
-    const xs = K.ones([batchSize, inputSize]);
-    const ys = K.ones([batchSize, 1]);
+    const xs = ones([batchSize, inputSize]);
+    const ys = ones([batchSize, 1]);
     const denseLayer1 = tfl.layers.dense({
       units: 3,
       useBias: false,


### PR DESCRIPTION
Like the previous PR this removes very simply forwarding functions in tfjs_backend.ts that simply forward to a similar function in -core.

Renames:
subtract->sub
multiply->mul
divide->div
clip->clipByValue

Removes internal usages of the permuteDimensions alias to transpose and just uses transpose

Changes layers code to use the core calling convention on squeeze (caller wrapper in the array) and removes our wrapper.

Functions that only varied in unused extra arguments:
zeros, ones, randomUniform, truncatedNormal, softmax

There's still a few more "easy" conversions but I think they'll need a touch more discussion for instance (scalarPlusArray, scalarTimesArray which are simple stricter type checks around add/mul  -- or replace layer's square(x) with core's mul(x,x)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/170)
<!-- Reviewable:end -->
