### PR TITLE
Implement logic for stopTraining in tf.Model.fit()

### DIFF
--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -1231,7 +1231,6 @@ export class Model extends Container {
       doValidation,
       metrics: callbackMetrics,
     });
-    // TODO(cais): Take care of the PyKeras logic of stop_training.
     await callbackList.onTrainBegin();
     this.stopTraining = false;
     // TODO(cais): Take care of callbacks.validation_data as in PyKeras.

--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -642,6 +642,10 @@ export class Model extends Container {
   private testFunction: (data: Tensor[]) => Scalar[];
   history: History;
 
+  // A public property that can be set by Callbacks to order early stopping
+  // during `fit()` calls.
+  stopTraining: boolean;
+
   metrics: string[]|{[outputName: string]: string};
   metricsNames: string[];
   // Porting Note: `metrics_tensors` in PyKeras is a symbolic tensor. But given
@@ -1229,6 +1233,7 @@ export class Model extends Container {
     });
     // TODO(cais): Take care of the PyKeras logic of stop_training.
     await callbackList.onTrainBegin();
+    this.stopTraining = false;
     // TODO(cais): Take care of callbacks.validation_data as in PyKeras.
 
     // TODO(cais): Pre-convert feeds for performance as in PyKeras.
@@ -1277,9 +1282,6 @@ export class Model extends Container {
               // TODO(cais): Use scope() to avoid ownership.
             }
 
-            // TODO(cais): Logic for early stopping using
-            //   callback_model.stop_training as in PyKeras.
-
             if (batchIndex === batches.length - 1) {  // Last batch.
               if (doValidation) {
                 const valOuts = this.testLoop(valF, valIns, batchSize);
@@ -1297,6 +1299,10 @@ export class Model extends Container {
 
           await callbackList.onBatchEnd(batchIndex, batchLogs);
           disposeTensorsInLogs(batchLogs);
+
+          if (this.stopTraining) {
+            break;
+          }
           // TODO(cais): return outs as list of Tensor.
         }
 
@@ -1304,8 +1310,9 @@ export class Model extends Container {
       }
       // TODO(cais): Run validation at the end of the epoch.
       await callbackList.onEpochEnd(epoch, epochLogs);
-      // TODO(cais): Logic for early stopping using
-      //   callback_model.stop_training as in PyKeras.
+      if (this.stopTraining) {
+        break;
+      }
     }
     await callbackList.onTrainEnd();
 

--- a/src/engine/training_test.ts
+++ b/src/engine/training_test.ts
@@ -16,7 +16,7 @@
 import {abs, mean, ones, Scalar, scalar, SGDOptimizer, Tensor, tensor1d, tensor2d, tensor3d, test_util, zeros} from '@tensorflow/tfjs-core';
 
 import * as K from '../backend/tfjs_backend';
-import {CustomCallback, CustomCallbackConfig, Logs} from '../callbacks';
+import {CustomCallback, CustomCallbackConfig, Logs, UnresolvedLogs} from '../callbacks';
 import * as tfl from '../index';
 import {Regularizer} from '../regularizers';
 import {Kwargs} from '../types';
@@ -1070,6 +1070,74 @@ describeMathCPUAndGPU('Model.fit', () => {
         .catch(err => {
           done.fail(err.stack);
         });
+  });
+
+  class StopAfterNEpochs extends tfl.Callback {
+    private readonly epochsToTrain: number;
+    constructor(epochsToTrain: number) {
+      super();
+      this.epochsToTrain = epochsToTrain;
+    }
+
+    async onEpochEnd(epoch: number, logs?: UnresolvedLogs) {
+      if (epoch === this.epochsToTrain - 1) {
+        this.model.stopTraining = true;
+      }
+    }
+  }
+
+  it('Stop training at the end of an epoch: Functional model', done => {
+    createDenseModelAndData(true);
+    model.compile({optimizer: 'SGD', loss: 'meanSquaredError'});
+    // Order 10 epochs of training, but the training should stop after two
+    // epochs due to the callback.
+    model
+        .fit(inputs, targets, {
+          batchSize: numSamples,
+          epochs: 10,
+          callbacks: [new StopAfterNEpochs(2)]
+        })
+        .then(history => {
+          expect(history.history.loss.length).toEqual(2);
+          done();
+        })
+        .catch(err => done.fail(err.stack));
+  });
+
+  class StopAfterNBatches extends tfl.Callback {
+    private readonly batchesToTrain: number;
+    constructor(epochsToTrain: number) {
+      super();
+      this.batchesToTrain = epochsToTrain;
+    }
+
+    async onBatchEnd(batch: number, logs?: Logs) {
+      if (batch === this.batchesToTrain - 1) {
+        this.model.stopTraining = true;
+      }
+    }
+  }
+
+  it('Stop training at the end of a batch: Sequential model', done => {
+    const sequentialModel = tfl.sequential();
+    sequentialModel.add(tfl.layers.dense(
+        {units: 1, kernelInitializer: 'ones', inputShape: [inputSize]}));
+    inputs = ones([numSamples, inputSize]);
+    targets = ones([numSamples, 1]);
+    sequentialModel.compile({optimizer: 'SGD', loss: 'meanSquaredError'});
+    // Order 10 epochs of training, but the training should stop after only one
+    // epochs due to the callback that orders the training to stop after two
+    // batches. The first epoch should have five batchs  due to a batchSize
+    // of 1.
+    sequentialModel
+        .fit(
+            inputs, targets,
+            {batchSize: 1, epochs: 10, callbacks: [new StopAfterNBatches(2)]})
+        .then(history => {
+          expect(history.history.loss.length).toEqual(1);
+          done();
+        })
+        .catch(err => done.fail(err.stack));
   });
 
   // TODO(cais): Uncommment the test below once the 1-tensor leak during

--- a/src/engine/training_test.ts
+++ b/src/engine/training_test.ts
@@ -1122,12 +1122,13 @@ describeMathCPUAndGPU('Model.fit', () => {
     const sequentialModel = tfl.sequential();
     sequentialModel.add(tfl.layers.dense(
         {units: 1, kernelInitializer: 'ones', inputShape: [inputSize]}));
+    // numSamples is 5.
     inputs = ones([numSamples, inputSize]);
     targets = ones([numSamples, 1]);
     sequentialModel.compile({optimizer: 'SGD', loss: 'meanSquaredError'});
     // Order 10 epochs of training, but the training should stop after only one
     // epochs due to the callback that orders the training to stop after two
-    // batches. The first epoch should have five batchs  due to a batchSize
+    // batches. The first epoch should have five batches  due to a batchSize
     // of 1.
     sequentialModel
         .fit(


### PR DESCRIPTION
* so that callbacks can set `this.model.stopTraining` to order
  early stopping of training.

Fixes: https://github.com/tensorflow/tfjs/issues/312

FEATURE: Support early stopping of training by `Callback`s.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/213)
<!-- Reviewable:end -->
