### PR TITLE
Relax peer dependency of tfjs-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "jsnext:main": "dist-es6/index.js",
   "module": "dist-es6/index.js",
   "devDependencies": {
-    "@tensorflow/tfjs-core": "0.11.5",
+    "@tensorflow/tfjs-core": "~0.11.5",
     "@types/jasmine": "~2.5.53",
     "browserify": "~16.1.0",
     "clang-format": "~1.2.2",
@@ -50,6 +50,6 @@
     "lint": "tslint -p . --type-check -t verbose"
   },
   "peerDependencies": {
-    "@tensorflow/tfjs-core": "0.11.5"
+    "@tensorflow/tfjs-core": "~0.11.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,7 +16,7 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@tensorflow/tfjs-core@0.11.5":
+"@tensorflow/tfjs-core@~0.11.5":
   version "0.11.5"
   resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.11.5.tgz#e8849f92a0def022d3b075dbc6133d94c60234f9"
   dependencies:


### PR DESCRIPTION
The peer dependency for tfjs-core is pegged to a specific build version of tfjs-core, so when you install @tensorflow/tfjs, you often get an npm warning.

This will be followed by relaxing peer dep versions in `tfjs-converter` and `tfjs-node` as well.

Fixes https://github.com/tensorflow/tfjs/issues/369

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/227)
<!-- Reviewable:end -->
