### PR TITLE
Speed up orthogonal initializer by using tf.linalg.gramSchmidt

### DIFF
--- a/src/backend/tfjs_backend.ts
+++ b/src/backend/tfjs_backend.ts
@@ -736,24 +736,6 @@ export function identity(x: Tensor): Tensor {
 }
 
 /**
- * Instantiate an identity matrix and returns it.
- *
- * @param size Number of rows/columns.
- * @param dtype Data type of returned Tensor.
- * @param name Name of returned Tensor.
- * @return An identity matrix.
- */
-export function eye(size: number, dtype?: DType, name?: string): Tensor {
-  const buffer: number[] = [];
-  for (let i = 0; i < size; ++i) {
-    for (let j = 0; j < size; ++j) {
-      buffer.push(i === j ? 1 : 0);
-    }
-  }
-  return tensor2d(buffer, [size, size]);
-}
-
-/**
  * Instantiate an identity matrix and returns it, as a Variable
  *
  * @param size Number of rows/columns.
@@ -763,7 +745,7 @@ export function eye(size: number, dtype?: DType, name?: string): Tensor {
  */
 export function eyeVariable(
     size: number, dtype?: DType, name?: string): LayerVariable {
-  return new LayerVariable(eye(size, dtype), dtype, name);
+  return new LayerVariable(tfc.eye(size, size, null, dtype), dtype, name);
 }
 
 /**
@@ -987,8 +969,8 @@ export function qr(x: Tensor2D): [Tensor, Tensor] {
     const m = x.shape[0];
     const n = x.shape[1];
 
-    let q = eye(m) as Tensor2D;  // Orthogonal transform so far.
-    let r = x.clone();           // Transformed matrix so far.
+    let q = tfc.eye(m) as Tensor2D;  // Orthogonal transform so far.
+    let r = x.clone();               // Transformed matrix so far.
 
     const one2D = tensor2d([[1]], [1, 1]);
     let w: Tensor2D = one2D.clone();

--- a/src/backend/tfjs_backend_test.ts
+++ b/src/backend/tfjs_backend_test.ts
@@ -1057,37 +1057,6 @@ describeMathCPUAndGPU('Identity', () => {
   });
 });
 
-describeMathCPUAndGPU('eye (I-matrix builder)', () => {
-  it('Zero sized 2D matrix', () => {
-    const I = K.eye(0);
-    expect(I.shape).toEqual([0, 0]);
-  });
-  it('1 sized 2D matrix', () => {
-    const I = K.eye(1);
-    expect(I.shape).toEqual([1, 1]);
-    expect(I.dataSync()).toEqual(new Float32Array([1]));
-  });
-  it('2 sized 2D matrix', () => {
-    const I = K.eye(2);
-    expect(I.shape).toEqual([2, 2]);
-    expect(I.dataSync()).toEqual(new Float32Array([1, 0, 0, 1]));
-  });
-  it('Variable Zero sized 2D matrix', () => {
-    const I = K.eyeVariable(0);
-    expect(I.shape).toEqual([0, 0]);
-  });
-  it('Variable 1 sized 2D matrix', () => {
-    const I = K.eyeVariable(1);
-    expect(I.shape).toEqual([1, 1]);
-    expect(I.read().dataSync()).toEqual(new Float32Array([1]));
-  });
-  it('Variable 2 sized 2D matrix', () => {
-    const I = K.eyeVariable(2);
-    expect(I.shape).toEqual([2, 2]);
-    expect(I.read().dataSync()).toEqual(new Float32Array([1, 0, 0, 1]));
-  });
-});
-
 describeMathCPUAndGPU('scalarTimesArray', () => {
   it('Scalar x Scalar', () => {
     expectTensorsClose(K.scalarTimesArray(scalar(-2), scalar(-3)), scalar(6));

--- a/src/engine/topology_test.ts
+++ b/src/engine/topology_test.ts
@@ -9,7 +9,7 @@
  */
 
 // tslint:disable:max-line-length
-import {ones, scalar, Tensor, tensor1d, tensor2d, zeros} from '@tensorflow/tfjs-core';
+import {eye, ones, scalar, Tensor, tensor1d, tensor2d, zeros} from '@tensorflow/tfjs-core';
 import * as K from '../backend/tfjs_backend';
 import * as tfl from '../index';
 import * as initializers from '../initializers';
@@ -633,7 +633,7 @@ describeMathCPU('Layer', () => {
 
   describe('initialized with weights at construction time', () => {
     it('sets those weights after calling apply().', () => {
-      const initialWeights = K.eye(2);
+      const initialWeights = eye(2);
       const arrayInput = zeros([1]);
       const symbolicInput =
           new tfl.SymbolicTensor(DType.float32, [1], null, [], {});
@@ -661,7 +661,7 @@ describeMathCPU('Layer', () => {
          const layer = new LayerForTest({});
          expect(layer.inboundNodes.length).toEqual(0);
          expect(layer.outboundNodes.length).toEqual(0);
-         layer.apply(K.eye(1));
+         layer.apply(eye(1));
          expect(layer.inboundNodes.length).toEqual(0);
          expect(layer.outboundNodes.length).toEqual(0);
        });

--- a/src/initializers.ts
+++ b/src/initializers.ts
@@ -567,7 +567,7 @@ export class Orthogonal extends Initializer {
     }
 
     // TODO(cais): Add seed support.
-    const normalizedShape = shape[0] >= shape[1] ? [shape[1], shape[0]] : shape;
+    const normalizedShape = shape[0] > shape[1] ? [shape[1], shape[0]] : shape;
     const a = K.randomNormal(normalizedShape, 0, 1, DType.float32) as Tensor2D;
     let q = linalg.gramSchmidt(a) as Tensor2D;
     if (shape[0] > shape[1]) {

--- a/src/initializers.ts
+++ b/src/initializers.ts
@@ -9,7 +9,7 @@
  */
 
 // tslint:disable:max-line-length
-import {doc, ones, randomUniform, scalar, Scalar, serialization, Tensor, Tensor2D, truncatedNormal, zeros} from '@tensorflow/tfjs-core';
+import {doc, eye, linalg, ones, randomUniform, scalar, Scalar, serialization, Tensor, Tensor2D, truncatedNormal, zeros} from '@tensorflow/tfjs-core';
 
 import * as K from './backend/tfjs_backend';
 import {checkDataFormat, DataFormat} from './common';
@@ -258,7 +258,7 @@ export class Identity extends Initializer {
           'Identity matrix initializer can only be used for' +
           ' 2D square matrices.');
     } else {
-      return K.scalarTimesArray(this.gain, K.eye(shape[0]));
+      return K.scalarTimesArray(this.gain, eye(shape[0]));
     }
   }
 
@@ -560,14 +560,17 @@ export class Orthogonal extends Initializer {
       throw new NotImplementedError(
           'The Orthogonal Initializer does not support non-2D shapes yet.');
     }
-    const normalizedShape = shape[0] >= shape[1] ? shape : [shape[1], shape[0]];
-    // TODO(cais): Add seed support.
-    const a = K.randomNormal(normalizedShape, 0, 1, DType.float32);
-    let q = K.qr(a as Tensor2D)[0];
-    if (q.shape[1] > normalizedShape[1]) {
-      q = q.slice([0, 0], normalizedShape);
+    if (shape[0] * shape[1] > 2000) {
+      console.warn(
+          `Orthgonal initializer is being called on a matrix with more than ` +
+          `2000 (${shape[0] * shape[1]}) elements: Slowness may result.`);
     }
-    if (shape[0] < shape[1]) {
+
+    // TODO(cais): Add seed support.
+    const normalizedShape = shape[0] >= shape[1] ? [shape[1], shape[0]] : shape;
+    const a = K.randomNormal(normalizedShape, 0, 1, DType.float32) as Tensor2D;
+    let q = linalg.gramSchmidt(a) as Tensor2D;
+    if (shape[0] > shape[1]) {
       q = q.transpose();
     }
     return K.scalarTimesArray(K.getScalar(this.gain), q);

--- a/src/initializers_test.ts
+++ b/src/initializers_test.ts
@@ -13,9 +13,8 @@
  */
 
 // tslint:disable:max-line-length
-import {serialization, Tensor2D, tensor2d} from '@tensorflow/tfjs-core';
+import {eye, serialization, Tensor2D, tensor2d} from '@tensorflow/tfjs-core';
 
-import * as K from './backend/tfjs_backend';
 import * as tfl from './index';
 import {checkDistribution, checkFanMode, getInitializer, serializeInitializer, VALID_DISTRIBUTION_VALUES, VALID_FAN_MODE_VALUES, VarianceScaling} from './initializers';
 import {DType} from './types';
@@ -452,7 +451,7 @@ describeMathCPUAndGPU('Orthogonal Initializer', () => {
     expect(w.shape).toEqual([2, 2]);
     expect(w.dtype).toEqual(DType.float32);
     // Assert that columns of w are orthogonal (w is a unitary matrix).
-    expectTensorsClose(w.transpose().matMul(w), K.eye(2));
+    expectTensorsClose(w.transpose().matMul(w), eye(2));
   });
 
   it('1x1 with gain', () => {
@@ -471,7 +470,7 @@ describeMathCPUAndGPU('Orthogonal Initializer', () => {
     expect(w.shape).toEqual([4, 2]);
     expect(w.dtype).toEqual(DType.float32);
     // Assert that columns of w are orthogonal.
-    expectTensorsClose(w.transpose().matMul(w), K.eye(2));
+    expectTensorsClose(w.transpose().matMul(w), eye(2));
   });
 
   it('2x4', () => {
@@ -480,6 +479,19 @@ describeMathCPUAndGPU('Orthogonal Initializer', () => {
     expect(w.shape).toEqual([2, 4]);
     expect(w.dtype).toEqual(DType.float32);
     // Assert that columns of w are orthogonal.
-    expectTensorsClose(w.matMul(w.transpose()), K.eye(2));
+    expectTensorsClose(w.matMul(w.transpose()), eye(2));
+  });
+
+  it('64x64', () => {
+    // Disable console warning during this test.
+    // Silence the large-size orthogonal matrix warnings.
+    spyOn(console, 'warn').and.callFake((message: string) => {});
+    const n = 64;
+    const init = getInitializer('Orthogonal');
+    const w = init.apply([n, n], DType.float32) as Tensor2D;
+    expect(w.shape).toEqual([n, n]);
+    expect(w.dtype).toEqual(DType.float32);
+    // Assert that columns of w are orthogonal.
+    expectTensorsClose(w.matMul(w.transpose()), eye(n));
   });
 });


### PR DESCRIPTION
instead of QR decomposition. This resutls in about 2x speed up
on CPU and 18x speed up on WebGL.

Also in this CL:
- Add test for relatively large-sized orthogonal matrix initialization
  to prevent speed regression.
- In `Orthogonal.apply()`, print a console warning about possible
  slowness if the # of elements in the matrix is > 2000.
- Remove tfjs_backend's `eye` function and use the `tf.eye` from added to
  tfjs-core recently.

BUG Fix slowness in `Orthgonal` initializer for some RNN layers.

Fixes: https://github.com/tensorflow/tfjs/issues/245

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/172)
<!-- Reviewable:end -->
