### PR TITLE
Add missing named optimizers

### DIFF
--- a/src/optimizers.ts
+++ b/src/optimizers.ts
@@ -41,6 +41,7 @@ export function getOptimizer(identifier: string): Optimizer {
   optimizerMap['momentum'] = optimizerMap['Momentum'];
   optimizerMap['rmsprop'] = optimizerMap['RMSProp'];
   optimizerMap['sgd'] = optimizerMap['SGD'];
+
   if (identifier in optimizerMap) {
     return optimizerMap[identifier]();
   }

--- a/src/optimizers.ts
+++ b/src/optimizers.ts
@@ -13,29 +13,34 @@
  */
 
 // tslint:disable:max-line-length
-import {Optimizer, train} from '@tensorflow/tfjs-core';
+import { Optimizer, train } from '@tensorflow/tfjs-core';
 
 import * as K from './backend/tfjs_backend';
 // tslint:enable:max-line-length
 
-import {ValueError} from './errors';
+import { ValueError } from './errors';
 
 // Add (de)serialize()
 
 // Porting note: This diverges from the PyKeras implementation and may need to
 // change based on (de)serialization requirements.
 export function getOptimizer(identifier: string): Optimizer {
-  const optimizerMap: {[optimizerName: string]: () => Optimizer} = {
+  const optimizerMap: { [optimizerName: string]: () => Optimizer } = {
     'Adagrad': () => train.adagrad(.01),
     'Adam': () => train.adam(.001, .9, .999, K.epsilon()),
+    'Adadelta': () => train.adadelta(1.0, 0.95, K.epsilon()),
+    'Adamax': () => train.adamax(0.002, .9, .999, K.epsilon(), 0.0),
+    'Momentum': () => train.momentum(0.01, 0.0, false),
     'RMSProp': () => train.rmsprop(.001, .9, null, K.epsilon()),
     'SGD': () => train.sgd(.01)
   };
   optimizerMap['adagrad'] = optimizerMap['Adagrad'];
   optimizerMap['adam'] = optimizerMap['Adam'];
+  optimizerMap['adadelta'] = optimizerMap['Adadelta'];
+  optimizerMap['adamax'] = optimizerMap['Adamax'];
+  optimizerMap['momentum'] = optimizerMap['Momentum'];
   optimizerMap['rmsprop'] = optimizerMap['RMSProp'];
   optimizerMap['sgd'] = optimizerMap['SGD'];
-
   if (identifier in optimizerMap) {
     return optimizerMap[identifier]();
   }

--- a/src/optimizers.ts
+++ b/src/optimizers.ts
@@ -13,30 +13,30 @@
  */
 
 // tslint:disable:max-line-length
-import { Optimizer, train } from '@tensorflow/tfjs-core';
+import {Optimizer, train} from '@tensorflow/tfjs-core';
 
 import * as K from './backend/tfjs_backend';
 // tslint:enable:max-line-length
 
-import { ValueError } from './errors';
+import {ValueError} from './errors';
 
 // Add (de)serialize()
 
 // Porting note: This diverges from the PyKeras implementation and may need to
 // change based on (de)serialization requirements.
 export function getOptimizer(identifier: string): Optimizer {
-  const optimizerMap: { [optimizerName: string]: () => Optimizer } = {
+  const optimizerMap: {[optimizerName: string]: () => Optimizer} = {
     'Adagrad': () => train.adagrad(.01),
-    'Adam': () => train.adam(.001, .9, .999, K.epsilon()),
     'Adadelta': () => train.adadelta(1.0, 0.95, K.epsilon()),
+    'Adam': () => train.adam(.001, .9, .999, K.epsilon()),
     'Adamax': () => train.adamax(0.002, .9, .999, K.epsilon(), 0.0),
     'Momentum': () => train.momentum(0.01, 0.0, false),
     'RMSProp': () => train.rmsprop(.001, .9, null, K.epsilon()),
     'SGD': () => train.sgd(.01)
   };
   optimizerMap['adagrad'] = optimizerMap['Adagrad'];
-  optimizerMap['adam'] = optimizerMap['Adam'];
   optimizerMap['adadelta'] = optimizerMap['Adadelta'];
+  optimizerMap['adam'] = optimizerMap['Adam'];
   optimizerMap['adamax'] = optimizerMap['Adamax'];
   optimizerMap['momentum'] = optimizerMap['Momentum'];
   optimizerMap['rmsprop'] = optimizerMap['RMSProp'];

--- a/src/optimizers.ts
+++ b/src/optimizers.ts
@@ -30,7 +30,6 @@ export function getOptimizer(identifier: string): Optimizer {
     'Adadelta': () => train.adadelta(1.0, 0.95, K.epsilon()),
     'Adam': () => train.adam(.001, .9, .999, K.epsilon()),
     'Adamax': () => train.adamax(0.002, .9, .999, K.epsilon(), 0.0),
-    'Momentum': () => train.momentum(0.01, 0.0, false),
     'RMSProp': () => train.rmsprop(.001, .9, null, K.epsilon()),
     'SGD': () => train.sgd(.01)
   };
@@ -38,7 +37,6 @@ export function getOptimizer(identifier: string): Optimizer {
   optimizerMap['adadelta'] = optimizerMap['Adadelta'];
   optimizerMap['adam'] = optimizerMap['Adam'];
   optimizerMap['adamax'] = optimizerMap['Adamax'];
-  optimizerMap['momentum'] = optimizerMap['Momentum'];
   optimizerMap['rmsprop'] = optimizerMap['RMSProp'];
   optimizerMap['sgd'] = optimizerMap['SGD'];
 

--- a/src/optimizers_test.ts
+++ b/src/optimizers_test.ts
@@ -86,5 +86,4 @@ describeMathCPU('getOptimizer', () => {
     const optimizer = getOptimizer('momentum');
     expect(optimizer instanceof MomentumOptimizer).toBe(true);
   });
-
 });

--- a/src/optimizers_test.ts
+++ b/src/optimizers_test.ts
@@ -13,10 +13,10 @@
  */
 
 // tslint:disable:max-line-length
-import { AdagradOptimizer, AdamOptimizer, RMSPropOptimizer, SGDOptimizer, AdadeltaOptimizer, AdamaxOptimizer, MomentumOptimizer } from '@tensorflow/tfjs-core';
+import {AdagradOptimizer, AdadeltaOptimizer, AdamOptimizer, AdamaxOptimizer, MomentumOptimizer, RMSPropOptimizer, SGDOptimizer} from '@tensorflow/tfjs-core';
 
-import { getOptimizer } from './optimizers';
-import { describeMathCPU } from './utils/test_utils';
+import {getOptimizer} from './optimizers';
+import {describeMathCPU} from './utils/test_utils';
 
 // tslint:enable:max-line-length
 
@@ -55,12 +55,6 @@ describeMathCPU('getOptimizer', () => {
     const optimizer = getOptimizer('adagrad');
     expect(optimizer instanceof AdagradOptimizer).toBe(true);
   });
-
-  it('throws for non-existent optimizer', () => {
-    expect(() => getOptimizer('not an optimizer'))
-      .toThrowError(/Unknown Optimizer/);
-  });
-
   it(`can instantiate Adadelta`, () => {
     const optimizer = getOptimizer('Adadelta');
     expect(optimizer instanceof AdadeltaOptimizer).toBe(true);
@@ -69,7 +63,6 @@ describeMathCPU('getOptimizer', () => {
     const optimizer = getOptimizer('adadelta');
     expect(optimizer instanceof AdadeltaOptimizer).toBe(true);
   });
-
   it(`can instantiate Adamax`, () => {
     const optimizer = getOptimizer('Adamax');
     expect(optimizer instanceof AdamaxOptimizer).toBe(true);
@@ -86,4 +79,9 @@ describeMathCPU('getOptimizer', () => {
     const optimizer = getOptimizer('momentum');
     expect(optimizer instanceof MomentumOptimizer).toBe(true);
   });
+  it('throws for non-existent optimizer', () => {
+    expect(() => getOptimizer('not an optimizer'))
+      .toThrowError(/Unknown Optimizer/);
+  });
+
 });

--- a/src/optimizers_test.ts
+++ b/src/optimizers_test.ts
@@ -13,10 +13,10 @@
  */
 
 // tslint:disable:max-line-length
-import {AdagradOptimizer, AdamOptimizer, RMSPropOptimizer, SGDOptimizer} from '@tensorflow/tfjs-core';
+import { AdagradOptimizer, AdamOptimizer, RMSPropOptimizer, SGDOptimizer, AdadeltaOptimizer, AdamaxOptimizer, MomentumOptimizer } from '@tensorflow/tfjs-core';
 
-import {getOptimizer} from './optimizers';
-import {describeMathCPU} from './utils/test_utils';
+import { getOptimizer } from './optimizers';
+import { describeMathCPU } from './utils/test_utils';
 
 // tslint:enable:max-line-length
 
@@ -58,6 +58,33 @@ describeMathCPU('getOptimizer', () => {
 
   it('throws for non-existent optimizer', () => {
     expect(() => getOptimizer('not an optimizer'))
-        .toThrowError(/Unknown Optimizer/);
+      .toThrowError(/Unknown Optimizer/);
   });
+
+  it(`can instantiate Adadelta`, () => {
+    const optimizer = getOptimizer('Adadelta');
+    expect(optimizer instanceof AdadeltaOptimizer).toBe(true);
+  });
+  it(`can instantiate adadelta`, () => {
+    const optimizer = getOptimizer('adadelta');
+    expect(optimizer instanceof AdadeltaOptimizer).toBe(true);
+  });
+
+  it(`can instantiate Adamax`, () => {
+    const optimizer = getOptimizer('Adamax');
+    expect(optimizer instanceof AdamaxOptimizer).toBe(true);
+  });
+  it(`can instantiate adamax`, () => {
+    const optimizer = getOptimizer('adamax');
+    expect(optimizer instanceof AdamaxOptimizer).toBe(true);
+  });
+  it(`can instantiate Momentum`, () => {
+    const optimizer = getOptimizer('Momentum');
+    expect(optimizer instanceof MomentumOptimizer).toBe(true);
+  });
+  it(`can instantiate momentum`, () => {
+    const optimizer = getOptimizer('momentum');
+    expect(optimizer instanceof MomentumOptimizer).toBe(true);
+  });
+
 });

--- a/src/optimizers_test.ts
+++ b/src/optimizers_test.ts
@@ -13,7 +13,7 @@
  */
 
 // tslint:disable:max-line-length
-import {AdagradOptimizer, AdadeltaOptimizer, AdamOptimizer, AdamaxOptimizer, MomentumOptimizer, RMSPropOptimizer, SGDOptimizer} from '@tensorflow/tfjs-core';
+import {AdagradOptimizer, AdadeltaOptimizer, AdamOptimizer, AdamaxOptimizer, RMSPropOptimizer, SGDOptimizer} from '@tensorflow/tfjs-core';
 
 import {getOptimizer} from './optimizers';
 import {describeMathCPU} from './utils/test_utils';
@@ -70,14 +70,6 @@ describeMathCPU('getOptimizer', () => {
   it(`can instantiate adamax`, () => {
     const optimizer = getOptimizer('adamax');
     expect(optimizer instanceof AdamaxOptimizer).toBe(true);
-  });
-  it(`can instantiate Momentum`, () => {
-    const optimizer = getOptimizer('Momentum');
-    expect(optimizer instanceof MomentumOptimizer).toBe(true);
-  });
-  it(`can instantiate momentum`, () => {
-    const optimizer = getOptimizer('momentum');
-    expect(optimizer instanceof MomentumOptimizer).toBe(true);
   });
   it('throws for non-existent optimizer', () => {
     expect(() => getOptimizer('not an optimizer'))


### PR DESCRIPTION
#### Description
added Adadelta (adadelta), Adamax (adamax), Momentum(momentum) as named optimizers to Layers API.
defaults taken from https://keras.io/optimizers/
---
##### For repository owners only:
FEATURE

PR for issue #401

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/229)
<!-- Reviewable:end -->
