### PR TITLE
Remove K.ndim in favor of .rank on Tensors/SymbolicTensors

### DIFF
--- a/src/backend/tfjs_backend_test.ts
+++ b/src/backend/tfjs_backend_test.ts
@@ -91,33 +91,6 @@ describe('intShape', () => {
   });
 });
 
-describe('ndim', () => {
-  it('Scalar', () => {
-    const x = zeros([]);
-    expect(K.ndim(x)).toEqual(0);
-  });
-
-  it('Tensor1D', () => {
-    const x = zeros([3]);
-    expect(K.ndim(x)).toEqual(1);
-  });
-
-  it('Tensor2D', () => {
-    const x = zeros([3, 2]);
-    expect(K.ndim(x)).toEqual(2);
-  });
-
-  it('Tensor3D', () => {
-    const x = zeros([4, 3, 2]);
-    expect(K.ndim(x)).toEqual(3);
-  });
-
-  it('Tensor4D', () => {
-    const x = zeros([4, 3, 2, 1]);
-    expect(K.ndim(x)).toEqual(4);
-  });
-});
-
 describe('dtype', () => {
   it('returns float32 for an Tensor', () => {
     const x = zeros([1]);

--- a/src/engine/topology.ts
+++ b/src/engine/topology.ts
@@ -660,7 +660,7 @@ export abstract class Layer extends serialization.Serializable {
       }
 
       // Check ndim.
-      const ndim = K.ndim(x);
+      const ndim = x.rank;
       if (spec.ndim != null) {
         if (ndim !== spec.ndim) {
           throw new ValueError(

--- a/src/layers/convolutional.ts
+++ b/src/layers/convolutional.ts
@@ -164,15 +164,15 @@ export function conv2dWithBias(
       dataFormat = imageDataFormat();
     }
     checkDataFormat(dataFormat);
-    if (K.ndim(x) !== 3 && K.ndim(x) !== 4) {
+    if (x.rank !== 3 && x.rank !== 4) {
       throw new ValueError(
           `conv2dWithBias expects input to be of rank 3 or 4, but received ` +
-          `${K.ndim(x)}.`);
+          `${x.rank}.`);
     }
-    if (K.ndim(kernel) !== 3 && K.ndim(kernel) !== 4) {
+    if (kernel.rank !== 3 && kernel.rank !== 4) {
       throw new ValueError(
           `conv2dWithBias expects kernel to be of rank 3 or 4, but received ` +
-          `${K.ndim(x)}.`);
+          `${x.rank}.`);
     }
     let y = preprocessConv2DInput(x, dataFormat);
     if (padding === 'causal') {

--- a/src/layers/convolutional_depthwise.ts
+++ b/src/layers/convolutional_depthwise.ts
@@ -55,15 +55,15 @@ export function depthwiseConv2d(
     }
     checkDataFormat(dataFormat);
     let y = preprocessConv2DInput(x, dataFormat);
-    if (K.ndim(x) !== 4) {
+    if (x.rank !== 4) {
       throw new ValueError(
           `Input for depthwiseConv2d is required to be 4-D, but is instead ` +
-          `${K.ndim(x)}-D`);
+          `${x.rank}-D`);
     }
-    if (K.ndim(depthwiseKernel) !== 4) {
+    if (depthwiseKernel.rank !== 4) {
       throw new ValueError(
           `depthwiseKernel is required to be 4-D, but is instead ` +
-          `${K.ndim(depthwiseKernel)}-D`);
+          `${depthwiseKernel.rank}-D`);
     }
     y = tfc.depthwiseConv2d(
         y as Tensor4D, depthwiseKernel as Tensor4D, strides,

--- a/src/layers/core_test.ts
+++ b/src/layers/core_test.ts
@@ -233,7 +233,7 @@ describeMathCPUAndGPU('Dense Layer: Tensor', () => {
                const expectedShape = input.shape.slice();
                expectedShape[expectedShape.length - 1] = units;
                let expectedOutput;
-               if (K.ndim(input) === 2) {
+               if (input.rank === 2) {
                  expectedOutput = tensor2d(
                      pyListRepeat(
                          expectedElementValue, arrayProd(expectedShape)),

--- a/src/layers/merge.ts
+++ b/src/layers/merge.ts
@@ -133,13 +133,13 @@ export abstract class Merge extends Layer {
       inputs = inputs as Tensor[];
       if (this.reshapeRequired) {
         const reshapedInputs: Tensor[] = [];
-        const inputDims = inputs.map(input => K.ndim(input));
+        const inputDims = inputs.map(input => input.rank);
         if (inputDims.indexOf(null) === -1) {
           // If ranks of all inputs are available, we simply expand each of them
           // at axis=1 until all of them have the same rank.
           const maxNDim = mathUtils.max(inputDims);
           for (let x of inputs) {
-            const xNDim = K.ndim(x);
+            const xNDim = x.rank;
             for (let k = 0; k < maxNDim - xNDim; ++k) {
               x = K.expandDims(x, 1);
             }
@@ -151,7 +151,7 @@ export abstract class Merge extends Layer {
           // [batchSize, dim1, dim2, ...] -> [dim1, dim2, ..., batchSize]
           let transposed = false;
           for (const x of inputs) {
-            const xNDim = K.ndim(x);
+            const xNDim = x.rank;
             if (xNDim == null) {
               const xShape = K.shape(x);
               const batchSize = xShape[0];
@@ -172,7 +172,7 @@ export abstract class Merge extends Layer {
             }
           }
           let y = this.mergeFunction(reshapedInputs);
-          const yNDim = K.ndim(y);
+          const yNDim = y.rank;
           if (transposed) {
             // If inputs have been transposed, we have to transpose the output
             // too.

--- a/src/layers/normalization.ts
+++ b/src/layers/normalization.ts
@@ -47,26 +47,25 @@ export function batchNormalization(
     x: Tensor, mean: Tensor, variance: Tensor, beta?: Tensor, gamma?: Tensor,
     epsilon = 1e-3): Tensor {
   let out: Tensor;
-  if (K.ndim(x) === 2) {
+  if (x.rank === 2) {
     out = tfc.batchNormalization2d(
         x as Tensor2D, mean as Tensor2D | Tensor1D,
         variance as Tensor2D | Tensor1D, epsilon, gamma as Tensor2D | Tensor1D,
         beta as Tensor2D | Tensor1D);
-  } else if (K.ndim(x) === 3) {
+  } else if (x.rank === 3) {
     // TODO(cais): Check rank; give proper error message.
     out = tfc.batchNormalization3d(
         x as Tensor3D, mean as Tensor3D | Tensor1D,
         variance as Tensor3D | Tensor1D, epsilon, gamma as Tensor3D | Tensor1D,
         beta as Tensor3D | Tensor1D);
-  } else if (K.ndim(x) === 4) {
+  } else if (x.rank === 4) {
     out = tfc.batchNormalization4d(
         x as Tensor4D, mean as Tensor4D | Tensor1D,
         variance as Tensor4D | Tensor1D, epsilon, gamma as Tensor4D | Tensor1D,
         beta as Tensor4D | Tensor1D);
   } else {
     throw new NotImplementedError(
-        `batchNormalization is not implememnted for array of rank ${
-            K.ndim(x)} ` +
+        `batchNormalization is not implememnted for array of rank ${x.rank} ` +
         `yet`);
   }
   return out;
@@ -127,7 +126,7 @@ function broadcastNormalizeBatchInTraining(
            const mean = meanAndVariance.mean;
            const variance = meanAndVariance.variance;
            const targetShape: number[] = [];
-           for (const axis of math_utils.range(0, K.ndim(x))) {
+           for (const axis of math_utils.range(0, x.rank)) {
              if (reductionAxes.indexOf(axis) !== -1) {
                targetShape.push(1);
              } else {
@@ -162,7 +161,7 @@ export function normalizeBatchInTraining(
     x: Tensor, gamma: Tensor, beta: Tensor, reductionAxes: number[],
     epsilon = 1e-3): [Tensor, Tensor, Tensor] {
   if (util.arraysEqual(
-          reductionAxes.slice().sort(), math_utils.range(0, K.ndim(x) - 1))) {
+          reductionAxes.slice().sort(), math_utils.range(0, x.rank - 1))) {
     return regularNormalizeBatchInTraining(
         x, gamma, beta, reductionAxes, epsilon);
   } else {

--- a/src/layers/padding.ts
+++ b/src/layers/padding.ts
@@ -20,7 +20,6 @@ import * as tfc from '@tensorflow/tfjs-core';
 import {serialization, Tensor, tidy} from '@tensorflow/tfjs-core';
 
 import {imageDataFormat} from '../backend/common';
-import * as K from '../backend/tfjs_backend';
 import {DataFormat} from '../common';
 import {InputSpec, Layer, LayerConfig} from '../engine/topology';
 import {ValueError} from '../errors';
@@ -39,10 +38,10 @@ import {getExactlyOneShape, getExactlyOneTensor} from '../utils/generic_utils';
  */
 export function temporalPadding(x: Tensor, padding?: [number, number]): Tensor {
   return tidy(() => {
-    if (K.ndim(x) !== 3) {
+    if (x.rank !== 3) {
       throw new ValueError(
           `temporalPadding expects input tensor to be 3-D, but received a ` +
-          `${K.ndim(x)}-D tensor.`);
+          `${x.rank}-D tensor.`);
     }
 
     if (padding == null) {
@@ -73,10 +72,10 @@ export function spatial2dPadding(
     x: Tensor, padding?: [[number, number], [number, number]],
     dataFormat?: DataFormat): Tensor {
   return tidy(() => {
-    if (K.ndim(x) !== 4) {
+    if (x.rank !== 4) {
       throw new ValueError(
           `temporalPadding expects input tensor to be 4-D, but received a ` +
-          `${K.ndim(x)}-D tensor.`);
+          `${x.rank}-D tensor.`);
     }
 
     if (padding == null) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,10 @@ export class SymbolicTensor {
   // original name is used as a key.
   readonly originalName?: string;
   /**
+   * Rank/dimensionality of the tensor.
+   */
+  readonly rank: number;
+  /**
    * Replacement for _keras_history.
    */
   nodeIndex: number;
@@ -79,6 +83,7 @@ export class SymbolicTensor {
       this.originalName = getScopedTensorName(name);
       this.name = getUniqueTensorName(this.originalName);
     }
+    this.rank = shape.length;
   }
 }
 

--- a/src/types_test.ts
+++ b/src/types_test.ts
@@ -27,6 +27,9 @@ describe('SymbolicTensor Test', () => {
     expect(st1.dtype).toEqual('float32');
     expect(st1.shape).toEqual([4, 6]);
     expect(st1.rank).toEqual(2);
+
+    const scalar = new SymbolicTensor('float32', [], null, [], {});
+    expect(scalar.rank).toEqual(0);
   });
 
   it('Correct names and ids', () => {

--- a/src/types_test.ts
+++ b/src/types_test.ts
@@ -27,8 +27,11 @@ describe('SymbolicTensor Test', () => {
     expect(st1.dtype).toEqual('float32');
     expect(st1.shape).toEqual([4, 6]);
     expect(st1.rank).toEqual(2);
-
+  });
+  it('Correct when operating on scalars', () => {
     const scalar = new SymbolicTensor('float32', [], null, [], {});
+    expect(scalar.dtype).toEqual('float32');
+    expect(scalar.shape).toEqual([]);
     expect(scalar.rank).toEqual(0);
   });
 

--- a/src/types_test.ts
+++ b/src/types_test.ts
@@ -26,6 +26,7 @@ describe('SymbolicTensor Test', () => {
     const st1 = new SymbolicTensor('float32', [4, 6], null, [], {});
     expect(st1.dtype).toEqual('float32');
     expect(st1.shape).toEqual([4, 6]);
+    expect(st1.rank).toEqual(2);
   });
 
   it('Correct names and ids', () => {


### PR DESCRIPTION
Introduce a 'rank' property on SymbolicTensor so that it matches Tensor.  Then remove tfjs_backend's ndim(x)=> x.shape.length.  Use x.rank anywhere we had ndim(x).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/200)
<!-- Reviewable:end -->
