### PR TITLE
Fix saving and loading of Bidrectional RNN layers

### DIFF
--- a/src/engine/topology.ts
+++ b/src/engine/topology.ts
@@ -2789,7 +2789,6 @@ export function loadWeightsFromNamedTensorMap(
   batchSetValue(weightValueTuples);
 }
 
-
 // TODO(cais): Maybe remove the following (b/74015805).
 /**
  * Load weights from a weights JSON object to an array of layers.

--- a/src/layers/wrappers.ts
+++ b/src/layers/wrappers.ts
@@ -276,7 +276,7 @@ export class Bidirectional extends Wrapper {
     //   (`config.layer`) ought to be cloned. This is why we call `getConfig()`
     //   followed by `deserialize()`. Without this cloning, the layer names
     //   saved during serialization will incorrectly contain the 'forward_'
-    //   perfix.
+    //   prefix.
     //   In Python Keras, this is done using `copy.copy` (shallow copy), which
     //   does not have a simple equivalent in JavaScript. JavaScript's
     //   `Object.assign()` does not copy methods.

--- a/src/layers/wrappers.ts
+++ b/src/layers/wrappers.ts
@@ -271,9 +271,21 @@ export class Bidirectional extends Wrapper {
 
   constructor(config: BidirectionalLayerConfig) {
     super(config);
-    this.forwardLayer = config.layer;
-    // TODO(cais): Perform shallow copy if necessary.
+    // this.forwardLayer = Object.assign({}, config.layer);
     const layerConfig = config.layer.getConfig();
+    // Note: When creating `this.forwardLayer`, the original Layer object
+    //   (`config.layer`) ought to be cloned. This is why we call `getConfig()`
+    //   followed by `deserialize()`. Without this cloning, the layer names
+    //   saved during serialization will incorrectly contain the 'forward_'
+    //   perfix.
+    //   In Python Keras, this is done using `copy.copy` (shallow copy), which
+    //   does not have a simple equivalent in JavaScript. JavaScript's
+    //   `Object.assign()` does not copy methods.
+    this.forwardLayer =
+        deserialize(
+            {className: config.layer.getClassName(), config: layerConfig}) as
+        RNN;
+    // TODO(cais): Perform shallow copy if necessary.
     layerConfig['goBackwards'] =
         layerConfig['goBackwards'] === true ? false : true;
     this.backwardLayer =
@@ -481,7 +493,8 @@ export class Bidirectional extends Wrapper {
   static fromConfig<T extends serialization.Serializable>(
       cls: serialization.SerializableConstructor<T>,
       config: serialization.ConfigDict): T {
-    const rnnLayer = deserialize(config['layer'] as serialization.ConfigDict);
+    const rnnLayer =
+        deserialize(config['layer'] as serialization.ConfigDict) as RNN;
     delete config['layer'];
     // TODO(cais): Add logic for `numConstants` once the property is added.
     if (config['numConstants'] != null) {

--- a/src/layers/wrappers.ts
+++ b/src/layers/wrappers.ts
@@ -271,8 +271,7 @@ export class Bidirectional extends Wrapper {
 
   constructor(config: BidirectionalLayerConfig) {
     super(config);
-    // this.forwardLayer = Object.assign({}, config.layer);
-    const layerConfig = config.layer.getConfig();
+
     // Note: When creating `this.forwardLayer`, the original Layer object
     //   (`config.layer`) ought to be cloned. This is why we call `getConfig()`
     //   followed by `deserialize()`. Without this cloning, the layer names
@@ -281,11 +280,11 @@ export class Bidirectional extends Wrapper {
     //   In Python Keras, this is done using `copy.copy` (shallow copy), which
     //   does not have a simple equivalent in JavaScript. JavaScript's
     //   `Object.assign()` does not copy methods.
+    const layerConfig = config.layer.getConfig();
     this.forwardLayer =
         deserialize(
             {className: config.layer.getClassName(), config: layerConfig}) as
         RNN;
-    // TODO(cais): Perform shallow copy if necessary.
     layerConfig['goBackwards'] =
         layerConfig['goBackwards'] === true ? false : true;
     this.backwardLayer =

--- a/src/model_save_test.ts
+++ b/src/model_save_test.ts
@@ -296,7 +296,6 @@ describeMathGPU('Save-load round trips', () => {
 
     const x = randomNormal([2, 4, 5]);
     const y = model.predict(x) as Tensor;
-    y.print();
 
     const path = `testModel${new Date().getTime()}_${Math.random()}`;
     const url = `indexeddb://${path}`;

--- a/src/model_save_test.ts
+++ b/src/model_save_test.ts
@@ -282,4 +282,48 @@ describeMathGPU('Save-load round trips', () => {
         })
         .catch(err => done.fail(err.stack));
   });
+
+  it('Call predict() and fit() after load: Bidirectional LSTM', done => {
+    const model = tfl.sequential();
+    const lstmUnits = 3;
+    const sequenceLength = 4;
+    const inputDims = 5;
+    model.add(tfl.layers.bidirectional({
+      layer: tfl.layers.lstm({units: lstmUnits}) as tfl.RNN,
+      mergeMode: 'concat',
+      inputShape: [sequenceLength, inputDims]
+    }));
+
+    const x = randomNormal([2, 4, 5]);
+    const y = model.predict(x) as Tensor;
+    y.print();
+
+    const path = `testModel${new Date().getTime()}_${Math.random()}`;
+    const url = `indexeddb://${path}`;
+    model.save(url)
+        .then(saveResult => {
+          tfl.loadModel(url)
+              .then(modelPrime => {
+                const yPrime = modelPrime.predict(x) as Tensor;
+                expectTensorsClose(y, yPrime);
+
+                // Call compile and fit() on the loaded model.
+                modelPrime.compile(
+                    {optimizer: 'sgd', loss: 'meanSquaredError'});
+                const trainExamples = 2;
+                modelPrime
+                    .fit(
+                        randomNormal(
+                            [trainExamples, sequenceLength, inputDims]),
+                        randomNormal([trainExamples, lstmUnits * 2]),
+                        {epochs: 2})
+                    .then(history => {
+                      done();
+                    })
+                    .catch(err => done.fail(err.stack));
+              })
+              .catch(err => done.fail(err.stack));
+        })
+        .catch(err => done.fail(err.stack));
+  });
 });


### PR DESCRIPTION
Fix saving and loading of Bidrectional RNN layers
    
* Previously the constructor of Bidirectional did not perform
  shallow copying of the input RNN layer, resulting in the 'forward_'
  suffix being written to serialized model topology, which in turn
  caused weight name mismatches and failure at loading time.
  This PR fixes that.

Fixes: https://github.com/tensorflow/tfjs/issues/342
BUG Fix saving and loading of models containing Bidirectional RNN layers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/211)
<!-- Reviewable:end -->
