### PR TITLE
Support compilation with strictNullChecks

### DIFF
--- a/src/engine/topology.ts
+++ b/src/engine/topology.ts
@@ -976,7 +976,7 @@ export abstract class Layer extends serialization.Serializable {
    *
    * @param inputShape A `Shape` or array of `Shape` (unused).
    */
-  public build(inputShape: Shape|Shape[]): void {
+  public build(inputShape?: Shape|Shape[]): void {
     this.built = true;
   }
 


### PR DESCRIPTION
FEATURE

Currently, Sequential is not a valid subclass of Layer because its build method has type `build(inputShape?: Shape | undefined)` whereas Layer's  build method has type `build(inputShape: Shape | Shape[])`.  This breaks when trying to use Sequential in a project that has --strictNullChecks turned on for the Typescript compiler because Layer.build never expects undefined.

The most obvious fix is to make Layer.build's inputShape parameter optional as well. That's what I did, but I'm not sure it's correct -- I *just* started using tensorflow but ran into problems when I tried setting strictNullChecks to true.

The other fix would be to make Sequential.build have type `build(inputShape: Shape)` -- that is, to require the inputShape parameter. But it doesn't even use it, so this seems wrong.

Fixes tensorflow/tfjs#226

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/214)
<!-- Reviewable:end -->
