### PR TITLE
Duplicate ModelPredictConfig

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -11,7 +11,7 @@
 /* Original source keras/models.py */
 
 // tslint:disable:max-line-length
-import {doc, io, ModelPredictConfig, Scalar, serialization, Tensor} from '@tensorflow/tfjs-core';
+import {doc, io, Scalar, serialization, Tensor} from '@tensorflow/tfjs-core';
 
 import * as K from './backend/tfjs_backend';
 import {History} from './callbacks';
@@ -101,6 +101,19 @@ export interface ModelAndWeightsConfig {
    * The path may optionally end in a slash ('/').
    */
   pathPrefix?: string;
+}
+
+// TODO(nielsene): Remove after: https://github.com/tensorflow/tfjs/issues/400
+export interface ModelPredictConfig {
+  /**
+   * Optional. Batch size (Integer). If unspecified, it will default to 32.
+   */
+  batchSize?: number;
+
+  /**
+   * Optional. Verbosity mode. Defaults to false.
+   */
+  verbose?: boolean;
 }
 
 // tslint:disable:max-line-length


### PR DESCRIPTION
Doc: Duplicate the code for ModelPredictConfig.

Until the resolution of https://github.com/tensorflow/tfjs/issues/400, we need to duplicate this code to allow the API DocGen to unpack config parameters, as they can not cross package boundaries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/225)
<!-- Reviewable:end -->
