### PR TITLE
Apply tidy/@operation systematically across tfjs-layers.

### DIFF
--- a/src/activations.ts
+++ b/src/activations.ts
@@ -10,7 +10,7 @@
 
 // Layer activation functions
 import * as tfc from '@tensorflow/tfjs-core';
-import {scalar, serialization, Tensor} from '@tensorflow/tfjs-core';
+import {scalar, serialization, Tensor, tidy} from '@tensorflow/tfjs-core';
 
 import * as K from './backend/tfjs_backend';
 import {deserializeKerasObject} from './utils/generic_utils';
@@ -47,7 +47,9 @@ export class Elu extends Activation {
    * @return Output of the ELU activation.
    */
   apply(x: Tensor, alpha = 1): Tensor {
-    return K.elu(x, alpha);
+    return tidy(() => {
+      return K.elu(x, alpha);
+    });
   }
 }
 serialization.SerializationMap.register(Elu);
@@ -62,7 +64,9 @@ serialization.SerializationMap.register(Elu);
 export class Selu extends Activation {
   static readonly className = 'selu';
   apply(x: Tensor): Tensor {
-    return tfc.selu(x);
+    return tidy(() => {
+      return tfc.selu(x);
+    });
   }
 }
 serialization.SerializationMap.register(Selu);
@@ -73,7 +77,9 @@ serialization.SerializationMap.register(Selu);
 export class Relu extends Activation {
   static readonly className = 'relu';
   apply(x: Tensor): Tensor {
-    return tfc.relu(x);
+    return tidy(() => {
+      return tfc.relu(x);
+    });
   }
 }
 serialization.SerializationMap.register(Relu);
@@ -87,7 +93,9 @@ serialization.SerializationMap.register(Relu);
 export class Relu6 extends Activation {
   static readonly className = 'relu6';
   apply(x: Tensor): Tensor {
-    return tfc.minimum(scalar(6.0), tfc.relu(x));
+    return tidy(() => {
+      return tfc.minimum(scalar(6.0), tfc.relu(x));
+    });
   }
 }
 serialization.SerializationMap.register(Relu6);
@@ -96,7 +104,9 @@ serialization.SerializationMap.register(Relu6);
 export class Linear extends Activation {
   static readonly className = 'linear';
   apply(x: Tensor): Tensor {
-    return x;
+    return tidy(() => {
+      return x;
+    });
   }
 }
 serialization.SerializationMap.register(Linear);
@@ -107,7 +117,9 @@ serialization.SerializationMap.register(Linear);
 export class Sigmoid extends Activation {
   static readonly className = 'sigmoid';
   apply(x: Tensor): Tensor {
-    return tfc.sigmoid(x);
+    return tidy(() => {
+      return tfc.sigmoid(x);
+    });
   }
 }
 serialization.SerializationMap.register(Sigmoid);
@@ -118,7 +130,9 @@ serialization.SerializationMap.register(Sigmoid);
 export class HardSigmoid extends Activation {
   static readonly className = 'hardSigmoid';
   apply(x: Tensor): Tensor {
-    return K.hardSigmoid(x);
+    return tidy(() => {
+      return K.hardSigmoid(x);
+    });
   }
 }
 serialization.SerializationMap.register(HardSigmoid);
@@ -129,7 +143,9 @@ serialization.SerializationMap.register(HardSigmoid);
 export class Softplus extends Activation {
   static readonly className = 'softplus';
   apply(x: Tensor): Tensor {
-    return K.softplus(x);
+    return tidy(() => {
+      return K.softplus(x);
+    });
   }
 }
 serialization.SerializationMap.register(Softplus);
@@ -140,7 +156,9 @@ serialization.SerializationMap.register(Softplus);
 export class Softsign extends Activation {
   static readonly className = 'softsign';
   apply(x: Tensor): Tensor {
-    return K.softsign(x);
+    return tidy(() => {
+      return K.softsign(x);
+    });
   }
 }
 serialization.SerializationMap.register(Softsign);
@@ -151,7 +169,9 @@ serialization.SerializationMap.register(Softsign);
 export class Tanh extends Activation {
   static readonly className = 'tanh';
   apply(x: Tensor): Tensor {
-    return tfc.tanh(x);
+    return tidy(() => {
+      return tfc.tanh(x);
+    });
   }
 }
 serialization.SerializationMap.register(Tanh);
@@ -174,7 +194,9 @@ export class Softmax extends Activation {
    * @throws ValueError: In case `dim(x) < 2`.
    */
   apply(x: Tensor, axis: number = (-1)): Tensor {
-    return tfc.softmax(x, axis);
+    return tidy(() => {
+      return tfc.softmax(x, axis);
+    });
   }
 }
 serialization.SerializationMap.register(Softmax);

--- a/src/activations.ts
+++ b/src/activations.ts
@@ -47,9 +47,7 @@ export class Elu extends Activation {
    * @return Output of the ELU activation.
    */
   apply(x: Tensor, alpha = 1): Tensor {
-    return tidy(() => {
-      return K.elu(x, alpha);
-    });
+    return tidy(() => K.elu(x, alpha));
   }
 }
 serialization.SerializationMap.register(Elu);
@@ -64,9 +62,7 @@ serialization.SerializationMap.register(Elu);
 export class Selu extends Activation {
   static readonly className = 'selu';
   apply(x: Tensor): Tensor {
-    return tidy(() => {
-      return tfc.selu(x);
-    });
+    return tidy(() => tfc.selu(x));
   }
 }
 serialization.SerializationMap.register(Selu);
@@ -77,9 +73,7 @@ serialization.SerializationMap.register(Selu);
 export class Relu extends Activation {
   static readonly className = 'relu';
   apply(x: Tensor): Tensor {
-    return tidy(() => {
-      return tfc.relu(x);
-    });
+    return tidy(() => tfc.relu(x));
   }
 }
 serialization.SerializationMap.register(Relu);
@@ -93,9 +87,7 @@ serialization.SerializationMap.register(Relu);
 export class Relu6 extends Activation {
   static readonly className = 'relu6';
   apply(x: Tensor): Tensor {
-    return tidy(() => {
-      return tfc.minimum(scalar(6.0), tfc.relu(x));
-    });
+    return tidy(() => tfc.minimum(scalar(6.0), tfc.relu(x)));
   }
 }
 serialization.SerializationMap.register(Relu6);
@@ -104,9 +96,7 @@ serialization.SerializationMap.register(Relu6);
 export class Linear extends Activation {
   static readonly className = 'linear';
   apply(x: Tensor): Tensor {
-    return tidy(() => {
-      return x;
-    });
+    return tidy(() => x);
   }
 }
 serialization.SerializationMap.register(Linear);
@@ -117,9 +107,7 @@ serialization.SerializationMap.register(Linear);
 export class Sigmoid extends Activation {
   static readonly className = 'sigmoid';
   apply(x: Tensor): Tensor {
-    return tidy(() => {
-      return tfc.sigmoid(x);
-    });
+    return tidy(() => tfc.sigmoid(x));
   }
 }
 serialization.SerializationMap.register(Sigmoid);
@@ -130,9 +118,7 @@ serialization.SerializationMap.register(Sigmoid);
 export class HardSigmoid extends Activation {
   static readonly className = 'hardSigmoid';
   apply(x: Tensor): Tensor {
-    return tidy(() => {
-      return K.hardSigmoid(x);
-    });
+    return tidy(() => K.hardSigmoid(x));
   }
 }
 serialization.SerializationMap.register(HardSigmoid);
@@ -143,9 +129,7 @@ serialization.SerializationMap.register(HardSigmoid);
 export class Softplus extends Activation {
   static readonly className = 'softplus';
   apply(x: Tensor): Tensor {
-    return tidy(() => {
-      return K.softplus(x);
-    });
+    return tidy(() => K.softplus(x));
   }
 }
 serialization.SerializationMap.register(Softplus);
@@ -156,9 +140,7 @@ serialization.SerializationMap.register(Softplus);
 export class Softsign extends Activation {
   static readonly className = 'softsign';
   apply(x: Tensor): Tensor {
-    return tidy(() => {
-      return K.softsign(x);
-    });
+    return tidy(() => K.softsign(x));
   }
 }
 serialization.SerializationMap.register(Softsign);
@@ -169,9 +151,7 @@ serialization.SerializationMap.register(Softsign);
 export class Tanh extends Activation {
   static readonly className = 'tanh';
   apply(x: Tensor): Tensor {
-    return tidy(() => {
-      return tfc.tanh(x);
-    });
+    return tidy(() => tfc.tanh(x));
   }
 }
 serialization.SerializationMap.register(Tanh);
@@ -194,9 +174,7 @@ export class Softmax extends Activation {
    * @throws ValueError: In case `dim(x) < 2`.
    */
   apply(x: Tensor, axis: number = (-1)): Tensor {
-    return tidy(() => {
-      return tfc.softmax(x, axis);
-    });
+    return tidy(() => tfc.softmax(x, axis));
   }
 }
 serialization.SerializationMap.register(Softmax);

--- a/src/constraints.ts
+++ b/src/constraints.ts
@@ -12,7 +12,7 @@
 
 // tslint:disable:max-line-length
 import * as tfc from '@tensorflow/tfjs-core';
-import {doc, serialization, Tensor} from '@tensorflow/tfjs-core';
+import {doc, serialization, Tensor, tidy} from '@tensorflow/tfjs-core';
 
 import * as K from './backend/tfjs_backend';
 import {deserializeKerasObject, serializeKerasObject} from './utils/generic_utils';
@@ -22,7 +22,9 @@ import {deserializeKerasObject, serializeKerasObject} from './utils/generic_util
  * Helper function used by many of the Constraints to find the L2Norms.
  */
 function calcL2Norms(w: Tensor, axis: number): Tensor {
-  return tfc.sqrt(tfc.sum(K.square(w), axis, true));
+  return tidy(() => {
+    return tfc.sqrt(tfc.sum(K.square(w), axis, true));
+  });
 }
 
 /**
@@ -85,11 +87,13 @@ export class MaxNorm extends Constraint {
   }
 
   apply(w: Tensor): Tensor {
-    const norms = calcL2Norms(w, this.axis);
-    const desired = tfc.clipByValue(norms, 0, this.maxValue);
-    return tfc.mul(
-        w,
-        tfc.div(desired, K.scalarPlusArray(K.getScalar(K.epsilon()), norms)));
+    return tidy(() => {
+      const norms = calcL2Norms(w, this.axis);
+      const desired = tfc.clipByValue(norms, 0, this.maxValue);
+      return tfc.mul(
+          w,
+          tfc.div(desired, K.scalarPlusArray(K.getScalar(K.epsilon()), norms)));
+    });
   }
 
   getConfig(): serialization.ConfigDict {
@@ -129,9 +133,12 @@ export class UnitNorm extends Constraint {
   }
 
   apply(w: Tensor): Tensor {
-    return tfc.div(
-        w,
-        K.scalarPlusArray(K.getScalar(K.epsilon()), calcL2Norms(w, this.axis)));
+    return tidy(() => {
+      return tfc.div(
+          w,
+          K.scalarPlusArray(
+              K.getScalar(K.epsilon()), calcL2Norms(w, this.axis)));
+    });
   }
 
   getConfig(): serialization.ConfigDict {
@@ -145,8 +152,11 @@ serialization.SerializationMap.register(UnitNorm);
  */
 export class NonNeg extends Constraint {
   static readonly className = 'NonNeg';
+
   apply(w: Tensor): Tensor {
-    return tfc.relu(w);
+    return tidy(() => {
+      return tfc.relu(w);
+    });
   }
 }
 serialization.SerializationMap.register(NonNeg);
@@ -207,15 +217,17 @@ export class MinMaxNorm extends Constraint {
   }
 
   apply(w: Tensor): Tensor {
-    const norms = calcL2Norms(w, this.axis);
-    const desired = tfc.add(
-        K.scalarTimesArray(
-            K.getScalar(this.rate),
-            tfc.clipByValue(norms, this.minValue, this.maxValue)),
-        K.scalarTimesArray(K.getScalar(1.0 - this.rate), norms));
-    return tfc.mul(
-        w,
-        tfc.div(desired, K.scalarPlusArray(K.getScalar(K.epsilon()), norms)));
+    return tidy(() => {
+      const norms = calcL2Norms(w, this.axis);
+      const desired = tfc.add(
+          K.scalarTimesArray(
+              K.getScalar(this.rate),
+              tfc.clipByValue(norms, this.minValue, this.maxValue)),
+          K.scalarTimesArray(K.getScalar(1.0 - this.rate), norms));
+      return tfc.mul(
+          w,
+          tfc.div(desired, K.scalarPlusArray(K.getScalar(K.epsilon()), norms)));
+    });
   }
 
   getConfig(): serialization.ConfigDict {

--- a/src/constraints.ts
+++ b/src/constraints.ts
@@ -22,9 +22,7 @@ import {deserializeKerasObject, serializeKerasObject} from './utils/generic_util
  * Helper function used by many of the Constraints to find the L2Norms.
  */
 function calcL2Norms(w: Tensor, axis: number): Tensor {
-  return tidy(() => {
-    return tfc.sqrt(tfc.sum(K.square(w), axis, true));
-  });
+  return tidy(() => tfc.sqrt(tfc.sum(K.square(w), axis, true)));
 }
 
 /**
@@ -133,12 +131,11 @@ export class UnitNorm extends Constraint {
   }
 
   apply(w: Tensor): Tensor {
-    return tidy(() => {
-      return tfc.div(
-          w,
-          K.scalarPlusArray(
-              K.getScalar(K.epsilon()), calcL2Norms(w, this.axis)));
-    });
+    return tidy(
+        () => tfc.div(
+            w,
+            K.scalarPlusArray(
+                K.getScalar(K.epsilon()), calcL2Norms(w, this.axis))));
   }
 
   getConfig(): serialization.ConfigDict {
@@ -154,9 +151,7 @@ export class NonNeg extends Constraint {
   static readonly className = 'NonNeg';
 
   apply(w: Tensor): Tensor {
-    return tidy(() => {
-      return tfc.relu(w);
-    });
+    return tidy(() => tfc.relu(w));
   }
 }
 serialization.SerializationMap.register(NonNeg);

--- a/src/initializers.ts
+++ b/src/initializers.ts
@@ -63,9 +63,7 @@ export class Zeros extends Initializer {
   static className = 'Zeros';
 
   apply(shape: Shape, dtype?: DataType): Tensor {
-    return tidy(() => {
-      return zeros(shape, dtype);
-    });
+    return tidy(() => zeros(shape, dtype));
   }
 }
 serialization.SerializationMap.register(Zeros);
@@ -77,9 +75,7 @@ export class Ones extends Initializer {
   static className = 'Ones';
 
   apply(shape: Shape, dtype?: DataType): Tensor {
-    return tidy(() => {
-      return ones(shape, dtype);
-    });
+    return tidy(() => ones(shape, dtype));
   }
 }
 serialization.SerializationMap.register(Ones);
@@ -101,9 +97,8 @@ export class Constant extends Initializer {
   }
 
   apply(shape: Shape, dtype?: DataType): Tensor {
-    return tidy(() => {
-      return K.scalarTimesArray(scalar(this.value), ones(shape, dtype));
-    });
+    return tidy(
+        () => K.scalarTimesArray(scalar(this.value), ones(shape, dtype)));
   }
 
   getConfig(): serialization.ConfigDict {
@@ -146,9 +141,7 @@ export class RandomUniform extends Initializer {
   }
 
   apply(shape: Shape, dtype?: DataType): Tensor {
-    return tidy(() => {
-      return randomUniform(shape, this.minval, this.maxval, dtype);
-    });
+    return tidy(() => randomUniform(shape, this.minval, this.maxval, dtype));
   }
 
   getConfig(): serialization.ConfigDict {

--- a/src/layers/convolutional.ts
+++ b/src/layers/convolutional.ts
@@ -125,9 +125,11 @@ export function conv1dWithBias(
 export function conv1d(
     x: Tensor, kernel: Tensor, strides = 1, padding = 'valid',
     dataFormat?: DataFormat, dilationRate = 1): Tensor {
-  checkDataFormat(dataFormat);
-  return conv1dWithBias(
-      x, kernel, null, strides, padding, dataFormat, dilationRate);
+  return tidy(() => {
+    checkDataFormat(dataFormat);
+    return conv1dWithBias(
+        x, kernel, null, strides, padding, dataFormat, dilationRate);
+  });
 }
 
 /**
@@ -143,9 +145,11 @@ export function conv1d(
 export function conv2d(
     x: Tensor, kernel: Tensor, strides = [1, 1], padding = 'valid',
     dataFormat?: DataFormat, dilationRate?: [number, number]): Tensor {
-  checkDataFormat(dataFormat);
-  return conv2dWithBias(
-      x, kernel, null, strides, padding, dataFormat, dilationRate);
+  return tidy(() => {
+    checkDataFormat(dataFormat);
+    return conv2dWithBias(
+        x, kernel, null, strides, padding, dataFormat, dilationRate);
+  });
 }
 
 /**

--- a/src/layers/convolutional.ts
+++ b/src/layers/convolutional.ts
@@ -73,7 +73,6 @@ export function conv1dWithBias(
       dataFormat = imageDataFormat();
     }
     checkDataFormat(dataFormat);
-
     // Check the ranks of x, kernel and bias.
     if (x.shape.length !== 3) {
       throw new ValueError(
@@ -90,7 +89,6 @@ export function conv1dWithBias(
           `The bias for a conv1dWithBias operation should be 1, but is ` +
           `${kernel.shape.length} instead`);
     }
-
     // TODO(cais): Support CAUSAL padding mode.
     if (dataFormat === 'channelsFirst') {
       x = tfc.transpose(x, [0, 2, 1]);  // NCW -> NWC.
@@ -628,9 +626,10 @@ export class Conv2DTranspose extends Conv2D {
       const outHeight = deconvLength(height, strideH, kernelH, this.padding);
       const outWidth = deconvLength(width, strideW, kernelW, this.padding);
 
-      // Porting Note: We don't branch based on `this.dataFormat` here, because
-      //   the tjfs-core function `conv2dTranspose` called below always assumes
-      //   channelsLast.
+      // Porting Note: We don't branch based on `this.dataFormat` here,
+      // because
+      //   the tjfs-core function `conv2dTranspose` called below always
+      //   assumes channelsLast.
       const outputShape: [number, number, number, number] =
           [batchSize, outHeight, outWidth, this.filters];
 
@@ -698,9 +697,8 @@ export interface SeparableConvLayerConfig extends ConvLayerConfig {
   /**
    * The number of depthwise convolution output channels for each input
    * channel.
-   * The total number of depthwise convolution output channels will be equal to
-   * `filtersIn * depthMultiplier`.
-   * Default: 1.
+   * The total number of depthwise convolution output channels will be equal
+   * to `filtersIn * depthMultiplier`. Default: 1.
    */
   depthMultiplier?: number;
 

--- a/src/layers/padding.ts
+++ b/src/layers/padding.ts
@@ -245,10 +245,9 @@ export class ZeroPadding2D extends Layer {
   }
 
   call(inputs: Tensor|Tensor[], kwargs: Kwargs): Tensor|Tensor[] {
-    return tidy(() => {
-      return spatial2dPadding(
-          getExactlyOneTensor(inputs), this.padding, this.dataFormat);
-    });
+    return tidy(
+        () => spatial2dPadding(
+            getExactlyOneTensor(inputs), this.padding, this.dataFormat));
   }
 
   getConfig(): serialization.ConfigDict {

--- a/src/layers/padding.ts
+++ b/src/layers/padding.ts
@@ -17,7 +17,7 @@
 
 // tslint:disable:max-line-length
 import * as tfc from '@tensorflow/tfjs-core';
-import {serialization, Tensor} from '@tensorflow/tfjs-core';
+import {serialization, Tensor, tidy} from '@tensorflow/tfjs-core';
 
 import {imageDataFormat} from '../backend/common';
 import * as K from '../backend/tfjs_backend';
@@ -38,23 +38,25 @@ import {getExactlyOneShape, getExactlyOneTensor} from '../utils/generic_utils';
  * @return A padded 3D `Tensor`.
  */
 export function temporalPadding(x: Tensor, padding?: [number, number]): Tensor {
-  if (K.ndim(x) !== 3) {
-    throw new ValueError(
-        `temporalPadding expects input tensor to be 3-D, but received a ` +
-        `${K.ndim(x)}-D tensor.`);
-  }
+  return tidy(() => {
+    if (K.ndim(x) !== 3) {
+      throw new ValueError(
+          `temporalPadding expects input tensor to be 3-D, but received a ` +
+          `${K.ndim(x)}-D tensor.`);
+    }
 
-  if (padding == null) {
-    padding = [1, 1];
-  }
-  if (padding.length !== 2) {
-    throw new ValueError(
-        `temporalPadding expects input padding pattern to be a length-2 ` +
-        `array, but received a length-${padding.length} array.`);
-  }
+    if (padding == null) {
+      padding = [1, 1];
+    }
+    if (padding.length !== 2) {
+      throw new ValueError(
+          `temporalPadding expects input padding pattern to be a length-2 ` +
+          `array, but received a length-${padding.length} array.`);
+    }
 
-  const pattern: Array<[number, number]> = [[0, 0], padding, [0, 0]];
-  return tfc.pad(x, pattern);
+    const pattern: Array<[number, number]> = [[0, 0], padding, [0, 0]];
+    return tfc.pad(x, pattern);
+  });
 }
 
 /**
@@ -70,39 +72,41 @@ export function temporalPadding(x: Tensor, padding?: [number, number]): Tensor {
 export function spatial2dPadding(
     x: Tensor, padding?: [[number, number], [number, number]],
     dataFormat?: DataFormat): Tensor {
-  if (K.ndim(x) !== 4) {
-    throw new ValueError(
-        `temporalPadding expects input tensor to be 4-D, but received a ` +
-        `${K.ndim(x)}-D tensor.`);
-  }
+  return tidy(() => {
+    if (K.ndim(x) !== 4) {
+      throw new ValueError(
+          `temporalPadding expects input tensor to be 4-D, but received a ` +
+          `${K.ndim(x)}-D tensor.`);
+    }
 
-  if (padding == null) {
-    padding = [[1, 1], [1, 1]];
-  }
-  if (padding.length !== 2 || padding[0].length !== 2 ||
-      padding[1].length !== 2) {
-    throw new ValueError(
-        'spatial2dPadding expects `padding` to be an Array of two Arrays, ' +
-        'each of which is an Array of two integers.');
-  }
+    if (padding == null) {
+      padding = [[1, 1], [1, 1]];
+    }
+    if (padding.length !== 2 || padding[0].length !== 2 ||
+        padding[1].length !== 2) {
+      throw new ValueError(
+          'spatial2dPadding expects `padding` to be an Array of two Arrays, ' +
+          'each of which is an Array of two integers.');
+    }
 
-  if (dataFormat == null) {
-    dataFormat = imageDataFormat();
-  }
-  if (dataFormat !== 'channelsLast' && dataFormat !== 'channelsFirst') {
-    throw new ValueError(
-        `Unknown data format: ${dataFormat}. ` +
-        `Supported data formats are 'channelsLast' and 'channelsFirst.`);
-  }
+    if (dataFormat == null) {
+      dataFormat = imageDataFormat();
+    }
+    if (dataFormat !== 'channelsLast' && dataFormat !== 'channelsFirst') {
+      throw new ValueError(
+          `Unknown data format: ${dataFormat}. ` +
+          `Supported data formats are 'channelsLast' and 'channelsFirst.`);
+    }
 
-  let pattern: Array<[number, number]>;
-  if (dataFormat === 'channelsFirst') {
-    pattern = [[0, 0], [0, 0], padding[0], padding[1]];
-  } else {
-    pattern = [[0, 0], padding[0], padding[1], [0, 0]];
-  }
+    let pattern: Array<[number, number]>;
+    if (dataFormat === 'channelsFirst') {
+      pattern = [[0, 0], [0, 0], padding[0], padding[1]];
+    } else {
+      pattern = [[0, 0], padding[0], padding[1], [0, 0]];
+    }
 
-  return tfc.pad(x, pattern);
+    return tfc.pad(x, pattern);
+  });
 }
 
 export interface ZeroPadding2DLayerConfig extends LayerConfig {
@@ -241,8 +245,10 @@ export class ZeroPadding2D extends Layer {
   }
 
   call(inputs: Tensor|Tensor[], kwargs: Kwargs): Tensor|Tensor[] {
-    return spatial2dPadding(
-        getExactlyOneTensor(inputs), this.padding, this.dataFormat);
+    return tidy(() => {
+      return spatial2dPadding(
+          getExactlyOneTensor(inputs), this.padding, this.dataFormat);
+    });
   }
 
   getConfig(): serialization.ConfigDict {

--- a/src/losses.ts
+++ b/src/losses.ts
@@ -10,7 +10,7 @@
 
 /* Original Source: losses.py */
 import * as tfc from '@tensorflow/tfjs-core';
-import {Tensor} from '@tensorflow/tfjs-core';
+import {Tensor, tidy} from '@tensorflow/tfjs-core';
 
 import * as K from './backend/tfjs_backend';
 import {ValueError} from './errors';
@@ -33,7 +33,9 @@ import {LossOrMetricFn} from './types';
  * @return Mean squared error Tensor.
  */
 export function meanSquaredError(yTrue: Tensor, yPred: Tensor): Tensor {
-  return tfc.mean(K.square(tfc.sub(yPred, yTrue)), -1);
+  return tidy(() => {
+    return tfc.mean(K.square(tfc.sub(yPred, yTrue)), -1);
+  });
 }
 
 /**
@@ -55,7 +57,9 @@ export function meanSquaredError(yTrue: Tensor, yPred: Tensor): Tensor {
  * @return Mean absolute error Tensor.
  */
 export function meanAbsoluteError(yTrue: Tensor, yPred: Tensor): Tensor {
-  return tfc.mean(tfc.abs(tfc.sub(yPred, yTrue)), -1);
+  return tidy(() => {
+    return tfc.mean(tfc.abs(tfc.sub(yPred, yTrue)), -1);
+  });
 }
 
 /**
@@ -76,48 +80,58 @@ export function meanAbsoluteError(yTrue: Tensor, yPred: Tensor): Tensor {
  */
 export function meanAbsolutePercentageError(
     yTrue: Tensor, yPred: Tensor): Tensor {
-  const diff = tfc.sub(yTrue, yPred);
-  const clippedTrue =
-      tfc.clipByValue(tfc.abs(yTrue), K.epsilon(), Number.MAX_VALUE);
-  const absResult = tfc.abs(tfc.div(diff, clippedTrue));
-  return K.scalarTimesArray(K.getScalar(100.0), tfc.mean(absResult, -1));
+  return tidy(() => {
+    const diff = tfc.sub(yTrue, yPred);
+    const clippedTrue =
+        tfc.clipByValue(tfc.abs(yTrue), K.epsilon(), Number.MAX_VALUE);
+    const absResult = tfc.abs(tfc.div(diff, clippedTrue));
+    return K.scalarTimesArray(K.getScalar(100.0), tfc.mean(absResult, -1));
+  });
 }
 
 export function meanSquaredLogarithmicError(
     yTrue: Tensor, yPred: Tensor): Tensor {
-  const one = K.getScalar(1.0);
+  return tidy(() => {
+    const one = K.getScalar(1.0);
 
-  const clippedPred = tfc.clipByValue(yPred, K.epsilon(), Number.MAX_VALUE);
-  const firstLog = tfc.log(K.scalarPlusArray(one, clippedPred));
+    const clippedPred = tfc.clipByValue(yPred, K.epsilon(), Number.MAX_VALUE);
+    const firstLog = tfc.log(K.scalarPlusArray(one, clippedPred));
 
-  const clippedTrue = tfc.clipByValue(yTrue, K.epsilon(), Number.MAX_VALUE);
-  const secondLog = tfc.log(K.scalarPlusArray(one, clippedTrue));
+    const clippedTrue = tfc.clipByValue(yTrue, K.epsilon(), Number.MAX_VALUE);
+    const secondLog = tfc.log(K.scalarPlusArray(one, clippedTrue));
 
-  return tfc.mean(K.square(tfc.sub(firstLog, secondLog)), -1);
+    return tfc.mean(K.square(tfc.sub(firstLog, secondLog)), -1);
+  });
 }
 
 export function squaredHinge(yTrue: Tensor, yPred: Tensor): Tensor {
-  const zeroTensor = K.getScalar(0.0);
-  const one = K.getScalar(1.0);
-  const maxResult =
-      tfc.maximum(zeroTensor, tfc.sub(one, tfc.mul(yTrue, yPred)));
-  return tfc.mean(K.square(maxResult), -1);
+  return tidy(() => {
+    const zeroTensor = K.getScalar(0.0);
+    const one = K.getScalar(1.0);
+    const maxResult =
+        tfc.maximum(zeroTensor, tfc.sub(one, tfc.mul(yTrue, yPred)));
+    return tfc.mean(K.square(maxResult), -1);
+  });
 }
 
 export function hinge(yTrue: Tensor, yPred: Tensor): Tensor {
-  const zeroTensor = K.getScalar(0.0);
-  const one = K.getScalar(1.0);
-  const maxResult =
-      tfc.maximum(zeroTensor, tfc.sub(one, tfc.mul(yTrue, yPred)));
-  return tfc.mean(maxResult, -1);
+  return tidy(() => {
+    const zeroTensor = K.getScalar(0.0);
+    const one = K.getScalar(1.0);
+    const maxResult =
+        tfc.maximum(zeroTensor, tfc.sub(one, tfc.mul(yTrue, yPred)));
+    return tfc.mean(maxResult, -1);
+  });
 }
 
 export function categoricalHinge(yTrue: Tensor, yPred: Tensor): Tensor {
-  const zeroTensor = K.getScalar(0.0);
-  const one = K.getScalar(1.0);
-  const pos = tfc.sum(tfc.mul(yTrue, yPred), -1);
-  const neg = tfc.max(tfc.mul(tfc.sub(one, yTrue), yPred), -1);
-  return tfc.maximum(zeroTensor, K.scalarPlusArray(one, tfc.sub(neg, pos)));
+  return tidy(() => {
+    const zeroTensor = K.getScalar(0.0);
+    const one = K.getScalar(1.0);
+    const pos = tfc.sum(tfc.mul(yTrue, yPred), -1);
+    const neg = tfc.max(tfc.mul(tfc.sub(one, yTrue), yPred), -1);
+    return tfc.maximum(zeroTensor, K.scalarPlusArray(one, tfc.sub(neg, pos)));
+  });
 }
 
 /**
@@ -129,40 +143,52 @@ export function categoricalHinge(yTrue: Tensor, yPred: Tensor): Tensor {
  * occasional wildly incorrect prediction.
  */
 export function logcosh(yTrue: Tensor, yPred: Tensor): Tensor {
-  const log2 = K.getScalar(Math.log(2.0));
-  const predictionDiff = tfc.sub(yPred, yTrue);
-  const logcoshResult = tfc.sub(
-      tfc.add(
-          predictionDiff,
-          K.softplus(K.scalarTimesArray(K.getScalar(-2.0), predictionDiff))),
-      log2);
-  return tfc.mean(logcoshResult, -1);
+  return tidy(() => {
+    const log2 = K.getScalar(Math.log(2.0));
+    const predictionDiff = tfc.sub(yPred, yTrue);
+    const logcoshResult = tfc.sub(
+        tfc.add(
+            predictionDiff,
+            K.softplus(K.scalarTimesArray(K.getScalar(-2.0), predictionDiff))),
+        log2);
+    return tfc.mean(logcoshResult, -1);
+  });
 }
 
 export function categoricalCrossentropy(yTrue: Tensor, yPred: Tensor): Tensor {
-  return K.categoricalCrossentropy(yTrue, yPred);
+  return tidy(() => {
+    return K.categoricalCrossentropy(yTrue, yPred);
+  });
 }
 
 export function sparseCategoricalCrossentropy(
     yTrue: Tensor, yPred: Tensor): Tensor {
-  return K.sparseCategoricalCrossentropy(yTrue, yPred);
+  return tidy(() => {
+    return K.sparseCategoricalCrossentropy(yTrue, yPred);
+  });
 }
 
 export function binaryCrossentropy(yTrue: Tensor, yPred: Tensor): Tensor {
-  return tfc.mean(K.binaryCrossentropy(yTrue, yPred), -1);
+  return tidy(() => {
+    return tfc.mean(K.binaryCrossentropy(yTrue, yPred), -1);
+  });
 }
 
 export function kullbackLeiblerDivergence(
     yTrue: Tensor, yPred: Tensor): Tensor {
-  const clippedTrue = tfc.clipByValue(yTrue, K.epsilon(), 1);
-  const clippedPred = tfc.clipByValue(yPred, K.epsilon(), 1);
-  return tfc.sum(
-      tfc.mul(yTrue, tfc.log(tfc.div(clippedTrue, clippedPred))), -1);
+  return tidy(() => {
+    const clippedTrue = tfc.clipByValue(yTrue, K.epsilon(), 1);
+    const clippedPred = tfc.clipByValue(yPred, K.epsilon(), 1);
+    return tfc.sum(
+        tfc.mul(yTrue, tfc.log(tfc.div(clippedTrue, clippedPred))), -1);
+  });
 }
 
 export function poisson(yTrue: Tensor, yPred: Tensor): Tensor {
-  const logPred = tfc.log(K.scalarPlusArray(K.getScalar(K.epsilon()), yPred));
-  return tfc.mean(tfc.sub(yPred, tfc.mul(yTrue, logPred)), -1);
+  return tidy(() => {
+    const logPred = tfc.log(K.scalarPlusArray(K.getScalar(K.epsilon()), yPred));
+    return tfc.mean(tfc.sub(yPred, tfc.mul(yTrue, logPred)), -1);
+  });
 }
 
 /**
@@ -185,10 +211,12 @@ export function poisson(yTrue: Tensor, yPred: Tensor): Tensor {
  * @return Cosine proximity Tensor.
  */
 export function cosineProximity(yTrue: Tensor, yPred: Tensor): Tensor {
-  const trueNormalized = K.l2Normalize(yTrue, -1);
-  const predNormalized = K.l2Normalize(yPred, -1);
-  const trueXPred = tfc.mul(trueNormalized, predNormalized);
-  return tfc.neg(tfc.sum(trueXPred, -1));
+  return tidy(() => {
+    const trueNormalized = K.l2Normalize(yTrue, -1);
+    const predNormalized = K.l2Normalize(yPred, -1);
+    const trueXPred = tfc.mul(trueNormalized, predNormalized);
+    return tfc.neg(tfc.sum(trueXPred, -1));
+  });
 }
 
 export const mse = meanSquaredError;

--- a/src/losses.ts
+++ b/src/losses.ts
@@ -33,9 +33,7 @@ import {LossOrMetricFn} from './types';
  * @return Mean squared error Tensor.
  */
 export function meanSquaredError(yTrue: Tensor, yPred: Tensor): Tensor {
-  return tidy(() => {
-    return tfc.mean(K.square(tfc.sub(yPred, yTrue)), -1);
-  });
+  return tidy(() => tfc.mean(K.square(tfc.sub(yPred, yTrue)), -1));
 }
 
 /**
@@ -57,9 +55,7 @@ export function meanSquaredError(yTrue: Tensor, yPred: Tensor): Tensor {
  * @return Mean absolute error Tensor.
  */
 export function meanAbsoluteError(yTrue: Tensor, yPred: Tensor): Tensor {
-  return tidy(() => {
-    return tfc.mean(tfc.abs(tfc.sub(yPred, yTrue)), -1);
-  });
+  return tidy(() => tfc.mean(tfc.abs(tfc.sub(yPred, yTrue)), -1));
 }
 
 /**
@@ -156,22 +152,16 @@ export function logcosh(yTrue: Tensor, yPred: Tensor): Tensor {
 }
 
 export function categoricalCrossentropy(yTrue: Tensor, yPred: Tensor): Tensor {
-  return tidy(() => {
-    return K.categoricalCrossentropy(yTrue, yPred);
-  });
+  return tidy(() => K.categoricalCrossentropy(yTrue, yPred));
 }
 
 export function sparseCategoricalCrossentropy(
     yTrue: Tensor, yPred: Tensor): Tensor {
-  return tidy(() => {
-    return K.sparseCategoricalCrossentropy(yTrue, yPred);
-  });
+  return tidy(() => K.sparseCategoricalCrossentropy(yTrue, yPred));
 }
 
 export function binaryCrossentropy(yTrue: Tensor, yPred: Tensor): Tensor {
-  return tidy(() => {
-    return tfc.mean(K.binaryCrossentropy(yTrue, yPred), -1);
-  });
+  return tidy(() => tfc.mean(K.binaryCrossentropy(yTrue, yPred), -1));
 }
 
 export function kullbackLeiblerDivergence(

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -74,10 +74,9 @@ export function binaryAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
  * @return Accuracy Tensor.
  */
 export function categoricalAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
-  return tidy(() => {
-    return K.cast(
-        tfc.equal(tfc.argMax(yTrue, -1), tfc.argMax(yPred, -1)), 'float32');
-  });
+  return tidy(
+      () => K.cast(
+          tfc.equal(tfc.argMax(yTrue, -1), tfc.argMax(yPred, -1)), 'float32'));
 }
 
 /**
@@ -96,9 +95,7 @@ export function categoricalAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
  * @return Accuracy Tensor.
  */
 export function binaryCrossentropy(yTrue: Tensor, yPred: Tensor): Tensor {
-  return tidy(() => {
-    return tfc.mean(K.binaryCrossentropy(yTrue, yPred), -1);
-  });
+  return tidy(() => tfc.mean(K.binaryCrossentropy(yTrue, yPred), -1));
 }
 
 export function sparseCategoricalAccuracy(

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -14,7 +14,7 @@
 
 // tslint:disable:max-line-length
 import * as tfc from '@tensorflow/tfjs-core';
-import {Tensor} from '@tensorflow/tfjs-core';
+import {Tensor, tidy} from '@tensorflow/tfjs-core';
 import * as K from './backend/tfjs_backend';
 import {NotImplementedError, ValueError} from './errors';
 import {categoricalCrossentropy as categoricalCrossentropyLoss, cosineProximity, meanAbsoluteError, meanAbsolutePercentageError, meanSquaredError, sparseCategoricalCrossentropy as sparseCategoricalCrossentropyLoss} from './losses';
@@ -50,9 +50,11 @@ import {LossOrMetricFn} from './types';
  */
 export function binaryAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
   // TODO(cais): Maybe avoid creating a new Scalar on every invocation.
-  const threshold = K.scalarTimesArray(K.getScalar(0.5), tfc.onesLike(yPred));
-  const yPredThresholded = K.cast(tfc.greater(yPred, threshold), yTrue.dtype);
-  return tfc.mean(tfc.equal(yTrue, yPredThresholded), -1);
+  return tidy(() => {
+    const threshold = K.scalarTimesArray(K.getScalar(0.5), tfc.onesLike(yPred));
+    const yPredThresholded = K.cast(tfc.greater(yPred, threshold), yTrue.dtype);
+    return tfc.mean(tfc.equal(yTrue, yPredThresholded), -1);
+  });
 }
 
 /**
@@ -72,8 +74,10 @@ export function binaryAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
  * @return Accuracy Tensor.
  */
 export function categoricalAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
-  return K.cast(
-      tfc.equal(tfc.argMax(yTrue, -1), tfc.argMax(yPred, -1)), 'float32');
+  return tidy(() => {
+    return K.cast(
+        tfc.equal(tfc.argMax(yTrue, -1), tfc.argMax(yPred, -1)), 'float32');
+  });
 }
 
 /**
@@ -92,7 +96,9 @@ export function categoricalAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
  * @return Accuracy Tensor.
  */
 export function binaryCrossentropy(yTrue: Tensor, yPred: Tensor): Tensor {
-  return tfc.mean(K.binaryCrossentropy(yTrue, yPred), -1);
+  return tidy(() => {
+    return tfc.mean(K.binaryCrossentropy(yTrue, yPred), -1);
+  });
 }
 
 export function sparseCategoricalAccuracy(

--- a/src/regularizers.ts
+++ b/src/regularizers.ts
@@ -11,7 +11,7 @@
 /* original source: keras/regularizers.py */
 
 // tslint:disable:max-line-length
-import {abs, add, doc, Scalar, serialization, sum, Tensor, zeros} from '@tensorflow/tfjs-core';
+import {abs, add, doc, Scalar, serialization, sum, Tensor, tidy, zeros} from '@tensorflow/tfjs-core';
 
 import * as K from './backend/tfjs_backend';
 import {deserializeKerasObject, serializeKerasObject} from './utils/generic_utils';
@@ -72,16 +72,18 @@ export class L1L2 extends Regularizer {
    * @param x Variable of which to calculate the regularization score.
    */
   apply(x: Tensor): Scalar {
-    let regularization: Tensor = zeros([1]);
-    if (this.hasL1) {
-      regularization =
-          add(regularization, sum(K.scalarTimesArray(this.l1, abs(x))));
-    }
-    if (this.hasL2) {
-      regularization =
-          add(regularization, sum(K.scalarTimesArray(this.l2, K.square(x))));
-    }
-    return regularization.asScalar();
+    return tidy(() => {
+      let regularization: Tensor = zeros([1]);
+      if (this.hasL1) {
+        regularization =
+            add(regularization, sum(K.scalarTimesArray(this.l1, abs(x))));
+      }
+      if (this.hasL2) {
+        regularization =
+            add(regularization, sum(K.scalarTimesArray(this.l2, K.square(x))));
+      }
+      return regularization.asScalar();
+    });
   }
 
   getConfig(): serialization.ConfigDict {


### PR DESCRIPTION
The need to tidy every call in layers came out of another PR review.  This PR shows a prototype version of the anticipated changes on a single file, wanted to get feedback before I start applying the same pattern everywhere.

Our stated approach:
1) use @operation on every class method.
2) use tidy on every non-class method.

I've taken this literally, even on methods that I don't think could leak, but I think the consensus was full coverage was worth the possible performance hits.

I'm not currently tidy-ing constructors, (can we?  does that make sense?)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/186)
<!-- Reviewable:end -->
