### PR TITLE
Delete un-needed code regarding an fixed TODO.

### DIFF
--- a/src/backend/tfjs_backend.ts
+++ b/src/backend/tfjs_backend.ts
@@ -19,7 +19,6 @@ import {DataType, dispose, onesLike as coreOnesLike, Scalar, scalar, Tensor, Ten
 import {checkDataFormat, checkPaddingMode, checkPoolMode, DataFormat, nameScope as commonNameScope, PaddingMode, PoolMode} from '../common';
 import {NotImplementedError, ValueError} from '../errors';
 import {RnnStepFunction, Shape, SymbolicTensor} from '../types';
-import {pyNormalizeArrayIndex} from '../utils/generic_utils';
 import * as math_utils from '../utils/math_utils';
 import {LayerVariable} from '../variables';
 import {epsilon as common_epsilon} from './common';
@@ -126,32 +125,6 @@ export function ndim(x: Tensor|SymbolicTensor): number {
 export function dtype(x: Tensor|SymbolicTensor): DataType {
   // TODO(michaelterry): Update if additional data types are available.
   return (x instanceof Tensor) ? DEFAULT_DTYPE : (x as SymbolicTensor).dtype;
-}
-
-/**
- * Normalize an axis specification, allowing negative indices (to enable
- * counting from the end).
- *
- * For example, if axis = -1 for an Tensor x with shape of [2, 2], then
- * normalizeAxis(x, -1) = 1.
- *
- * TODO(michaelterry): Remove once the following issue is resolved:
- *   https://github.com/PAIR-code/deeplearnjs/issues/477
- *
- * @param x The Tensor to normalize against.
- * @param axis One or more axis indices to normalize. If an array is passed in,
- *   all values must be non-null/defined.
- */
-export function normalizeAxis(
-    x: Tensor|SymbolicTensor, axis: number|number[]): number|number[] {
-  if (axis == null) {
-    return axis;
-  }
-  const xShape = shape(x);
-  if (Array.isArray(axis)) {
-    return axis.map(thisAxis => pyNormalizeArrayIndex(xShape, thisAxis));
-  }
-  return pyNormalizeArrayIndex(xShape, axis);
 }
 
 /**
@@ -871,8 +844,6 @@ export function oneHot(indices: Tensor, numClasses: number): Tensor {
  */
 export function mean(
     x: Tensor, axis?: number|number[], keepDims?: boolean): Scalar|Tensor {
-  // TODO(michaelterry): Remove once negative supported axes in deeplearn.js
-  axis = normalizeAxis(x, axis);
   return tfc.mean(x, axis, keepDims);
 }
 

--- a/src/backend/tfjs_backend_test.ts
+++ b/src/backend/tfjs_backend_test.ts
@@ -131,36 +131,6 @@ describe('dtype', () => {
   });
 });
 
-describe('normalizeAxis', () => {
-  let x: Tensor;
-  beforeEach(() => {
-    x = zeros([2, 2, 2, 2]);
-  });
-
-  it('handles single-value axis.', () => {
-    expect(K.normalizeAxis(x, -1)).toEqual(3);
-  });
-
-  it('handles an array of axes.', () => {
-    expect(K.normalizeAxis(x, [-1, 1])).toEqual([3, 1]);
-  });
-
-  it('returns null if axis is null.', () => {
-    expect(K.normalizeAxis(x, null)).toBeNull();
-  });
-
-  it('throws exception if a single index is invalid.', () => {
-    expect(() => K.normalizeAxis(x, 4)).toThrowError();
-  });
-
-  it('throws exception if a single index in an array is invalid.', () => {
-    expect(() => K.normalizeAxis(x, [1, 4])).toThrowError();
-  });
-
-  it('throws exception if a single index in an array is null.', () => {
-    expect(() => K.normalizeAxis(x, [null])).toThrowError();
-  });
-});
 
 describeMathCPU('countParams', () => {
   it('Scalar', () => {

--- a/src/utils/generic_utils.ts
+++ b/src/utils/generic_utils.ts
@@ -60,36 +60,6 @@ export function pyGetAttr<T>(obj: any, attrName: string, defaultValue?: T): T {
   return defaultValue;
 }
 
-/**
- * Python allows indexing into a list from the end using negative values. This
- * utility functions translates an index into a list into a non-negative index,
- * allowing for negative indices, just like Python.
- *
- * @param x An array.
- * @param index The index to normalize.
- * @return A non-negative index, within range.
- * @exception IndexError if index is not within [-x.length, x.length)
- * @exception ValueError if x or index is null or undefined
- */
-export function pyNormalizeArrayIndex<T>(x: T[], index: number): number {
-  if (x == null || index == null) {
-    throw new ValueError(
-        `Must provide a valid array and index for ` +
-        `pyNormalizeArrayIndex(). Got array ${x} and index ${index}.`);
-  }
-  const errMsg = `Index ${index} out of range for array of length ${x.length}`;
-  if (index < 0) {
-    if (index < -x.length) {
-      throw new IndexError(errMsg);
-    }
-    return x.length + index;
-  }
-  if (index >= x.length) {
-    throw new IndexError(errMsg);
-  }
-  return index;
-}
-
 export function assert(val: boolean, message?: string): void {
   if (!val) {
     throw new AssertionError(message);

--- a/src/utils/generic_utils.ts
+++ b/src/utils/generic_utils.ts
@@ -13,11 +13,8 @@
 // tslint:disable:max-line-length
 import {DataType, serialization, Tensor} from '@tensorflow/tfjs-core';
 
-import {AssertionError, AttributeError, IndexError, ValueError} from '../errors';
+import {AssertionError, AttributeError, ValueError} from '../errors';
 import {Shape} from '../types';
-
-
-
 // tslint:enable
 
 /**

--- a/src/utils/generic_utils_test.ts
+++ b/src/utils/generic_utils_test.ts
@@ -9,7 +9,6 @@
  */
 
 import * as utils from './generic_utils';
-import {pyNormalizeArrayIndex} from './generic_utils';
 
 describe('pyListRepeat() ', () => {
   it('creates an empty array for 0 numValues', () => {
@@ -75,39 +74,6 @@ describe('pyListRepeat() ', () => {
          expect(utils.pyGetAttr(obj, key, defaultValue)).toBeNull();
        });
   });
-});
-
-describe('pyNormalizeArrayIndex', () => {
-  const x = [2, 2, 2];
-
-  for (const index of [0, 1, 2]) {
-    it('returns index if index >= 0 and index < x.length', () => {
-      expect(pyNormalizeArrayIndex(x, index)).toEqual(index);
-    });
-  }
-
-  for (const [index, expected] of [[-1, 2], [-2, 1], [-3, 0]]) {
-    it('returns index if index < 0 and abs(index) <= x.length', () => {
-      expect(pyNormalizeArrayIndex(x, index)).toEqual(expected);
-    });
-  }
-
-  it('throws an exception if the array is null', () => {
-    expect(() => pyNormalizeArrayIndex(null, 0))
-        .toThrowError(/Must provide a valid array/);
-  });
-
-  it('throws an exception if the index is null', () => {
-    expect(() => pyNormalizeArrayIndex(x, null))
-        .toThrowError(/Must provide a valid array/);
-  });
-
-  for (const index of [3, -4]) {
-    it('throws an exception if the index is out of range', () => {
-      expect(() => pyNormalizeArrayIndex(x, index))
-          .toThrowError(/Index.*out of range/);
-    });
-  }
 });
 
 describe('assert', () => {


### PR DESCRIPTION
The referenced issue from the old deeplearn repo was fixed before we switched to tensorflow.js, so this allows us to clean up a lot of un-needed code.

This PR could also be expanded to remove definition of mean in backend (and adjust all call sites to go to tfc.mean), however I felt that complicated/confused the changes around the generally pure deletion.  So I'm planning that as a follow-up PR unless there's strong feelings that I should fold it in here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/178)
<!-- Reviewable:end -->
