### PR TITLE
Use ModelPredictConfig from core and don't re-export it since it conflicts at the union level

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensorflow/tfjs-layers",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "TensorFlow layers API in JavaScript",
   "private": false,
   "main": "dist/index.js",

--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -12,8 +12,7 @@
 
 // tslint:disable:max-line-length
 import * as tfc from '@tensorflow/tfjs-core';
-import {doc, io, Optimizer, Scalar, serialization, Tensor, Tensor1D, tensor1d, util} from '@tensorflow/tfjs-core';
-
+import {doc, io, ModelPredictConfig, Optimizer, Scalar, serialization, Tensor, Tensor1D, tensor1d, util} from '@tensorflow/tfjs-core';
 import * as K from '../backend/tfjs_backend';
 import {BaseLogger, Callback, CallbackList, CustomCallbackConfig, disposeTensorsInLogs, History, standardizeCallbacks, UnresolvedLogs} from '../callbacks';
 import {NotImplementedError, RuntimeError, ValueError} from '../errors';
@@ -455,19 +454,6 @@ function collectMetrics(
 export enum ModelLoggingVerbosity {
   SILENT = 0,
   VERBOSE = 1
-}
-
-
-export interface ModelPredictConfig {
-  /**
-   * Batch size (Integer). If unspecified, it will default to 32.
-   */
-  batchSize?: number;
-
-  /**
-   * Verbosity mode. Defaults to false.
-   */
-  verbose?: boolean;
 }
 
 export interface ModelEvaluateConfig {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@
 import {ConstraintExports, InitializerExports, LayerExports, MetricExports, ModelExports, RegularizerExports} from './exports';
 
 export {Callback, CallbackList, CustomCallback, CustomCallbackConfig, Logs} from './callbacks';
-export {Model, ModelCompileConfig, ModelEvaluateConfig, ModelFitConfig, ModelPredictConfig} from './engine/training';
+export {Model, ModelCompileConfig, ModelEvaluateConfig, ModelFitConfig} from './engine/training';
 export {GRUCellLayerConfig, GRULayerConfig, LSTMCellLayerConfig, LSTMLayerConfig, RNN, RNNLayerConfig, SimpleRNNCellLayerConfig, SimpleRNNLayerConfig} from './layers/recurrent';
 export {ModelAndWeightsConfig, Sequential, SequentialConfig} from './models';
 export {Shape, SymbolicTensor} from './types';

--- a/src/models.ts
+++ b/src/models.ts
@@ -11,12 +11,12 @@
 /* Original source keras/models.py */
 
 // tslint:disable:max-line-length
-import {doc, io, Scalar, serialization, Tensor} from '@tensorflow/tfjs-core';
+import {doc, io, ModelPredictConfig, Scalar, serialization, Tensor} from '@tensorflow/tfjs-core';
 
 import * as K from './backend/tfjs_backend';
 import {History} from './callbacks';
 import {getSourceInputs, Input, Layer, Node} from './engine/topology';
-import {Model, ModelCompileConfig, ModelEvaluateConfig, ModelFitConfig, ModelPredictConfig} from './engine/training';
+import {Model, ModelCompileConfig, ModelEvaluateConfig, ModelFitConfig} from './engine/training';
 import {RuntimeError, ValueError} from './errors';
 import {deserialize} from './layers/serialization';
 import {Kwargs, NamedTensorMap, Shape} from './types';

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,5 +1,5 @@
 /** @license See the LICENSE file. */
 
 // This code is auto-generated, do not modify this file!
-const version = '0.6.3';
+const version = '0.6.4';
 export {version};


### PR DESCRIPTION
BUG

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/218)
<!-- Reviewable:end -->
