### PR TITLE
Remove redundant tidys, but add tests to catch regressions

### DIFF
--- a/src/activations.ts
+++ b/src/activations.ts
@@ -47,7 +47,7 @@ export class Elu extends Activation {
    * @return Output of the ELU activation.
    */
   apply(x: Tensor, alpha = 1): Tensor {
-    return tidy(() => K.elu(x, alpha));
+    return K.elu(x, alpha);
   }
 }
 serialization.SerializationMap.register(Elu);
@@ -62,7 +62,7 @@ serialization.SerializationMap.register(Elu);
 export class Selu extends Activation {
   static readonly className = 'selu';
   apply(x: Tensor): Tensor {
-    return tidy(() => tfc.selu(x));
+    return tfc.selu(x);
   }
 }
 serialization.SerializationMap.register(Selu);
@@ -73,7 +73,7 @@ serialization.SerializationMap.register(Selu);
 export class Relu extends Activation {
   static readonly className = 'relu';
   apply(x: Tensor): Tensor {
-    return tidy(() => tfc.relu(x));
+    return tfc.relu(x);
   }
 }
 serialization.SerializationMap.register(Relu);
@@ -96,7 +96,7 @@ serialization.SerializationMap.register(Relu6);
 export class Linear extends Activation {
   static readonly className = 'linear';
   apply(x: Tensor): Tensor {
-    return tidy(() => x);
+    return x;
   }
 }
 serialization.SerializationMap.register(Linear);
@@ -107,7 +107,7 @@ serialization.SerializationMap.register(Linear);
 export class Sigmoid extends Activation {
   static readonly className = 'sigmoid';
   apply(x: Tensor): Tensor {
-    return tidy(() => tfc.sigmoid(x));
+    return tfc.sigmoid(x);
   }
 }
 serialization.SerializationMap.register(Sigmoid);
@@ -118,7 +118,7 @@ serialization.SerializationMap.register(Sigmoid);
 export class HardSigmoid extends Activation {
   static readonly className = 'hardSigmoid';
   apply(x: Tensor): Tensor {
-    return tidy(() => K.hardSigmoid(x));
+    return K.hardSigmoid(x);
   }
 }
 serialization.SerializationMap.register(HardSigmoid);
@@ -129,7 +129,7 @@ serialization.SerializationMap.register(HardSigmoid);
 export class Softplus extends Activation {
   static readonly className = 'softplus';
   apply(x: Tensor): Tensor {
-    return tidy(() => K.softplus(x));
+    return tfc.softplus(x);
   }
 }
 serialization.SerializationMap.register(Softplus);
@@ -140,7 +140,7 @@ serialization.SerializationMap.register(Softplus);
 export class Softsign extends Activation {
   static readonly className = 'softsign';
   apply(x: Tensor): Tensor {
-    return tidy(() => K.softsign(x));
+    return K.softsign(x);
   }
 }
 serialization.SerializationMap.register(Softsign);
@@ -151,7 +151,7 @@ serialization.SerializationMap.register(Softsign);
 export class Tanh extends Activation {
   static readonly className = 'tanh';
   apply(x: Tensor): Tensor {
-    return tidy(() => tfc.tanh(x));
+    return tfc.tanh(x);
   }
 }
 serialization.SerializationMap.register(Tanh);
@@ -174,7 +174,7 @@ export class Softmax extends Activation {
    * @throws ValueError: In case `dim(x) < 2`.
    */
   apply(x: Tensor, axis: number = (-1)): Tensor {
-    return tidy(() => tfc.softmax(x, axis));
+    return tfc.softmax(x, axis);
   }
 }
 serialization.SerializationMap.register(Softmax);

--- a/src/activations_test.ts
+++ b/src/activations_test.ts
@@ -15,7 +15,8 @@
 import {scalar, tensor1d, tensor2d, tensor3d} from '@tensorflow/tfjs-core';
 
 import {Elu, HardSigmoid, Linear, Relu, Relu6, Selu, Sigmoid, Softmax, Softplus, Softsign, Tanh} from './activations';
-import {describeMathCPUAndGPU, expectTensorsClose} from './utils/test_utils';
+import {describeMathCPUAndGPU, expectNoLeakedTensors, expectTensorsClose} from './utils/test_utils';
+
 // tslint:enable
 
 describeMathCPUAndGPU('linear activation', () => {
@@ -34,6 +35,10 @@ describeMathCPUAndGPU('linear activation', () => {
     const initX = tensor3d(initVals, [1, 2, 3]);
     expectTensorsClose(linear(initX), tensor3d(expectedVals, [1, 2, 3]));
   });
+  it('Does not leak', () => {
+    const initX = tensor1d(initVals);
+    expectNoLeakedTensors(() => linear(initX), 0);
+  });
 });
 
 describeMathCPUAndGPU('elu activation', () => {
@@ -51,6 +56,10 @@ describeMathCPUAndGPU('elu activation', () => {
   it('3D', () => {
     const initX = tensor3d(initVals, [1, 2, 3]);
     expectTensorsClose(elu(initX), tensor3d(expectedVals, [1, 2, 3]));
+  });
+  it('Does not leak', () => {
+    const initX = tensor1d(initVals);
+    expectNoLeakedTensors(() => elu(initX), 1);
   });
 });
 
@@ -75,6 +84,10 @@ describeMathCPUAndGPU('selu activation', () => {
     const initX = tensor3d(initVals, [1, 2, 3]);
     expectTensorsClose(selu(initX), tensor3d(expectedVals, [1, 2, 3]));
   });
+  it('Does not leak', () => {
+    const initX = tensor1d(initVals);
+    expectNoLeakedTensors(() => selu(initX), 1);
+  });
 });
 
 
@@ -94,6 +107,10 @@ describeMathCPUAndGPU('relu activation', () => {
     const initX = tensor3d(initVals, [1, 2, 3]);
     expectTensorsClose(relu(initX), tensor3d(expectedVals, [1, 2, 3]));
   });
+  it('Does not leak', () => {
+    const initX = tensor1d(initVals);
+    expectNoLeakedTensors(() => relu(initX), 1);
+  });
 });
 
 describeMathCPUAndGPU('relu6 activation', () => {
@@ -112,28 +129,36 @@ describeMathCPUAndGPU('relu6 activation', () => {
     const initX = tensor3d(initVals, [1, 2, 3]);
     expectTensorsClose(relu6(initX), tensor3d(expectedVals, [1, 2, 3]));
   });
+  it('Does not leak', () => {
+    const initX = tensor1d(initVals);
+    expectNoLeakedTensors(() => relu6(initX), 1);
+  });
 });
 
 describeMathCPUAndGPU('sigmoid activation', () => {
   const sigmoid = new Sigmoid().apply;
+  const initVals = [-1, 2, 0, 4, -5, 6];
   it('Scalar', () => {
     expectTensorsClose(sigmoid(scalar(0)), scalar(0.5));
   });
   it('3D', () => {
-    const initVals = [-1, 2, 0, 4, -5, 6];
     const expectedVals = initVals.map(v => 1 / (1 + Math.exp(-v)));
     const initX = tensor3d(initVals, [1, 2, 3]);
     expectTensorsClose(sigmoid(initX), tensor3d(expectedVals, [1, 2, 3]));
+  });
+  it('Does not leak', () => {
+    const initX = tensor1d(initVals);
+    expectNoLeakedTensors(() => sigmoid(initX), 1);
   });
 });
 
 describeMathCPUAndGPU('hardSigmoid activation', () => {
   const hardSigmoid = new HardSigmoid().apply;
+  const initVals = [-1, 2, 0, 4, -5, 6];
   it('Scalar', () => {
     expectTensorsClose(hardSigmoid(scalar(0)), scalar(0.5));
   });
   it('3D', () => {
-    const initVals = [-1, 2, 0, 4, -5, 6];
     const expectedVals = initVals.map(v => {
       const y = 0.2 * v + 0.5;
       if (y > 1) {
@@ -147,31 +172,43 @@ describeMathCPUAndGPU('hardSigmoid activation', () => {
     const initX = tensor3d(initVals, [1, 2, 3]);
     expectTensorsClose(hardSigmoid(initX), tensor3d(expectedVals, [1, 2, 3]));
   });
+  it('Does not leak', () => {
+    const initX = tensor1d(initVals);
+    expectNoLeakedTensors(() => hardSigmoid(initX), 1);
+  });
 });
 
 describeMathCPUAndGPU('softplus activation', () => {
   const softplus = new Softplus().apply;
+  const initVals = [-1, 2, 0, 4, -5, 6];
   it('Scalar', () => {
     expectTensorsClose(softplus(scalar(0)), scalar(Math.log(2)));
   });
   it('3D', () => {
-    const initVals = [-1, 2, 0, 4, -5, 6];
     const expectedVals = initVals.map(v => Math.log(Math.exp(v) + 1));
     const initX = tensor3d(initVals, [1, 2, 3]);
     expectTensorsClose(softplus(initX), tensor3d(expectedVals, [1, 2, 3]));
+  });
+  it('Does not leak', () => {
+    const initX = tensor1d(initVals);
+    expectNoLeakedTensors(() => softplus(initX), 1);
   });
 });
 
 describeMathCPUAndGPU('softsign activation', () => {
   const softsign = new Softsign().apply;
+  const initVals = [-1, 2, 0, 4, -5, 6];
   it('Scalar', () => {
     expectTensorsClose(softsign(scalar(0)), scalar(0));
   });
   it('3D', () => {
-    const initVals = [-1, 2, 0, 4, -5, 6];
     const expectedVals = initVals.map(v => v / (Math.abs(v) + 1));
     const initX = tensor3d(initVals, [1, 2, 3]);
     expectTensorsClose(softsign(initX), tensor3d(expectedVals, [1, 2, 3]));
+  });
+  it('Does not leak', () => {
+    const initX = tensor1d(initVals);
+    expectNoLeakedTensors(() => softsign(initX), 1);
   });
 });
 
@@ -190,6 +227,10 @@ describeMathCPUAndGPU('tanh activation', () => {
   it('3D', () => {
     const initX = tensor3d(initVals, [1, 2, 3]);
     expectTensorsClose(tanh(initX), tensor3d(expectedVals, [1, 2, 3]));
+  });
+  it('Does not leak', () => {
+    const initX = tensor1d(initVals);
+    expectNoLeakedTensors(() => tanh(initX), 1);
   });
 });
 
@@ -223,5 +264,10 @@ describeMathCPUAndGPU('softmax activation', () => {
         [0.000, 0.000, 0.002, 0.997, 0.000, 0.000, 0.002, 0.997]);
     const initX = tensor3d(initVals, [1, 2, 4]);
     expectTensorsClose(softmax(initX), tensor3d(expectedVals, [1, 2, 4]));
+  });
+  it('Does not leak', () => {
+    const initVals = new Float32Array([0, 1, 3, 9]);
+    const initX = tensor1d(initVals);
+    expectNoLeakedTensors(() => softmax(initX), 1);
   });
 });

--- a/src/backend/tfjs_backend.ts
+++ b/src/backend/tfjs_backend.ts
@@ -963,18 +963,6 @@ export function elu(x: Tensor, alpha = 1): Tensor {
 }
 
 /**
- * Softplus of a tensor.
- *
- * Defined as log(exp(x) + 1), element-wise.
- *
- * @param x: Input.
- * @returns Output.
- */
-export function softplus(x: Tensor): Tensor {
-  return tfc.log(tfc.add(getScalar(1), tfc.exp(x)));
-}
-
-/**
  * Softsign of a tensor.
  *
  * Defined as x / (abs(x) + 1), element-wise.
@@ -983,7 +971,7 @@ export function softplus(x: Tensor): Tensor {
  * @returns Output.
  */
 export function softsign(x: Tensor): Tensor {
-  return tfc.div(x, tfc.add(getScalar(1), tfc.abs(x)));
+  return tidy(() => tfc.div(x, tfc.add(getScalar(1), tfc.abs(x))));
 }
 
 /**

--- a/src/backend/tfjs_backend_test.ts
+++ b/src/backend/tfjs_backend_test.ts
@@ -1304,7 +1304,7 @@ describeMathCPUAndGPU('softsign', () => {
       tensor2d(xData.map(x => x / (Math.abs(x) + 1)), [2, 2]));
   });
   it ('Does not leak', () => {
-    const input = tensor2d([-1, 0, 1, -1]);
+    const input = tensor2d([-1, 0, 1, -1], [2, 2]);
     expectNoLeakedTensors(() => K.softsign(input), 1);
   });
 });

--- a/src/backend/tfjs_backend_test.ts
+++ b/src/backend/tfjs_backend_test.ts
@@ -20,7 +20,7 @@ import {SymbolicTensor} from '../types';
 import {LayerVariable} from '../variables';
 import {unique} from '../utils/generic_utils';
 import {range} from '../utils/math_utils';
-import {describeMathCPU, describeMathCPUAndGPU, expectTensorsClose} from '../utils/test_utils';
+import {describeMathCPU, describeMathCPUAndGPU, expectTensorsClose, expectNoLeakedTensors} from '../utils/test_utils';
 
 import * as K from './tfjs_backend';
 
@@ -1296,21 +1296,16 @@ describeMathCPUAndGPU('elu', () => {
   });
 });
 
-describeMathCPUAndGPU('softplus', () => {
-  it('softplus', () => {
-    const xData = [-1, 0, 1, -1];
-    expectTensorsClose(
-      K.softplus(tensor2d(xData, [2, 2])),
-      tensor2d(xData.map(x => Math.log(Math.exp(x) + 1)), [2, 2]));
-  });
-});
-
 describeMathCPUAndGPU('softsign', () => {
   it('softsign', () => {
     const xData = [-1, 0, 1, -1];
     expectTensorsClose(
       K.softsign(tensor2d(xData, [2, 2])),
       tensor2d(xData.map(x => x / (Math.abs(x) + 1)), [2, 2]));
+  });
+  it ('Does not leak', () => {
+    const input = tensor2d([-1, 0, 1, -1]);
+    expectNoLeakedTensors(() => K.softsign(input), 1);
   });
 });
 

--- a/src/constraints.ts
+++ b/src/constraints.ts
@@ -151,7 +151,7 @@ export class NonNeg extends Constraint {
   static readonly className = 'NonNeg';
 
   apply(w: Tensor): Tensor {
-    return tidy(() => tfc.relu(w));
+    return tfc.relu(w);
   }
 }
 serialization.SerializationMap.register(NonNeg);

--- a/src/constraints_test.ts
+++ b/src/constraints_test.ts
@@ -15,7 +15,7 @@ import {serialization, Tensor1D, tensor1d} from '@tensorflow/tfjs-core';
 
 import {ConstraintIdentifier, deserializeConstraint, getConstraint, serializeConstraint} from './constraints';
 import * as tfl from './index';
-import {describeMathCPU, expectTensorsClose} from './utils/test_utils';
+import {describeMathCPU, expectNoLeakedTensors, expectTensorsClose} from './utils/test_utils';
 
 // tslint:enable:max-line-length
 
@@ -30,6 +30,7 @@ describeMathCPU('Built-in Constraints', () => {
     const postConstraint = constraint.apply(initVals);
     expectTensorsClose(
         postConstraint, tensor1d(new Float32Array([0, 2, 0, 4, 0, 6])));
+    expectNoLeakedTensors(() => constraint.apply(initVals), 1);
   });
 
   it('MaxNorm', () => {
@@ -39,6 +40,7 @@ describeMathCPU('Built-in Constraints', () => {
                          -0.2208630521, 0.4417261043, 0, 0.8834522086,
                          -1.104315261, 1.325178313
                        ])));
+    expectNoLeakedTensors(() => constraint.apply(initVals), 1);
   });
   it('UnitNorm', () => {
     const constraint = getConstraint('UnitNorm');
@@ -47,6 +49,7 @@ describeMathCPU('Built-in Constraints', () => {
                          -0.2208630521 / 2, 0.4417261043 / 2, 0,
                          0.8834522086 / 2, -1.104315261 / 2, 1.325178313 / 2
                        ])));
+    expectNoLeakedTensors(() => constraint.apply(initVals), 1);
   });
   it('MinMaxNorm', () => {
     const constraint = getConstraint('MinMaxNorm');
@@ -55,6 +58,7 @@ describeMathCPU('Built-in Constraints', () => {
                          -0.2208630521 / 2, 0.4417261043 / 2, 0,
                          0.8834522086 / 2, -1.104315261 / 2, 1.325178313 / 2
                        ])));
+    expectNoLeakedTensors(() => constraint.apply(initVals), 1);
   });
 
   // Lower camel case.

--- a/src/initializers.ts
+++ b/src/initializers.ts
@@ -63,7 +63,7 @@ export class Zeros extends Initializer {
   static className = 'Zeros';
 
   apply(shape: Shape, dtype?: DataType): Tensor {
-    return tidy(() => zeros(shape, dtype));
+    return zeros(shape, dtype);
   }
 }
 serialization.SerializationMap.register(Zeros);
@@ -75,7 +75,7 @@ export class Ones extends Initializer {
   static className = 'Ones';
 
   apply(shape: Shape, dtype?: DataType): Tensor {
-    return tidy(() => ones(shape, dtype));
+    return ones(shape, dtype);
   }
 }
 serialization.SerializationMap.register(Ones);
@@ -141,7 +141,7 @@ export class RandomUniform extends Initializer {
   }
 
   apply(shape: Shape, dtype?: DataType): Tensor {
-    return tidy(() => randomUniform(shape, this.minval, this.maxval, dtype));
+    return randomUniform(shape, this.minval, this.maxval, dtype);
   }
 
   getConfig(): serialization.ConfigDict {
@@ -179,13 +179,11 @@ export class RandomNormal extends Initializer {
   }
 
   apply(shape: Shape, dtype?: DataType): Tensor {
-    return tidy(() => {
-      if (dtype === 'bool') {
-        throw new NotImplementedError(
-            `randomNormal does not support dType bool.`);
-      }
-      return K.randomNormal(shape, this.mean, this.stddev, dtype, this.seed);
-    });
+    if (dtype === 'bool') {
+      throw new NotImplementedError(
+          `randomNormal does not support dType bool.`);
+    }
+    return K.randomNormal(shape, this.mean, this.stddev, dtype, this.seed);
   }
 
   getConfig(): serialization.ConfigDict {
@@ -228,13 +226,11 @@ export class TruncatedNormal extends Initializer {
   }
 
   apply(shape: Shape, dtype?: DataType): Tensor {
-    return tidy(() => {
-      if (dtype === 'bool') {
-        throw new NotImplementedError(
-            `truncatedNormal does not support dType bool.`);
-      }
-      return truncatedNormal(shape, this.mean, this.stddev, dtype, this.seed);
-    });
+    if (dtype === 'bool') {
+      throw new NotImplementedError(
+          `truncatedNormal does not support dType bool.`);
+    }
+    return truncatedNormal(shape, this.mean, this.stddev, dtype, this.seed);
   }
 
   getConfig(): serialization.ConfigDict {
@@ -367,31 +363,29 @@ export class VarianceScaling extends Initializer {
   }
 
   apply(shape: Shape, dtype?: DataType): Tensor {
-    return tidy(() => {
-      const fans = computeFans(shape);
-      const fanIn = fans[0];
-      const fanOut = fans[1];
-      let scale = this.scale;
-      if (this.mode === 'fanIn') {
-        scale /= Math.max(1, fanIn);
-      } else if (this.mode === 'fanOut') {
-        scale /= Math.max(1, fanOut);
-      } else {
-        scale /= Math.max(1, (fanIn + fanOut) / 2);
-      }
+    const fans = computeFans(shape);
+    const fanIn = fans[0];
+    const fanOut = fans[1];
+    let scale = this.scale;
+    if (this.mode === 'fanIn') {
+      scale /= Math.max(1, fanIn);
+    } else if (this.mode === 'fanOut') {
+      scale /= Math.max(1, fanOut);
+    } else {
+      scale /= Math.max(1, (fanIn + fanOut) / 2);
+    }
 
-      if (this.distribution === 'normal') {
-        const stddev = Math.sqrt(scale);
-        if (dtype === 'bool') {
-          throw new NotImplementedError(
-              `${this.getClassName()} does not support dType bool.`);
-        }
-        return truncatedNormal(shape, 0, stddev, dtype, this.seed);
-      } else {
-        const limit = Math.sqrt(3 * scale);
-        return randomUniform(shape, -limit, limit, dtype);
+    if (this.distribution === 'normal') {
+      const stddev = Math.sqrt(scale);
+      if (dtype === 'bool') {
+        throw new NotImplementedError(
+            `${this.getClassName()} does not support dType bool.`);
       }
-    });
+      return truncatedNormal(shape, 0, stddev, dtype, this.seed);
+    } else {
+      const limit = Math.sqrt(3 * scale);
+      return randomUniform(shape, -limit, limit, dtype);
+    }
   }
 
   getConfig(): serialization.ConfigDict {

--- a/src/initializers_test.ts
+++ b/src/initializers_test.ts
@@ -104,8 +104,8 @@ describeMathCPU('Constant initializer', () => {
   it('Does not leak', () => {
     const initializerConfig:
         serialization.ConfigDict = {className: 'Constant', config: {value: 5}};
-    const init = getInitializer(initializerConfig);
-    expectNoLeakedTensors(() => init.apply([3]), 1);
+    expectNoLeakedTensors(
+        () => getInitializer(initializerConfig).apply([3]), 1);
   });
 });
 
@@ -166,8 +166,7 @@ describeMathCPU('RandomUniform initializer', () => {
     expectTensorsValuesInRange(weights, 17, 47);
   });
   it('Does not leak', () => {
-    const init = getInitializer('RandomUniform');
-    expectNoLeakedTensors(() => init.apply([3]), 1);
+    expectNoLeakedTensors(() => getInitializer('RandomUniform').apply([3]), 1);
   });
 });
 
@@ -201,8 +200,7 @@ describeMathCPU('RandomNormal initializer', () => {
     // TODO(bileschi): Add test to assert the values match expectations.
   });
   it('Does not leak', () => {
-    const init = getInitializer('RandomNormal');
-    expectNoLeakedTensors(() => init.apply([3]), 1);
+    expectNoLeakedTensors(() => getInitializer('RandomNormal').apply([3]), 1);
   });
 });
 
@@ -226,8 +224,7 @@ describeMathCPU('HeNormal initializer', () => {
     expectTensorsValuesInRange(weights, -2 * stddev, 2 * stddev);
   });
   it('Does not leak', () => {
-    const init = getInitializer('HeNormal');
-    expectNoLeakedTensors(() => init.apply([3]), 1);
+    expectNoLeakedTensors(() => getInitializer('HeNormal').apply([3]), 1);
   });
 });
 
@@ -251,8 +248,7 @@ describeMathCPU('LecunNormal initializer', () => {
     expectTensorsValuesInRange(weights, -2 * stddev, 2 * stddev);
   });
   it('Does not leak', () => {
-    const init = getInitializer('LeCunNormal');
-    expectNoLeakedTensors(() => init.apply([3]), 1);
+    expectNoLeakedTensors(() => getInitializer('LeCunNormal').apply([3]), 1);
   });
 });
 
@@ -286,8 +282,8 @@ describeMathCPU('TruncatedNormal initializer', () => {
     expectTensorsValuesInRange(weights, 0.0, 2.0);
   });
   it('Does not leak', () => {
-    const init = getInitializer('TruncatedNormal');
-    expectNoLeakedTensors(() => init.apply([3]), 1);
+    expectNoLeakedTensors(
+        () => getInitializer('TruncatedNormal').apply([3]), 1);
   });
 });
 
@@ -341,8 +337,7 @@ describeMathCPU('Glorot uniform initializer', () => {
     });
   });
   it('Does not leak', () => {
-    const init = getInitializer('GlorotUniform');
-    expectNoLeakedTensors(() => init.apply([3]), 1);
+    expectNoLeakedTensors(() => getInitializer('GlorotUniform').apply([3]), 1);
   });
 });
 
@@ -400,8 +395,7 @@ describeMathCPU('Glorot normal initializer', () => {
     });
   });
   it('Does not leak', () => {
-    const init = getInitializer('GlorotNormal');
-    expectNoLeakedTensors(() => init.apply([3]), 1);
+    expectNoLeakedTensors(() => getInitializer('GlorotNormal').apply([3]), 1);
   });
 });
 

--- a/src/initializers_test.ts
+++ b/src/initializers_test.ts
@@ -18,7 +18,7 @@ import {eye, serialization, Tensor2D, tensor2d} from '@tensorflow/tfjs-core';
 import * as tfl from './index';
 import {checkDistribution, checkFanMode, getInitializer, serializeInitializer, VALID_DISTRIBUTION_VALUES, VALID_FAN_MODE_VALUES, VarianceScaling} from './initializers';
 import * as math_utils from './utils/math_utils';
-import {describeMathCPU, describeMathCPUAndGPU, expectTensorsClose, expectTensorsValuesInRange} from './utils/test_utils';
+import {describeMathCPU, describeMathCPUAndGPU, expectNoLeakedTensors, expectTensorsClose, expectTensorsValuesInRange} from './utils/test_utils';
 
 // tslint:enable:max-line-length
 
@@ -46,6 +46,10 @@ describeMathCPU('Zeros initializer', () => {
     expect(weights.dtype).toEqual('float32');
     expect(weights.dataSync()).toEqual(new Float32Array([0, 0, 0, 0]));
   });
+
+  it('Does not leak', () => {
+    expectNoLeakedTensors(() => getInitializer('zeros').apply([3]), 1);
+  });
 });
 
 describeMathCPU('Ones initializer', () => {
@@ -72,6 +76,9 @@ describeMathCPU('Ones initializer', () => {
     expect(weights.dtype).toEqual('float32');
     expect(weights.dataSync()).toEqual(new Float32Array([1, 1, 1, 1]));
   });
+  it('Does not leak', () => {
+    expectNoLeakedTensors(() => getInitializer('ones').apply([3]), 1);
+  });
 });
 
 describeMathCPU('Constant initializer', () => {
@@ -93,6 +100,12 @@ describeMathCPU('Constant initializer', () => {
     expect(weights.shape).toEqual([2, 2]);
     expect(weights.dtype).toEqual('float32');
     expect(weights.dataSync()).toEqual(new Float32Array([5, 5, 5, 5]));
+  });
+  it('Does not leak', () => {
+    const initializerConfig:
+        serialization.ConfigDict = {className: 'Constant', config: {value: 5}};
+    const init = getInitializer(initializerConfig);
+    expectNoLeakedTensors(() => init.apply([3]), 1);
   });
 });
 
@@ -152,6 +165,10 @@ describeMathCPU('RandomUniform initializer', () => {
     expect(weights.dtype).toEqual('float32');
     expectTensorsValuesInRange(weights, 17, 47);
   });
+  it('Does not leak', () => {
+    const init = getInitializer('RandomUniform');
+    expectNoLeakedTensors(() => init.apply([3]), 1);
+  });
 });
 
 describeMathCPU('RandomNormal initializer', () => {
@@ -183,6 +200,10 @@ describeMathCPU('RandomNormal initializer', () => {
     expect(weights.dtype).toEqual('float32');
     // TODO(bileschi): Add test to assert the values match expectations.
   });
+  it('Does not leak', () => {
+    const init = getInitializer('RandomNormal');
+    expectNoLeakedTensors(() => init.apply([3]), 1);
+  });
 });
 
 describeMathCPU('HeNormal initializer', () => {
@@ -204,6 +225,10 @@ describeMathCPU('HeNormal initializer', () => {
     expect(weights.dtype).toEqual('float32');
     expectTensorsValuesInRange(weights, -2 * stddev, 2 * stddev);
   });
+  it('Does not leak', () => {
+    const init = getInitializer('HeNormal');
+    expectNoLeakedTensors(() => init.apply([3]), 1);
+  });
 });
 
 describeMathCPU('LecunNormal initializer', () => {
@@ -224,6 +249,10 @@ describeMathCPU('LecunNormal initializer', () => {
     expect(weights.shape).toEqual(shape);
     expect(weights.dtype).toEqual('float32');
     expectTensorsValuesInRange(weights, -2 * stddev, 2 * stddev);
+  });
+  it('Does not leak', () => {
+    const init = getInitializer('LeCunNormal');
+    expectNoLeakedTensors(() => init.apply([3]), 1);
   });
 });
 
@@ -255,6 +284,10 @@ describeMathCPU('TruncatedNormal initializer', () => {
     expect(weights.shape).toEqual(shape);
     expect(weights.dtype).toEqual('float32');
     expectTensorsValuesInRange(weights, 0.0, 2.0);
+  });
+  it('Does not leak', () => {
+    const init = getInitializer('TruncatedNormal');
+    expectNoLeakedTensors(() => init.apply([3]), 1);
   });
 });
 
@@ -306,6 +339,10 @@ describeMathCPU('Glorot uniform initializer', () => {
       expect(math_utils.min(weights.dataSync() as Float32Array))
           .toBeGreaterThan(-limit);
     });
+  });
+  it('Does not leak', () => {
+    const init = getInitializer('GlorotUniform');
+    expectNoLeakedTensors(() => init.apply([3]), 1);
   });
 });
 
@@ -361,6 +398,10 @@ describeMathCPU('Glorot normal initializer', () => {
       const variance2 = math_utils.median(varianceArr2);
       expect(variance2).toBeLessThan(variance1);
     });
+  });
+  it('Does not leak', () => {
+    const init = getInitializer('GlorotNormal');
+    expectNoLeakedTensors(() => init.apply([3]), 1);
   });
 });
 
@@ -492,5 +533,9 @@ describeMathCPUAndGPU('Orthogonal Initializer', () => {
     expect(w.dtype).toEqual('float32');
     // Assert that columns of w are orthogonal.
     expectTensorsClose(w.matMul(w.transpose()), eye(n));
+  });
+  it('Does not leak', () => {
+    const init = getInitializer('Orthogonal');
+    expectNoLeakedTensors(() => init.apply([3, 3]), 1);
   });
 });

--- a/src/losses.ts
+++ b/src/losses.ts
@@ -145,7 +145,8 @@ export function logcosh(yTrue: Tensor, yPred: Tensor): Tensor {
     const logcoshResult = tfc.sub(
         tfc.add(
             predictionDiff,
-            K.softplus(K.scalarTimesArray(K.getScalar(-2.0), predictionDiff))),
+            tfc.softplus(
+                K.scalarTimesArray(K.getScalar(-2.0), predictionDiff))),
         log2);
     return tfc.mean(logcoshResult, -1);
   });

--- a/src/utils/test_utils.ts
+++ b/src/utils/test_utils.ts
@@ -94,8 +94,8 @@ export function describeMathGPU(testName: string, tests: () => void) {
 /**
  * Check that a function only generates the expected number of new Tensors.
  *
- * The function is called twice, once to prime any regular constants and once
- * to ensure that additional copies aren't created/tensors aren't leaked.
+ * The test  function is called twice, once to prime any regular constants and
+ * once to ensure that additional copies aren't created/tensors aren't leaked.
  *
  * @param testFunc A fully curried (zero arg) version of the function to test.
  * @param numNewTensors The expected number of new Tensors that should exist.

--- a/src/utils/test_utils.ts
+++ b/src/utils/test_utils.ts
@@ -13,7 +13,7 @@
  */
 
 // tslint:disable:max-line-length
-import {Tensor, test_util} from '@tensorflow/tfjs-core';
+import {memory, Tensor, test_util} from '@tensorflow/tfjs-core';
 import * as jasmine_util from '@tensorflow/tfjs-core/dist/jasmine_util';
 import {disposeScalarCache} from '../backend/tfjs_backend';
 import {ValueError} from '../errors';
@@ -89,4 +89,30 @@ export function describeMathGPU(testName: string, tests: () => void) {
     });
     tests();
   });
+}
+
+/**
+ * Check that a function only generates the expected number of new Tensors.
+ *
+ * The function is called twice, once to prime any regular constants and once
+ * to ensure that additional copies aren't created/tensors aren't leaked.
+ *
+ * @param testFunc A fully curried (zero arg) version of the function to test.
+ * @param numNewTensors The expected number of new Tensors that should exist.
+ */
+export function expectNoLeakedTensors(
+    // tslint:disable-next-line:no-any
+    testFunc: () => any, numNewTensors: number) {
+  testFunc();
+  const numTensorsBefore = memory().numTensors;
+  testFunc();
+  const numTensorsAfter = memory().numTensors;
+  const actualNewTensors = numTensorsAfter - numTensorsBefore;
+  if (actualNewTensors !== numNewTensors) {
+    throw new ValueError(
+        `Created an unexpected number of new ` +
+        `Tensors.  Expected: ${numNewTensors}, created : ${
+            actualNewTensors}. ` +
+        `Please investigate the discrepency and/or use tidy.`);
+  }
 }


### PR DESCRIPTION
Re-purposing #166 to introduce a helper test method for checking for memory leaks.  Adding tests for all the methods that had trivial/redundant tidy's and removing the tidys.

Also removing the K.softplus in favor of tfc.softplus.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/192)
<!-- Reviewable:end -->
