### PR TITLE
Fix issue re Pooling1D layer deserialization

### DIFF
--- a/src/model_save_test.ts
+++ b/src/model_save_test.ts
@@ -261,8 +261,7 @@ describeMathGPU('Save-load round trips', () => {
           tfl.loadModel(url)
               .then(modelPrime => {
                 // Call predict() on the loaded model and assert the
-                // result
-                // equals the original predict() result.
+                // result equals the original predict() result.
                 const yPrime = modelPrime.predict(x) as Tensor;
                 expectTensorsClose(y, yPrime);
 

--- a/src/model_save_test.ts
+++ b/src/model_save_test.ts
@@ -8,7 +8,7 @@
  * =============================================================================
  */
 
-import {io} from '@tensorflow/tfjs-core';
+import {io, randomNormal, Tensor} from '@tensorflow/tfjs-core';
 
 import * as tfl from './index';
 
@@ -183,5 +183,104 @@ describeMathGPU('Save-load round trips', () => {
         .catch(err => {
           done.fail(err.stack);
         });
+  });
+
+  it('Call predict() and fit() after load: conv2d model', done => {
+    const model = tfl.sequential();
+    model.add(tfl.layers.conv2d({
+      filters: 8,
+      kernelSize: 4,
+      inputShape: [28, 28, 1],
+      padding: 'same',
+      activation: 'relu'
+    }));
+    model.add(tfl.layers.maxPooling2d({
+      poolSize: 2,
+      padding: 'same',
+    }));
+    model.add(tfl.layers.flatten());
+    model.add(tfl.layers.dense({units: 1}));
+
+    const x = randomNormal([1, 28, 28, 1]);
+    const y = model.predict(x) as Tensor;
+
+    const path = `testModel${new Date().getTime()}_${Math.random()}`;
+    const url = `indexeddb://${path}`;
+    model.save(url)
+        .then(saveResult => {
+          // Load the model back.
+          tfl.loadModel(url)
+              .then(modelPrime => {
+                // Call predict() on the loaded model and assert the result
+                // equals the original predict() result.
+                const yPrime = modelPrime.predict(x) as Tensor;
+                expectTensorsClose(y, yPrime);
+
+                // Call compile and fit() on the loaded model.
+                modelPrime.compile(
+                    {optimizer: 'sgd', loss: 'meanSquaredError'});
+                const trainExamples = 10;
+                modelPrime
+                    .fit(
+                        randomNormal([trainExamples, 28, 28, 1]),
+                        randomNormal([trainExamples]), {epochs: 4})
+                    .then(history => {
+                      done();
+                    })
+                    .catch(err => done.fail(err.stack));
+              })
+              .catch(err => done.fail(err.stack));
+        })
+        .catch(err => done.fail(err.stack));
+  });
+
+  it('Call predict() and fit() after load: conv1d model', done => {
+    const model = tfl.sequential();
+    model.add(tfl.layers.conv1d({
+      filters: 8,
+      kernelSize: 4,
+      inputShape: [100, 1],
+      padding: 'same',
+      activation: 'relu'
+    }));
+    model.add(tfl.layers.maxPooling1d({
+      poolSize: 2,
+      padding: 'same',
+    }));
+    model.add(tfl.layers.flatten());
+    model.add(tfl.layers.dense({units: 1}));
+
+    const x = randomNormal([1, 100, 1]);
+    const y = model.predict(x) as Tensor;
+
+    const path = `testModel${new Date().getTime()}_${Math.random()}`;
+    const url = `indexeddb://${path}`;
+    model.save(url)
+        .then(saveResult => {
+          // Load the model back.
+          tfl.loadModel(url)
+              .then(modelPrime => {
+                // Call predict() on the loaded model and assert the
+                // result
+                // equals the original predict() result.
+                const yPrime = modelPrime.predict(x) as Tensor;
+                expectTensorsClose(y, yPrime);
+
+                // Call compile and fit() on the loaded model.
+                modelPrime.compile(
+                    {optimizer: 'sgd', loss: 'meanSquaredError'});
+                const trainExamples = 10;
+                modelPrime
+                    .fit(
+                        randomNormal([trainExamples, 100, 1]),
+                        randomNormal([trainExamples]), {epochs: 4})
+                    .then(history => {
+                      done();
+                    })
+                    .catch(err => done.fail(err.stack));
+              })
+              .catch(err => done.fail(err.stack));
+        })
+        .catch(err => done.fail(err.stack));
   });
 });

--- a/src/utils/conv_utils.ts
+++ b/src/utils/conv_utils.ts
@@ -48,25 +48,24 @@ export function normalizeArray(
 /**
  * Determines output length of a convolution given input length.
  * @param inputLength
- * @param fliterSize
+ * @param filterSize
  * @param padding
  * @param stride
  * @param dilation: dilation rate.
  */
 export function convOutputLength(
-    inputLength: number, fliterSize: number, padding: PaddingMode,
+    inputLength: number, filterSize: number, padding: PaddingMode,
     stride: number, dilation = 1): number {
   if (inputLength == null) {
     return inputLength;
   }
-  const dilatedFilterSize = fliterSize + (fliterSize - 1) * (dilation - 1);
+  const dilatedFilterSize = filterSize + (filterSize - 1) * (dilation - 1);
   let outputLength: number;
   if (padding === 'same') {
     outputLength = inputLength;
   } else {  // VALID
     outputLength = inputLength - dilatedFilterSize + 1;
   }
-  // TODO(cais): Implement logic for padding modes 'causal' and 'full'.
   return Math.floor((outputLength + stride - 1) / stride);
 }
 


### PR DESCRIPTION
The handling of `number` versus `[number]` types for the Pooling1D layer
and its subtypes, e.g., MaxPooling1D, was not done correctly, leading to
errors during deserialization of such layers. This PR fixes that.

Fixes: https://github.com/tensorflow/tfjs/issues/331

BUG: Fix the loading of Pooling1D layers such as MaxPooling1D.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/208)
<!-- Reviewable:end -->
