### PR TITLE
Remove -layer's reshape.

### DIFF
--- a/src/backend/tfjs_backend.ts
+++ b/src/backend/tfjs_backend.ts
@@ -160,7 +160,7 @@ export function cast(x: Tensor, dtype: 'float32'|'int32'|'bool'): Tensor {
  */
 export function reshape(x: Tensor, shape: Shape): Tensor {
   // TODO(cais): Should this call TensorMath.reshape instead for backprop?
-  return x.reshape(shape);
+  return tfc.reshape(x, shape);
 }
 
 /**

--- a/src/backend/tfjs_backend.ts
+++ b/src/backend/tfjs_backend.ts
@@ -164,7 +164,7 @@ export function expandDims(x: Tensor, axis = -1): Tensor {
     axis = outShape.length + axis + 1;
   }
   outShape.splice(axis, 0, 1);
-  return tfc.reshape(x, outShape);
+  return x.reshape(outShape);
 }
 
 /**
@@ -197,7 +197,7 @@ export function repeat(x: Tensor, n: number): Tensor {
  */
 export function flatten(x: Tensor): Tensor {
   const newShape = [math_utils.arrayProd(x.shape)];
-  return tfc.reshape(x, newShape);
+  return x.reshape(newShape);
 }
 
 /**
@@ -214,7 +214,7 @@ export function batchFlatten(x: Tensor): Tensor {
         `batchFlatten requires a minimum rank of 2. Got rank: ${ndim(x)}.`);
   }
   const newShape = [x.shape[0], math_utils.arrayProd(x.shape, 1)];
-  return tfc.reshape(x, newShape);
+  return x.reshape(newShape);
 }
 
 /**
@@ -414,12 +414,12 @@ function broadcastNormalizeBatchInTraining(
                targetShape.push(x.shape[axis]);
              }
            }
-           const broadcastMean = tfc.reshape(mean, targetShape);
-           const broadcastVariance = tfc.reshape(variance, targetShape);
+           const broadcastMean = mean.reshape(targetShape);
+           const broadcastVariance = variance.reshape(targetShape);
            const broadcastGamma =
-               gamma == null ? null : tfc.reshape(gamma, targetShape);
+               gamma == null ? null : gamma.reshape(targetShape);
            const broadcastBeta =
-               beta == null ? null : tfc.reshape(beta, targetShape);
+               beta == null ? null : beta.reshape(targetShape);
            const normed = batchNormalization(
                x, broadcastMean, broadcastVariance, broadcastBeta,
                broadcastGamma, epsilon);
@@ -1082,9 +1082,9 @@ export function sparseCategoricalCrossentropy(
   return tidy(() => {
     const flatTarget = tfc.floor(flatten(target)).toInt() as Tensor1D;
     const outputShape = shape(output);
-    const oneHotTarget = tfc.reshape(
-        tfc.oneHot(flatTarget, outputShape[outputShape.length - 1]),
-        outputShape);
+    const oneHotTarget =
+        tfc.oneHot(flatTarget, outputShape[outputShape.length - 1])
+            .reshape(outputShape);
     return categoricalCrossentropy(oneHotTarget, output, fromLogits);
   });
 }

--- a/src/backend/tfjs_backend.ts
+++ b/src/backend/tfjs_backend.ts
@@ -153,17 +153,6 @@ export function cast(x: Tensor, dtype: 'float32'|'int32'|'bool'): Tensor {
 }
 
 /**
- * Reshape tensor to specified shape.
- * @param x Input tensor.
- * @param shape Target shape.
- * @return The resultant tensor of the reshaping.
- */
-export function reshape(x: Tensor, shape: Shape): Tensor {
-  // TODO(cais): Should this call TensorMath.reshape instead for backprop?
-  return tfc.reshape(x, shape);
-}
-
-/**
  * Adds a 1-sized dimension at index "axis".
  * @param x Input tensor.
  * @param axis Position where to add the new axis.
@@ -175,7 +164,7 @@ export function expandDims(x: Tensor, axis = -1): Tensor {
     axis = outShape.length + axis + 1;
   }
   outShape.splice(axis, 0, 1);
-  return reshape(x, outShape);
+  return tfc.reshape(x, outShape);
 }
 
 /**
@@ -208,7 +197,7 @@ export function repeat(x: Tensor, n: number): Tensor {
  */
 export function flatten(x: Tensor): Tensor {
   const newShape = [math_utils.arrayProd(x.shape)];
-  return reshape(x, newShape);
+  return tfc.reshape(x, newShape);
 }
 
 /**
@@ -225,7 +214,7 @@ export function batchFlatten(x: Tensor): Tensor {
         `batchFlatten requires a minimum rank of 2. Got rank: ${ndim(x)}.`);
   }
   const newShape = [x.shape[0], math_utils.arrayProd(x.shape, 1)];
-  return reshape(x, newShape);
+  return tfc.reshape(x, newShape);
 }
 
 /**
@@ -425,12 +414,12 @@ function broadcastNormalizeBatchInTraining(
                targetShape.push(x.shape[axis]);
              }
            }
-           const broadcastMean = reshape(mean, targetShape);
-           const broadcastVariance = reshape(variance, targetShape);
+           const broadcastMean = tfc.reshape(mean, targetShape);
+           const broadcastVariance = tfc.reshape(variance, targetShape);
            const broadcastGamma =
-               gamma == null ? null : reshape(gamma, targetShape);
+               gamma == null ? null : tfc.reshape(gamma, targetShape);
            const broadcastBeta =
-               beta == null ? null : reshape(beta, targetShape);
+               beta == null ? null : tfc.reshape(beta, targetShape);
            const normed = batchNormalization(
                x, broadcastMean, broadcastVariance, broadcastBeta,
                broadcastGamma, epsilon);
@@ -1093,7 +1082,7 @@ export function sparseCategoricalCrossentropy(
   return tidy(() => {
     const flatTarget = tfc.floor(flatten(target)).toInt() as Tensor1D;
     const outputShape = shape(output);
-    const oneHotTarget = reshape(
+    const oneHotTarget = tfc.reshape(
         tfc.oneHot(flatTarget, outputShape[outputShape.length - 1]),
         outputShape);
     return categoricalCrossentropy(oneHotTarget, output, fromLogits);

--- a/src/backend/tfjs_backend_test.ts
+++ b/src/backend/tfjs_backend_test.ts
@@ -210,48 +210,6 @@ describeMathCPUAndGPU('cast', () => {
   });
 });
 
-describeMathCPUAndGPU('Reshape', () => {
-  it('1D', () => {
-    const x = zeros([12]);
-    expect(K.reshape(x, [12]).shape).toEqual([12]);
-    expect(K.reshape(x, [3, 4]).shape).toEqual([3, 4]);
-    expect(K.reshape(x, [2, 2, 3]).shape).toEqual([2, 2, 3]);
-    expect(K.reshape(x, [1, 2, 2, 3]).shape).toEqual([1, 2, 2, 3]);
-    expect(() => {
-      K.reshape(x, [2, 2, 2, 3]);
-    }).toThrowError();
-  });
-
-  it('Scalar', () => {
-    const s = zeros([]);
-    expect(K.reshape(s, []).shape).toEqual([]);
-    expect(K.reshape(s, [1]).shape).toEqual([1]);
-    expect(() => {
-      K.reshape(s, [2]);
-    }).toThrowError();
-  });
-
-  it('2D to 1D', () => {
-    const x = tensor2d([[10, 20, 30], [40, 50, 60]], [2, 3]);
-    const reshaped = K.reshape(x, [6]);
-    expect(reshaped.shape).toEqual([6]);
-    expect(reshaped.dataSync()).toEqual(new Float32Array([
-      10, 20, 30, 40, 50, 60
-    ]));
-  });
-
-  it('3D to 2D', () => {
-    const x = tensor3d(
-      [[[10, 20, 30], [40, 50, 60]], [[-10, -20, -30], [-40, -50, -60]]],
-      [2, 2, 3]);
-    const reshaped = K.reshape(x, [2, 6]);
-    expect(reshaped.shape).toEqual([2, 6]);
-    expect(reshaped.dataSync()).toEqual(new Float32Array([
-      10, 20, 30, 40, 50, 60, -10, -20, -30, -40, -50, -60
-    ]));
-  });
-});
-
 describeMathCPUAndGPU('expandDims', () => {
   it('Scalar to 1D', () => {
     const x = scalar(10);

--- a/src/layers/core.ts
+++ b/src/layers/core.ts
@@ -12,6 +12,7 @@
  * TensorFlow.js Layers: Basic Layers.
  */
 
+import * as tfc from '@tensorflow/tfjs-core';
 import {Scalar, serialization, Tensor, tidy, util} from '@tensorflow/tfjs-core';
 
 // tslint:disable:max-line-length
@@ -589,7 +590,7 @@ export class Reshape extends Layer {
       const inputShape = K.shape(input);
       const outputShape = inputShape.slice(0, 1).concat(
           this.fixUnknownDimension(inputShape.slice(1), this.targetShape));
-      return K.reshape(input, outputShape);
+      return tfc.reshape(input, outputShape);
     });
   }
 }

--- a/src/layers/core.ts
+++ b/src/layers/core.ts
@@ -12,7 +12,6 @@
  * TensorFlow.js Layers: Basic Layers.
  */
 
-import * as tfc from '@tensorflow/tfjs-core';
 import {Scalar, serialization, Tensor, tidy, util} from '@tensorflow/tfjs-core';
 
 // tslint:disable:max-line-length
@@ -590,7 +589,7 @@ export class Reshape extends Layer {
       const inputShape = K.shape(input);
       const outputShape = inputShape.slice(0, 1).concat(
           this.fixUnknownDimension(inputShape.slice(1), this.targetShape));
-      return tfc.reshape(input, outputShape);
+      return input.reshape(outputShape);
     });
   }
 }

--- a/src/layers/embeddings.ts
+++ b/src/layers/embeddings.ts
@@ -13,6 +13,7 @@
  *
  * Original source: keras/constraints.py
  */
+import * as tfc from '@tensorflow/tfjs-core';
 import {serialization, Tensor, tidy} from '@tensorflow/tfjs-core';
 
 // tslint:disable:max-line-length
@@ -183,7 +184,7 @@ export class Embedding extends Layer {
         input = K.cast(input, 'int32');
       }
       const output = K.gather(this.embeddings.read(), input.as1D());
-      return K.reshape(
+      return tfc.reshape(
           output, getExactlyOneShape(this.computeOutputShape(input.shape)));
     });
   }

--- a/src/layers/embeddings.ts
+++ b/src/layers/embeddings.ts
@@ -13,7 +13,6 @@
  *
  * Original source: keras/constraints.py
  */
-import * as tfc from '@tensorflow/tfjs-core';
 import {serialization, Tensor, tidy} from '@tensorflow/tfjs-core';
 
 // tslint:disable:max-line-length
@@ -184,8 +183,8 @@ export class Embedding extends Layer {
         input = K.cast(input, 'int32');
       }
       const output = K.gather(this.embeddings.read(), input.as1D());
-      return tfc.reshape(
-          output, getExactlyOneShape(this.computeOutputShape(input.shape)));
+      return output.reshape(
+          getExactlyOneShape(this.computeOutputShape(input.shape)));
     });
   }
 

--- a/src/layers/merge.ts
+++ b/src/layers/merge.ts
@@ -156,10 +156,10 @@ export abstract class Merge extends Layer {
               const xShape = K.shape(x);
               const batchSize = xShape[0];
               const newShape = xShape.slice(1).concat([batchSize]);
-              let xTransposed = K.reshape(
+              let xTransposed = tfc.reshape(
                   x, [batchSize].concat(mathUtils.arrayProd(xShape.slice(1))));
               xTransposed = tfc.transpose(xTransposed, [1, 0]);
-              xTransposed = K.reshape(xTransposed, newShape);
+              xTransposed = tfc.reshape(xTransposed, newShape);
               reshapedInputs.push(xTransposed);
               transposed = true;
             } else if (xNDim > 1) {
@@ -182,8 +182,8 @@ export abstract class Merge extends Layer {
               const batchSize = yShape[yNDim - 1];
               const newShape =
                   [batchSize].concat(yShape.slice(0, yShape.length - 1));
-              y = K.reshape(
-                  tfc.transpose(K.reshape(y, [-1, batchSize]), [1, 0]),
+              y = tfc.reshape(
+                  tfc.transpose(tfc.reshape(y, [-1, batchSize]), [1, 0]),
                   newShape);
             } else if (yNDim > 1) {
               const dims = [yNDim - 1].concat(mathUtils.range(0, yNDim - 1));

--- a/src/layers/merge.ts
+++ b/src/layers/merge.ts
@@ -156,10 +156,10 @@ export abstract class Merge extends Layer {
               const xShape = K.shape(x);
               const batchSize = xShape[0];
               const newShape = xShape.slice(1).concat([batchSize]);
-              let xTransposed = tfc.reshape(
-                  x, [batchSize].concat(mathUtils.arrayProd(xShape.slice(1))));
+              let xTransposed = x.reshape(
+                  [batchSize].concat(mathUtils.arrayProd(xShape.slice(1))));
               xTransposed = tfc.transpose(xTransposed, [1, 0]);
-              xTransposed = tfc.reshape(xTransposed, newShape);
+              xTransposed = xTransposed.reshape(newShape);
               reshapedInputs.push(xTransposed);
               transposed = true;
             } else if (xNDim > 1) {
@@ -182,9 +182,8 @@ export abstract class Merge extends Layer {
               const batchSize = yShape[yNDim - 1];
               const newShape =
                   [batchSize].concat(yShape.slice(0, yShape.length - 1));
-              y = tfc.reshape(
-                  tfc.transpose(tfc.reshape(y, [-1, batchSize]), [1, 0]),
-                  newShape);
+              y = tfc.transpose(y.reshape([-1, batchSize]), [1, 0])
+                      .reshape(newShape);
             } else if (yNDim > 1) {
               const dims = [yNDim - 1].concat(mathUtils.range(0, yNDim - 1));
               y = tfc.transpose(y, dims);

--- a/src/layers/normalization.ts
+++ b/src/layers/normalization.ts
@@ -13,7 +13,8 @@
  */
 
 // tslint:disable:max-line-length
-import {movingAverage, serialization, Tensor, tidy, util} from '@tensorflow/tfjs-core';
+import * as tfc from '@tensorflow/tfjs-core';
+import {serialization, Tensor, tidy, util} from '@tensorflow/tfjs-core';
 
 import * as K from '../backend/tfjs_backend';
 import {Constraint, ConstraintIdentifier, getConstraint, serializeConstraint} from '../constraints';
@@ -223,13 +224,15 @@ export class BatchNormalization extends Layer {
       const normalizeInference: () => Tensor = () => {
         if (needsBroadcasting) {
           const broadcastMovingMean =
-              K.reshape(this.movingMean.read(), broadcastShape);
+              tfc.reshape(this.movingMean.read(), broadcastShape);
           const broadcastMovingVariance =
-              K.reshape(this.movingVariance.read(), broadcastShape);
-          const broadcastBeta =
-              this.center ? K.reshape(this.beta.read(), broadcastShape) : null;
-          const broadcastGamma =
-              this.scale ? K.reshape(this.gamma.read(), broadcastShape) : null;
+              tfc.reshape(this.movingVariance.read(), broadcastShape);
+          const broadcastBeta = this.center ?
+              tfc.reshape(this.beta.read(), broadcastShape) :
+              null;
+          const broadcastGamma = this.scale ?
+              tfc.reshape(this.gamma.read(), broadcastShape) :
+              null;
           return K.batchNormalization(
               input, broadcastMovingMean, broadcastMovingVariance,
               broadcastBeta, broadcastGamma, this.epsilon);
@@ -263,10 +266,10 @@ export class BatchNormalization extends Layer {
       //   immediately.
       const updateMovingMeanAndVariance = () => {
         this.stepCount++;
-        const newMovingMean = movingAverage(
+        const newMovingMean = tfc.movingAverage(
             this.movingMean.read(), mean, this.momentum, this.stepCount);
         this.movingMean.write(newMovingMean);
-        const newMovingVariance = movingAverage(
+        const newMovingVariance = tfc.movingAverage(
             this.movingVariance.read(), varianceDebiased, this.momentum,
             this.stepCount);
         this.movingVariance.write(newMovingVariance);

--- a/src/layers/recurrent.ts
+++ b/src/layers/recurrent.ts
@@ -124,7 +124,7 @@ export function rnn(
   const timeSteps = inputs.shape[0];
   for (let t = 0; t < timeSteps; ++t) {
     let currentInput = K.sliceAlongFirstAxis(inputs, t, 1);
-    currentInput = tfc.reshape(currentInput, currentInput.shape.slice(1));
+    currentInput = currentInput.reshape(currentInput.shape.slice(1));
     const stepOutputs = stepFunction(currentInput, states);
     lastOutput = stepOutputs[0];
     if (t === 0) {

--- a/src/layers/recurrent.ts
+++ b/src/layers/recurrent.ts
@@ -124,7 +124,7 @@ export function rnn(
   const timeSteps = inputs.shape[0];
   for (let t = 0; t < timeSteps; ++t) {
     let currentInput = K.sliceAlongFirstAxis(inputs, t, 1);
-    currentInput = K.reshape(currentInput, currentInput.shape.slice(1));
+    currentInput = tfc.reshape(currentInput, currentInput.shape.slice(1));
     const stepOutputs = stepFunction(currentInput, states);
     lastOutput = stepOutputs[0];
     if (t === 0) {


### PR DESCRIPTION
Remove K.reshape in favor of tfc.reshape.

Initially changed the K.reshape implementation from x.reshape(shape) to tfc.reshape(x, shape), all tests pass.  Then removed K.reshape and adjusted all call sites to go direct to the core symbol.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/194)
<!-- Reviewable:end -->
