### PR TITLE
Fix memory leak during tf.Model.fit()

### DIFF
--- a/src/callbacks.ts
+++ b/src/callbacks.ts
@@ -251,7 +251,6 @@ export class BaseLogger extends Callback {
         if (!this.totals.hasOwnProperty(key)) {
           this.totals[key] = K.getScalar(0);
         }
-        // TODO(cais): Do not leak tidy from TensorFlow.js Core.
         tidy(() => {
           this.totals[key] = K.scalarPlusArray(
                                  this.totals[key] as Scalar,

--- a/src/callbacks.ts
+++ b/src/callbacks.ts
@@ -10,7 +10,7 @@
 
 /* Original source: keras/callbacks.py */
 
-import {div, keep, memory, mul, Scalar, Tensor, tidy} from '@tensorflow/tfjs-core';
+import {div, keep, mul, Scalar, Tensor, tidy} from '@tensorflow/tfjs-core';
 
 import * as K from './backend/tfjs_backend';
 import {Model} from './engine/training';
@@ -156,8 +156,6 @@ export class CallbackList {
     if (logs == null) {
       logs = {};
     }
-    console.log(
-        `CallbackList.onEpochEnd: # of callbacks = ${this.callbacks.length}`);
     for (const callback of this.callbacks) {
       await callback.onEpochEnd(epoch, logs);
     }
@@ -186,8 +184,6 @@ export class CallbackList {
     if (logs == null) {
       logs = {};
     }
-    console.log(
-        `onBatchEnd: # of callbacks: ${this.callbacks.length}`);  // DEBUG
     for (const callback of this.callbacks) {
       await callback.onBatchEnd(batch, logs);
     }
@@ -239,7 +235,6 @@ export class BaseLogger extends Callback {
   }
 
   async onBatchEnd(batch: number, logs?: UnresolvedLogs) {
-    console.log(`  onBatchEnd: 1: ${memory().numTensors}`);  // DEBUG
     if (logs == null) {
       logs = {};
     }
@@ -258,19 +253,13 @@ export class BaseLogger extends Callback {
         }
         // TODO(cais): Do not leak tidy from TensorFlow.js Core.
         tidy(() => {
-          console.log(
-              `  onBatchEnd: 10: key=${key}, ${memory().numTensors}`);  // DEBUG
-          console.log(`  batchSize = ${batchSize}`);                    // DEBUG
           this.totals[key] = K.scalarPlusArray(
                                  this.totals[key] as Scalar,
                                  mul(value, K.getScalar(batchSize))) as Scalar;
-          console.log(
-              `  onBatchEnd: 11: key=${key}, ${memory().numTensors}`);  // DEBUG
           keep(this.totals[key] as Scalar);
         });
       }
     }
-    console.log(`  onBatchEnd: 100: ${memory().numTensors}`);  // DEBUG
   }
 
   async onEpochEnd(epoch: number, logs?: UnresolvedLogs) {
@@ -283,7 +272,6 @@ export class BaseLogger extends Callback {
           logs[key] = this.totals[key] as number / this.seen;
         } else {
           tidy(() => {
-            console.log(`onEpochEnd: this.seen = ${this.seen}`);  // DEBUG
             logs[key] =
                 K.scalarTimesArray(
                     div(K.getScalar(1), K.getScalar(this.seen)) as Scalar,
@@ -332,13 +320,9 @@ export function disposeTensorsInLogs(logs: UnresolvedLogs) {
   if (logs == null) {
     return;
   }
-  console.log(
-      `disposeTensorsInLogs: number of keys: ${Object.keys(logs).length}`);
-  // DEBUG
   for (const key in logs) {
     const value = logs[key];
     if (typeof value !== 'number') {
-      console.log(`disposeTensorsInLogs: disposing key ${key}`);
       value.dispose();
     }
   }
@@ -379,7 +363,6 @@ export class History extends Callback {
     const keys: string[] = [];
     const indices: number[] = [];
     for (const key in this.history) {
-      // console.log(`this.history key: ${key}`);  // DEBUG
       const valueArray = this.history[key];
       for (let i = 0; i < valueArray.length; ++i) {
         if (typeof valueArray[i] !== 'number') {
@@ -392,11 +375,7 @@ export class History extends Callback {
     }
     const values = await Promise.all(promises);
     for (let n = 0; n < values.length; ++n) {
-      console.log(`Before calling dispose: ${memory().numTensors}`);
-      // DEBUG
       (this.history[keys[n]][indices[n]] as Tensor).dispose();
-      console.log(`After calling dispose: ${memory().numTensors}`);
-      // DEBUG
       this.history[keys[n]][indices[n]] = values[n][0];
     }
   }

--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -1169,6 +1169,7 @@ export class Model extends Container {
       valIns?: Tensor[], shuffle?: boolean|string, callbackMetrics?: string[],
       initialEpoch = 0, stepsPerEpoch?: number,
       validationSteps?: number): Promise<History> {
+    console.log(`fitLoop() 1: ${tfc.memory().numTensors}`);  // DEBUG
     if (batchSize == null) {
       batchSize = 32;
     }
@@ -1211,6 +1212,7 @@ export class Model extends Container {
       callbacks = [new BaseLogger() as Callback].concat(callbacks);
     }
     callbacks = callbacks.concat([this.history]);
+    console.log(`callbacks.length = ${callbacks.length}`);  // DEBUG
 
     if (verbose > 0) {
       throw new NotImplementedError('Verbose mode is not implemented yet.');
@@ -1233,7 +1235,10 @@ export class Model extends Container {
 
     // TODO(cais): Pre-convert feeds for performance as in PyKeras.
 
+    console.log(`fitLoop() 10: ${tfc.memory().numTensors}`);  // DEBUG
     for (let epoch = initialEpoch; epoch < epochs; ++epoch) {
+      console.log(
+          `fitLoop() 20: epoch=${epoch}, ${tfc.memory().numTensors}`);  // DEBUG
       await callbackList.onEpochBegin(epoch);
       const epochLogs: UnresolvedLogs = {};
       if (stepsPerEpoch != null) {
@@ -1250,12 +1255,21 @@ export class Model extends Container {
         // cost of repeated creation of Array1Ds later on.
         const epochIndexArray1D = tensor1d(indexArray);
 
+        console.log(`fitLoop() 24: epoch=${epoch}, ${
+            tfc.memory().numTensors}`);  // DEBUG
         const batches = makeBatches(numTrainSamples, batchSize);
+        console.log(`fitLoop() 25: epoch=${epoch}, ${
+            tfc.memory().numTensors}`);  // DEBUG
         for (let batchIndex = 0; batchIndex < batches.length; ++batchIndex) {
           // TODO(cais): tfc.tidy() should not be leaked from the backend.
           //   Wrap it with a backend function called mathScope.
           const batchLogs: UnresolvedLogs = {};
+          console.log(`fitLoop() 26: epoch=${epoch}, batch=${batchIndex}, ${
+              tfc.memory().numTensors}`);  // DEBUG
           await callbackList.onBatchBegin(batchIndex, batchLogs);
+          console.log(`fitLoop() 27: epoch=${epoch}, batch=${batchIndex}, ${
+              tfc.memory().numTensors}`);                 // DEBUG
+          console.log(`  doValidation=${doValidation}`);  // DEBUG
           tfc.tidy(() => {
             const batchStart = batches[batchIndex][0];
             const batchEnd = batches[batchIndex][1];
@@ -1273,6 +1287,7 @@ export class Model extends Container {
               const label = outLabels[i];
               const out = outs[i];
               batchLogs[label] = out;
+              console.log(`Calling keep on label: ${label}`);  // DEBUG
               tfc.keep(out);
               // TODO(cais): Use scope() to avoid ownership.
             }
@@ -1295,21 +1310,41 @@ export class Model extends Container {
             }
           });
 
+          console.log(`fitLoop() 29: epoch=${epoch}, batch=${batchIndex}, ${
+              tfc.memory().numTensors}`);  // DEBUG
+
           await callbackList.onBatchEnd(batchIndex, batchLogs);
+          console.log(`fitLoop() 29.3: epoch=${epoch}, batch=${batchIndex}, ${
+              tfc.memory().numTensors}`);  // DEBUG
           disposeTensorsInLogs(batchLogs);
+          console.log(`fitLoop() 29.5: epoch=${epoch}, batch=${batchIndex}, ${
+              tfc.memory().numTensors}`);  // DEBUG
           // TODO(cais): return outs as list of Tensor.
         }
 
+        console.log(`fitLoop() 30: epoch=${epoch}, ${
+            tfc.memory().numTensors}`);  // DEBUG
         epochIndexArray1D.dispose();
+        console.log(`fitLoop() 31: epoch=${epoch}, ${
+            tfc.memory().numTensors}`);  // DEBUG
       }
       // TODO(cais): Run validation at the end of the epoch.
+      console.log(
+          `fitLoop() 40: epoch=${epoch}, ${tfc.memory().numTensors}`);  // DEBUG
       await callbackList.onEpochEnd(epoch, epochLogs);
+      console.log(
+          `fitLoop() 41: epoch=${epoch}, ${tfc.memory().numTensors}`);  // DEBUG
       // TODO(cais): Logic for early stopping using
       //   callback_model.stop_training as in PyKeras.
     }
+    console.log(`fitLoop() 50: ${tfc.memory().numTensors}`);  // DEBUG
     await callbackList.onTrainEnd();
+    console.log(`fitLoop() 51: ${tfc.memory().numTensors}`);  // DEBUG
 
+    console.log('Calling this.syncData()');                    // DEBUG
+    console.log(`fitLoop() 100: ${tfc.memory().numTensors}`);  // DEBUG
     await this.history.syncData();
+    console.log(`fitLoop() 101: ${tfc.memory().numTensors}`);  // DEBUG
     return this.history;
   }
 
@@ -1462,6 +1497,7 @@ export class Model extends Container {
       x: Tensor|Tensor[]|{[inputName: string]: Tensor},
       y: Tensor|Tensor[]|{[inputName: string]: Tensor},
       config: ModelFitConfig = {}): Promise<History> {
+    console.log(`fit() 1: ${tfc.memory().numTensors}`);  // DEBUG
     const batchSize = config.batchSize == null ? 32 : config.batchSize;
 
     // Validate user data.
@@ -1477,6 +1513,7 @@ export class Model extends Container {
     let valX: Tensor|Tensor[];
     let valY: Tensor|Tensor[];
     let valIns: Tensor[];
+    let needValidationDisposal = false;
     if (config.validationData != null && config.validationData.length > 0) {
       doValidation = true;
       if (config.validationData.length === 2) {
@@ -1509,13 +1546,17 @@ export class Model extends Container {
       const splitAt =
           Math.floor(inputs[0].shape[0] * (1 - config.validationSplit));
       const originalBatchSize = inputs[0].shape[0];
+      console.log(`fit() 2.1: ${tfc.memory().numTensors}`);  // DEBUG
       valX = sliceArrays(inputs, splitAt, originalBatchSize) as Tensor[];
       inputs = sliceArrays(inputs, 0, splitAt) as Tensor[];
       valY = sliceArrays(targets, splitAt, originalBatchSize) as Tensor[];
       targets = sliceArrays(targets, 0, splitAt) as Tensor[];
+      needValidationDisposal = true;
+      console.log(`fit() 2.9: ${tfc.memory().numTensors}`);  // DEBUG
       // TODO(cais): Once sampleWeights becomes available, slice it to get
       //   valSampleWeights.
       valIns = valX.concat(valY);
+
       // TODO(cais): Add useLearningPhase data properly.
     } else if (config.validationSteps != null) {
       doValidation = true;
@@ -1525,6 +1566,7 @@ export class Model extends Container {
     const ins = inputs.concat(targets);
 
     this.checkTrainableWeightsConsistency();
+    console.log(`fit() 3: ${tfc.memory().numTensors}`);  // DEBUG
 
     // TODO(cais): Handle use_learning_phase and learning_phase?
 
@@ -1623,7 +1665,9 @@ export class Model extends Container {
     let valFunction: (data: Tensor[]) => Scalar[];
     let callbackMetrics: string[];
     if (doValidation) {
+      console.log(`fit() 5: ${tfc.memory().numTensors}`);  // DEBUG
       this.makeTestFunction();
+      console.log(`fit() 6: ${tfc.memory().numTensors}`);  // DEBUG
       valFunction = this.testFunction;
       callbackMetrics =
           outLabels.slice().concat(outLabels.map(n => 'val_' + n));
@@ -1633,11 +1677,19 @@ export class Model extends Container {
       callbackMetrics = outLabels.slice();
     }
 
+    console.log(`fit() 10: ${tfc.memory().numTensors}`);  // DEBUG
     const callbacks = standardizeCallbacks(config.callbacks);
-    return this.fitLoop(
+    console.log(`fit() 20: ${tfc.memory().numTensors}`);  // DEBUG
+    const out = await this.fitLoop(
         trainFunction, ins, outLabels, batchSize, config.epochs, config.verbose,
         callbacks, valFunction, valIns, config.shuffle, callbackMetrics, null,
         null, null);
+    if (needValidationDisposal) {
+      valIns.forEach(tensor => tensor.dispose());
+      inputs.forEach(tensor => tensor.dispose());
+      targets.forEach(tensor => tensor.dispose());
+    }
+    return out;
     // TODO(cais): Add value to outLabels.
     // TODO(cais): Add initialEpoch.
   }

--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -1478,6 +1478,11 @@ export class Model extends Container {
     let valX: Tensor|Tensor[];
     let valY: Tensor|Tensor[];
     let valIns: Tensor[];
+    // A flag to keep track of whether `valIns`, `inputs` and `targets` need to
+    // be memory-disposed prior to returning from this method. This is the case
+    // if `config.validationSplit` is set to a number between 0 and 1, in which
+    // case the input `x` and `y` tensors will be sliced, leading to allocation
+    // of new tensor memory.
     let needValidationDisposal = false;
     if (config.validationData != null && config.validationData.length > 0) {
       doValidation = true;

--- a/src/engine/training_test.ts
+++ b/src/engine/training_test.ts
@@ -13,7 +13,7 @@
  */
 
 // tslint:disable:max-line-length
-import {abs, mean, ones, Scalar, scalar, SGDOptimizer, Tensor, tensor1d, tensor2d, tensor3d, test_util, zeros} from '@tensorflow/tfjs-core';
+import {abs, mean, memory, ones, Scalar, scalar, SGDOptimizer, Tensor, tensor1d, tensor2d, tensor3d, test_util, zeros} from '@tensorflow/tfjs-core';
 
 import * as K from '../backend/tfjs_backend';
 import {CustomCallback, CustomCallbackConfig, Logs} from '../callbacks';
@@ -22,6 +22,7 @@ import {Regularizer} from '../regularizers';
 import {Kwargs} from '../types';
 import {pyListRepeat, stringsEqual} from '../utils/generic_utils';
 import {describeMathCPU, describeMathCPUAndGPU, expectTensorsClose} from '../utils/test_utils';
+
 // TODO(bileschi): Use external version of Layer.
 import {Layer} from './topology';
 import {checkArrayLengths, isDataArray, isDataDict, isDataTensor, makeBatches, sliceArraysByIndices, standardizeInputData} from './training';
@@ -1072,28 +1073,6 @@ describeMathCPUAndGPU('Model.fit', () => {
         });
   });
 
-  // TODO(cais): Uncommment the test below once the 1-tensor leak during
-  // //   `updateVariable` is fixed.
-  // it('Repeated fit calls leads to no memory leak: no validation',
-  //    async done => {
-  //      createDenseModelAndData();
-
-  //      model.compile({optimizer: 'SGD', loss: 'meanSquaredError'});
-  //      // Use batchSize === numSamples to get exactly one batch.
-  //      await model.fit(inputs, targets, {batchSize: numSamples, epochs: 1});
-  //      const numTensors1 = memory().numTensors;
-  //      await model.fit(inputs, targets, {batchSize: numSamples, epochs: 1});
-  //      const numTensors2 = memory().numTensors;
-  //      if (numTensors2 > numTensors1) {
-  //        done.fail(
-  //            `Memory leak detected during fit(): Leaked ` +
-  //            `${numTensors2 - numTensors1} tensor(s) after the ` +
-  //            `second fit() call.`);
-  //      } else {
-  //        done();
-  //      }
-  //    });
-
   it('Invalid dict loss: nonexistent output name', () => {
     createDenseModelAndData();
     expect(() => model.compile({
@@ -1166,6 +1145,143 @@ describeMathCPUAndGPU('Model.fit with training-sensitive layers', () => {
 
     done();
   });
+});
+
+describeMathCPUAndGPU('Model.fit-memory', () => {
+  const inputSize = 4;   // Input vector size for model with one input.
+  const numSamples = 5;  // Number of samples in a batch.
+
+  const inputTensor = tfl.layers.input(
+      {shape: [inputSize], name: 'inputLayer1', dtype: 'float32'});
+  let model: tfl.Model;
+  let inputs: Tensor;
+  let targets: Tensor;
+
+  function createDenseModelAndData(
+      useBias = false,
+      kernelRegularizer?: string|Regularizer,
+      biasRegularizer?: string|Regularizer,
+      ): void {
+    const layer = tfl.layers.dense(
+        {units: 1, useBias, kernelInitializer: 'ones', kernelRegularizer});
+    const output = layer.apply(inputTensor) as tfl.SymbolicTensor;
+    model = new tfl.Model({inputs: [inputTensor], outputs: [output]});
+    inputs = ones([numSamples, inputSize]);
+    targets = ones([numSamples, 1]);
+  }
+
+  it('Repeated fit calls leads to no memory leak: no validation or metrics',
+     async done => {
+       createDenseModelAndData();
+
+       model.compile({optimizer: 'SGD', loss: 'meanSquaredError'});
+       // Use batchSize === numSamples to get exactly one batch.
+       await model.fit(inputs, targets, {batchSize: numSamples, epochs: 1});
+       const numTensors0 = memory().numTensors;
+       for (let i = 0; i < 2; ++i) {
+         console.log(`---- Fit call #${i + 1} ----`);  // DEBUG
+         await model.fit(inputs, targets, {batchSize: numSamples, epochs: 1});
+         const numTensorsNow = memory().numTensors;
+         if (numTensorsNow > numTensors0) {
+           // DEBUG
+           done.fail(
+               `Memory leak detected during fit(): Leaked ` +
+               `${numTensorsNow - numTensors0} tensor(s) after the ` +
+               `${i + 1}-th fit() call.`);
+         } else {
+           done();
+         }
+       }
+     });
+
+  it('Repeated fit calls leads to no memory leak: with metrics', async done => {
+    createDenseModelAndData();
+
+    model.compile(
+        {optimizer: 'SGD', loss: 'meanSquaredError', metrics: ['mse']});
+    // Use batchSize === numSamples to get exactly one batch.
+    await model.fit(inputs, targets, {batchSize: numSamples, epochs: 1});
+    const numTensors0 = memory().numTensors;
+    for (let i = 0; i < 2; ++i) {
+      console.log(`---- Fit call #${i + 1} ----`);  // DEBUG
+      await model.fit(inputs, targets, {batchSize: numSamples, epochs: 1});
+      const numTensorsNow = memory().numTensors;
+      if (numTensorsNow > numTensors0) {
+        // DEBUG
+        done.fail(
+            `Memory leak detected during fit(): Leaked ` +
+            `${numTensorsNow - numTensors0} tensor(s) after the ` +
+            `${i + 1}-th fit() call.`);
+      } else {
+        done();
+      }
+    }
+  });
+
+  it('Repeated fit calls leads to no memory leak: validationSplit',
+     async done => {
+       createDenseModelAndData();
+
+       const validationSplit = 0.4;
+       model.compile({optimizer: 'SGD', loss: 'meanSquaredError'});
+       // Use batchSize === numSamples to get exactly one batch.
+       console.log('---- Fit call #0 ----');  // DEBUG
+       await model.fit(
+           inputs, targets,
+           {batchSize: numSamples, epochs: 1, validationSplit});
+       const numTensors0 = memory().numTensors;
+       for (let i = 0; i < 2; ++i) {
+         // TODO(cais): Make 2 again. DO NOT SUBMIT.
+         console.log(`numTensors1 = ${numTensors0}`);  // DEBUG
+         console.log(`---- Fit call #${i + 1} ----`);  // DEBUG
+         await model.fit(
+             inputs, targets,
+             {batchSize: numSamples, epochs: 1, validationSplit});
+         const numTensorsNow = memory().numTensors;
+         console.log(`numTensors2 = ${numTensorsNow}`);  // DEBUG
+         if (numTensorsNow > numTensors0) {
+           done.fail(
+               `Memory leak detected during fit(): Leaked ` +
+               `${numTensorsNow - numTensors0} tensor(s) after the ` +
+               `${i + 1}-th fit() call.`);
+         } else {
+           done();
+         }
+       }
+     });
+
+  it('Repeated fit calls leads to no memory leak: metrics & validationSplit',
+     async done => {
+       createDenseModelAndData();
+
+       const validationSplit = 0.4;
+       model.compile(
+           {optimizer: 'SGD', loss: 'meanSquaredError', metrics: ['mse']});
+       // Use batchSize === numSamples to get exactly one batch.
+       console.log('---- Fit call #0 ----');  // DEBUG
+       await model.fit(
+           inputs, targets,
+           {batchSize: numSamples, epochs: 1, validationSplit});
+       const numTensors0 = memory().numTensors;
+       for (let i = 0; i < 2; ++i) {
+         // TODO(cais): Make 2 again. DO NOT SUBMIT.
+         console.log(`numTensors1 = ${numTensors0}`);  // DEBUG
+         console.log(`---- Fit call #${i + 1} ----`);  // DEBUG
+         await model.fit(
+             inputs, targets,
+             {batchSize: numSamples, epochs: 1, validationSplit});
+         const numTensorsNow = memory().numTensors;
+         console.log(`numTensors2 = ${numTensorsNow}`);  // DEBUG
+         if (numTensorsNow > numTensors0) {
+           done.fail(
+               `Memory leak detected during fit(): Leaked ` +
+               `${numTensorsNow - numTensors0} tensor(s) after the ` +
+               `${i + 1}-th fit() call.`);
+         } else {
+           done();
+         }
+       }
+     });
 });
 
 describeMathCPUAndGPU('Model.evaluate', () => {

--- a/src/engine/training_test.ts
+++ b/src/engine/training_test.ts
@@ -1147,7 +1147,7 @@ describeMathCPUAndGPU('Model.fit with training-sensitive layers', () => {
   });
 });
 
-describeMathCPUAndGPU('Model.fit-memory', () => {
+describeMathCPUAndGPU('Model.fit: No memory leak', () => {
   const inputSize = 4;   // Input vector size for model with one input.
   const numSamples = 5;  // Number of samples in a batch.
 


### PR DESCRIPTION
Previously, calling `tf.Model.fit()` lead to slow and gradual memory leak, due to
the following factors:
1) that tensors in per-batch logs of `BaseLogger` were not disposed correctly
2) that newly sliced tensors werenot dipsosely correctly, if `config.validationSplit` was
    used.

This PR fixes the memory leaks.

Fixes: https://github.com/tensorflow/tfjs/issues/200

BUG Fix slow WebGL memory leaks during calls to `tf.Model.fi()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/212)
<!-- Reviewable:end -->
