### PR TITLE
Remove mean and argmax from layers backend

### DIFF
--- a/src/backend/tfjs_backend.ts
+++ b/src/backend/tfjs_backend.ts
@@ -834,30 +834,6 @@ export function oneHot(indices: Tensor, numClasses: number): Tensor {
 /* Elementary math functions. */
 
 /**
- * Mean of a tensor, alongside the specified axis.
- * @param x: Input tensor.
- * @param axis: An integer or an Array of integers.
- * @param keepDims: A boolean, whether to keep the dimensions or not
- *   If `keepDims` is `false`, the rank of the tensor is reduced
- *   by `1 for each entry in `axis`. If `keepDims` is `true`,
- *   the reduced dimensions are retained with length 1.
- */
-export function mean(
-    x: Tensor, axis?: number|number[], keepDims?: boolean): Scalar|Tensor {
-  return tfc.mean(x, axis, keepDims);
-}
-
-/**
- * Returns the index of the maximum value along an axis.
- * @param x Input tensor.
- * @param axis Axis along which to perform the reduction.
- * @returns The argmax index tensor.
- */
-export function argmax(x: Tensor, axis = -1): Tensor {
-  return tfc.argMax(x, axis);
-}
-
-/**
  * Retrieves the elements of indices `indices` in the tensor `reference`.
  * @param reference A tensor.
  * @param indices An integer tensor of indices or an `Array` of integers.

--- a/src/backend/tfjs_backend_test.ts
+++ b/src/backend/tfjs_backend_test.ts
@@ -1013,59 +1013,6 @@ describeMathCPUAndGPU('OneHot', () => {
   });
 });
 
-describeMathCPUAndGPU('Mean', () => {
-  it('reduce_mean', () => {
-    expectTensorsClose(
-      K.mean(tensor2d([[4, -1], [0, -2]], [2, 2])), scalar(0.25));
-  });
-  it('mean 2D, axis=1, keepdims=false', () => {
-    expectTensorsClose(
-      K.mean(tensor2d([[4, -1], [0, -2]], [2, 2]), 1), tensor1d([1.5, -1]));
-  });
-  it('mean 2D, axis=1, keepdims=true', () => {
-    expectTensorsClose(
-      K.mean(tensor2d([[4, -1], [0, -2]], [2, 2]), 1, true),
-      tensor2d([[1.5], [-1]], [2, 1]));
-  });
-  it('mean 3D, axis=[1,2], keepdims=false', () => {
-    expectTensorsClose(
-      K.mean(
-        tensor3d([[[4, -1], [0, -2]], [[40, -10], [0, -20]]], [2, 2, 2]),
-        [1, 2]),
-      tensor1d([0.25, 2.5]));
-  });
-  it('mean 3D, axis=[1,2], keepdims=true', () => {
-    expectTensorsClose(
-      K.mean(
-        tensor3d([[[4, -1], [0, -2]], [[40, -10], [0, -20]]], [2, 2, 2]),
-        [1, 2], true),
-      tensor3d([[[0.25]], [[2.5]]], [2, 1, 1]));
-  });
-  it('reduce_mean keepdims=true', () => {
-    expectTensorsClose(
-      K.mean(tensor2d([[4, -1], [0, -2]], [2, 2]), undefined, true),
-      tensor2d([[0.25]], [1, 1]));
-  });
-});
-
-describeMathCPUAndGPU('Argmax', () => {
-  it('2D, default axis', () => {
-    expectTensorsClose(
-      K.argmax(tensor2d([[4, -1], [-2, 0]], [2, 2])),
-      tensor1d([0, 1], 'int32'));
-  });
-  it('2D, axis=-1', () => {
-    expectTensorsClose(
-      K.argmax(tensor2d([[4, -1], [-2, 0]], [2, 2]), -1),
-      tensor1d([0, 1], 'int32'));
-  });
-  it('2D, axis=0', () => {
-    expectTensorsClose(
-      K.argmax(tensor2d([[4, -1], [3, 2]], [2, 2]), 0),
-      tensor1d([0, 1], 'int32'));
-  });
-});
-
 describeMathCPUAndGPU('Gather', () => {
   it('1D, Array of numbers with repeats', () => {
     expectTensorsClose(
@@ -1974,7 +1921,7 @@ describe('inTrainPhase', () => {
  * @param states
  */
 function rnnStepForTest(inputs: Tensor, states: Tensor[]): [Tensor, Tensor[]] {
-  const mean = K.mean(inputs) as Scalar;
+  const mean = tfc.mean(inputs) as Scalar;
   const newStates = states.map(state => K.scalarPlusArray(mean, state));
   const output = tfc.neg(newStates[0]);
   return [output, newStates];
@@ -2118,7 +2065,8 @@ describeMathCPUAndGPU('gradients', () => {
   it('Simple mean: 1 variable', () => {
     const var1 =
       new LayerVariable(K.scalarTimesArray(scalar(2.0), tfc.ones([2, 2])));
-    const gradients = K.gradients(() => K.mean(var1.read()) as Scalar, [var1]);
+    const gradients = K.gradients(
+      () => tfc.mean(var1.read()) as Scalar, [var1]);
     expect(gradients.length).toEqual(1);
     expectTensorsClose(
       tensor2d([[0.25, 0.25], [0.25, 0.25]], [2, 2]), gradients[0]);
@@ -2127,7 +2075,7 @@ describeMathCPUAndGPU('gradients', () => {
     const var1 = new LayerVariable(tensor2d([[1, 0], [0, 0]], [2, 2]));
     const var2 = new LayerVariable(tensor2d([[1, 0], [0, 1]], [2, 2]));
     const gradients = K.gradients(
-      () => K.mean(K.dot(var1.read(), var2.read())) as Scalar, [var1, var2]);
+      () => tfc.mean(K.dot(var1.read(), var2.read())) as Scalar, [var1, var2]);
     expect(gradients.length).toEqual(2);
     // d(loss) / d(var1).
     expectTensorsClose(

--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -1404,7 +1404,7 @@ export class Model extends Container {
         for (let i = 0; i < this.lossFunctions.length; ++i) {
           const lossFunction = this.lossFunctions[i];
           // TODO(cais): Add sample weighting and replace the simple averaging.
-          const loss = K.mean(lossFunction(targets[i], outputs[i])) as Scalar;
+          const loss = tfc.mean(lossFunction(targets[i], outputs[i])) as Scalar;
           if (i === 0) {
             totalLoss = loss;
           } else {
@@ -1418,7 +1418,7 @@ export class Model extends Container {
           const outputIndex = this.metricsTensors[i][1];
           // TODO(cais): Replace K.mean() with a proper weighting function.
           const meanMetric =
-              K.mean(metric(targets[outputIndex], outputs[outputIndex]));
+              tfc.mean(metric(targets[outputIndex], outputs[outputIndex]));
           valOutputs.push(meanMetric as Scalar);
         }
         return valOutputs;
@@ -1574,7 +1574,7 @@ export class Model extends Container {
           const loss = lossFunction(targets[i], outputs[i]);
           losses.push(loss);
           // TODO(cais): push Scalar instead.
-          const meanLoss = K.mean(loss) as Scalar;
+          const meanLoss = tfc.mean(loss) as Scalar;
           // TODO(cais): Use a scope() instead, to avoid ownership.
           lossValues.push(meanLoss);
           if (i === 0) {
@@ -1592,14 +1592,14 @@ export class Model extends Container {
           const outputIndex = this.metricsTensors[i][1];
           // TODO(cais): Replace K.mean() with a proper weighting function.
           const meanMetric =
-              K.mean(metric(targets[outputIndex], outputs[outputIndex])) as
+              tfc.mean(metric(targets[outputIndex], outputs[outputIndex])) as
               Scalar;
           tfc.keep(meanMetric);
           // TODO(cais): Use a scope() instead, to avoid ownership.
           metricsValues.push(meanMetric);
         }
 
-        totalLoss = K.mean(totalLoss);
+        totalLoss = tfc.mean(totalLoss);
 
         // Add regularizer penalties.
         this.calculateLosses().forEach(regularizerLoss => {

--- a/src/layers/pooling.ts
+++ b/src/layers/pooling.ts
@@ -13,6 +13,7 @@
  */
 
 // tslint:disable:max-line-length
+import * as tfc from '@tensorflow/tfjs-core';
 import {max, serialization, squeeze, Tensor} from '@tensorflow/tfjs-core';
 
 import * as K from '../backend/tfjs_backend';
@@ -347,7 +348,7 @@ export class GlobalAveragePooling1D extends GlobalPooling1D {
 
   call(inputs: Tensor|Tensor[], kwargs: Kwargs): Tensor|Tensor[] {
     const input = generic_utils.getExactlyOneTensor(inputs);
-    return K.mean(input, 1);
+    return tfc.mean(input, 1);
   }
 }
 serialization.SerializationMap.register(GlobalAveragePooling1D);
@@ -435,9 +436,9 @@ export class GlobalAveragePooling2D extends GlobalPooling2D {
   call(inputs: Tensor|Tensor[], kwargs: Kwargs): Tensor|Tensor[] {
     const input = generic_utils.getExactlyOneTensor(inputs);
     if (this.dataFormat === 'channelsLast') {
-      return K.mean(input, [1, 2]);
+      return tfc.mean(input, [1, 2]);
     } else {
-      return K.mean(input, [2, 3]);
+      return tfc.mean(input, [2, 3]);
     }
   }
 }

--- a/src/layers/recurrent_test.ts
+++ b/src/layers/recurrent_test.ts
@@ -13,6 +13,7 @@
  */
 
 // tslint:disable:max-line-length
+import * as tfc from '@tensorflow/tfjs-core';
 import {neg, ones, Scalar, scalar, Tensor, tensor2d, tensor3d, train, transpose, zeros} from '@tensorflow/tfjs-core';
 
 import * as K from '../backend/tfjs_backend';
@@ -46,7 +47,7 @@ class RNNCellForTest extends RNNCell {
     inputs = inputs as Tensor[];
     const dataInputs = inputs[0];
     const states = inputs.slice(1);
-    const mean = K.mean(dataInputs) as Scalar;
+    const mean = tfc.mean(dataInputs) as Scalar;
     const newStates = states.map(state => K.scalarPlusArray(mean, state));
     const output = neg(newStates[0]);
     return [output].concat(newStates);
@@ -511,7 +512,7 @@ describeMathCPUAndGPU('SimpleRNN Tensor', () => {
     const y = zeros([batchSize, 1]);
     dense.apply(simpleRNN.apply(x));
     const lossFn = () => {
-      return K.mean(metrics.mse(y, dense.apply(simpleRNN.apply(x)) as Tensor))
+      return tfc.mean(metrics.mse(y, dense.apply(simpleRNN.apply(x)) as Tensor))
           .asScalar();
     };
     for (let i = 0; i < 2; ++i) {
@@ -739,7 +740,7 @@ describeMathCPUAndGPU('GRU Tensor', () => {
     const y = ones([batchSize, 1]);
     dense.apply(gru.apply(x));
     const lossFn = () => {
-      return K.mean(metrics.mse(y, dense.apply(gru.apply(x)) as Tensor))
+      return tfc.mean(metrics.mse(y, dense.apply(gru.apply(x)) as Tensor))
           .asScalar();
     };
     for (let i = 0; i < 2; ++i) {
@@ -978,7 +979,7 @@ describeMathCPUAndGPU('LSTM Tensor', () => {
       const y = ones([batchSize, 1]);
       dense.apply(lstm.apply(x));
       const lossFn = () => {
-        return K.mean(metrics.mse(y, dense.apply(lstm.apply(x)) as Tensor))
+        return tfc.mean(metrics.mse(y, dense.apply(lstm.apply(x)) as Tensor))
             .asScalar();
       };
       for (let i = 0; i < 2; ++i) {

--- a/src/losses.ts
+++ b/src/losses.ts
@@ -33,7 +33,7 @@ import {LossOrMetricFn} from './types';
  * @return Mean squared error Tensor.
  */
 export function meanSquaredError(yTrue: Tensor, yPred: Tensor): Tensor {
-  return K.mean(K.square(tfc.sub(yPred, yTrue)), -1);
+  return tfc.mean(K.square(tfc.sub(yPred, yTrue)), -1);
 }
 
 /**
@@ -55,7 +55,7 @@ export function meanSquaredError(yTrue: Tensor, yPred: Tensor): Tensor {
  * @return Mean absolute error Tensor.
  */
 export function meanAbsoluteError(yTrue: Tensor, yPred: Tensor): Tensor {
-  return K.mean(tfc.abs(tfc.sub(yPred, yTrue)), -1);
+  return tfc.mean(tfc.abs(tfc.sub(yPred, yTrue)), -1);
 }
 
 /**
@@ -80,7 +80,7 @@ export function meanAbsolutePercentageError(
   const clippedTrue =
       tfc.clipByValue(tfc.abs(yTrue), K.epsilon(), Number.MAX_VALUE);
   const absResult = tfc.abs(tfc.div(diff, clippedTrue));
-  return K.scalarTimesArray(K.getScalar(100.0), K.mean(absResult, -1));
+  return K.scalarTimesArray(K.getScalar(100.0), tfc.mean(absResult, -1));
 }
 
 export function meanSquaredLogarithmicError(
@@ -93,7 +93,7 @@ export function meanSquaredLogarithmicError(
   const clippedTrue = tfc.clipByValue(yTrue, K.epsilon(), Number.MAX_VALUE);
   const secondLog = tfc.log(K.scalarPlusArray(one, clippedTrue));
 
-  return K.mean(K.square(tfc.sub(firstLog, secondLog)), -1);
+  return tfc.mean(K.square(tfc.sub(firstLog, secondLog)), -1);
 }
 
 export function squaredHinge(yTrue: Tensor, yPred: Tensor): Tensor {
@@ -101,7 +101,7 @@ export function squaredHinge(yTrue: Tensor, yPred: Tensor): Tensor {
   const one = K.getScalar(1.0);
   const maxResult =
       tfc.maximum(zeroTensor, tfc.sub(one, tfc.mul(yTrue, yPred)));
-  return K.mean(K.square(maxResult), -1);
+  return tfc.mean(K.square(maxResult), -1);
 }
 
 export function hinge(yTrue: Tensor, yPred: Tensor): Tensor {
@@ -109,7 +109,7 @@ export function hinge(yTrue: Tensor, yPred: Tensor): Tensor {
   const one = K.getScalar(1.0);
   const maxResult =
       tfc.maximum(zeroTensor, tfc.sub(one, tfc.mul(yTrue, yPred)));
-  return K.mean(maxResult, -1);
+  return tfc.mean(maxResult, -1);
 }
 
 export function categoricalHinge(yTrue: Tensor, yPred: Tensor): Tensor {
@@ -136,7 +136,7 @@ export function logcosh(yTrue: Tensor, yPred: Tensor): Tensor {
           predictionDiff,
           K.softplus(K.scalarTimesArray(K.getScalar(-2.0), predictionDiff))),
       log2);
-  return K.mean(logcoshResult, -1);
+  return tfc.mean(logcoshResult, -1);
 }
 
 export function categoricalCrossentropy(yTrue: Tensor, yPred: Tensor): Tensor {
@@ -149,7 +149,7 @@ export function sparseCategoricalCrossentropy(
 }
 
 export function binaryCrossentropy(yTrue: Tensor, yPred: Tensor): Tensor {
-  return K.mean(K.binaryCrossentropy(yTrue, yPred), -1);
+  return tfc.mean(K.binaryCrossentropy(yTrue, yPred), -1);
 }
 
 export function kullbackLeiblerDivergence(
@@ -162,7 +162,7 @@ export function kullbackLeiblerDivergence(
 
 export function poisson(yTrue: Tensor, yPred: Tensor): Tensor {
   const logPred = tfc.log(K.scalarPlusArray(K.getScalar(K.epsilon()), yPred));
-  return K.mean(tfc.sub(yPred, tfc.mul(yTrue, logPred)), -1);
+  return tfc.mean(tfc.sub(yPred, tfc.mul(yTrue, logPred)), -1);
 }
 
 /**

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -13,7 +13,8 @@
  */
 
 // tslint:disable:max-line-length
-import {equal, greater, onesLike, Tensor} from '@tensorflow/tfjs-core';
+import * as tfc from '@tensorflow/tfjs-core';
+import {Tensor} from '@tensorflow/tfjs-core';
 import * as K from './backend/tfjs_backend';
 import {NotImplementedError, ValueError} from './errors';
 import {categoricalCrossentropy as categoricalCrossentropyLoss, cosineProximity, meanAbsoluteError, meanAbsolutePercentageError, meanSquaredError, sparseCategoricalCrossentropy as sparseCategoricalCrossentropyLoss} from './losses';
@@ -49,9 +50,9 @@ import {LossOrMetricFn} from './types';
  */
 export function binaryAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
   // TODO(cais): Maybe avoid creating a new Scalar on every invocation.
-  const threshold = K.scalarTimesArray(K.getScalar(0.5), onesLike(yPred));
-  const yPredThresholded = K.cast(greater(yPred, threshold), yTrue.dtype);
-  return K.mean(equal(yTrue, yPredThresholded), -1);
+  const threshold = K.scalarTimesArray(K.getScalar(0.5), tfc.onesLike(yPred));
+  const yPredThresholded = K.cast(tfc.greater(yPred, threshold), yTrue.dtype);
+  return tfc.mean(tfc.equal(yTrue, yPredThresholded), -1);
 }
 
 /**
@@ -71,7 +72,8 @@ export function binaryAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
  * @return Accuracy Tensor.
  */
 export function categoricalAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
-  return K.cast(equal(K.argmax(yTrue, -1), K.argmax(yPred, -1)), 'float32');
+  return K.cast(
+      tfc.equal(tfc.argMax(yTrue, -1), tfc.argMax(yPred, -1)), 'float32');
 }
 
 /**
@@ -90,7 +92,7 @@ export function categoricalAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
  * @return Accuracy Tensor.
  */
 export function binaryCrossentropy(yTrue: Tensor, yPred: Tensor): Tensor {
-  return K.mean(K.binaryCrossentropy(yTrue, yPred), -1);
+  return tfc.mean(K.binaryCrossentropy(yTrue, yPred), -1);
 }
 
 export function sparseCategoricalAccuracy(


### PR DESCRIPTION
Removes mean and argmax from layer's backend and changes code to directly use core's mean and argMax respectively. argMax had a different default axis in core versus layers, however all existing uses in layers explicitly passed a value rather than relying on the default.