### PR TITLE
Resolve TODOs for scalar creation

### DIFF
--- a/src/activations.ts
+++ b/src/activations.ts
@@ -10,7 +10,7 @@
 
 // Layer activation functions
 import * as tfc from '@tensorflow/tfjs-core';
-import {scalar, serialization, Tensor, tidy} from '@tensorflow/tfjs-core';
+import {serialization, Tensor, tidy} from '@tensorflow/tfjs-core';
 
 import * as K from './backend/tfjs_backend';
 import {deserializeKerasObject} from './utils/generic_utils';
@@ -81,13 +81,10 @@ serialization.SerializationMap.register(Relu);
 /**
  * Rectified linear unit activation maxing out at 6.0.
  */
-// TODO(bileschi): A new constant 6 here is being created at each invocation.
-// A better pattern would be to reuse a single constant 6, created after the
-// backend math has been instantiated.
 export class Relu6 extends Activation {
   static readonly className = 'relu6';
   apply(x: Tensor): Tensor {
-    return tidy(() => tfc.minimum(scalar(6.0), tfc.relu(x)));
+    return tidy(() => tfc.minimum(K.getScalar(6.0), tfc.relu(x)));
   }
 }
 serialization.SerializationMap.register(Relu6);

--- a/src/backend/tfjs_backend.ts
+++ b/src/backend/tfjs_backend.ts
@@ -896,9 +896,8 @@ export function getUid(prefix = ''): string {
  */
 export function hardSigmoid(x: Tensor): Tensor {
   return tidy(() => {
-    // TODO(cais): Maybe avoid creating scalar constants on each invocation by
-    //   turning them into module-level constants.
-    const y = scalarPlusArray(scalar(0.5), scalarTimesArray(scalar(0.2), x));
+    const y =
+        scalarPlusArray(getScalar(0.5), scalarTimesArray(getScalar(0.2), x));
     return tfc.clipByValue(y, 0, 1);
   });
 }

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -51,7 +51,6 @@ import {LossOrMetricFn} from './types';
  * @return Accuracy Tensor.
  */
 export function binaryAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
-  // TODO(cais): Maybe avoid creating a new Scalar on every invocation.
   return tidy(() => {
     const threshold = K.scalarTimesArray(K.getScalar(0.5), tfc.onesLike(yPred));
     const yPredThresholded = K.cast(tfc.greater(yPred, threshold), yTrue.dtype);


### PR DESCRIPTION
Replace the three todos referencing caching scalar constants, with the getScalar call.  One of the todos had already been resolved, but not removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/202)
<!-- Reviewable:end -->
