### PR TITLE
Update to the new test runner, and use core 0.11.7.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "jsnext:main": "dist-es6/index.js",
   "module": "dist-es6/index.js",
   "devDependencies": {
-    "@tensorflow/tfjs-core": "~0.11.6",
+    "@tensorflow/tfjs-core": "~0.11.7",
     "@types/jasmine": "~2.5.53",
     "browserify": "~16.1.0",
     "clang-format": "~1.2.2",
@@ -50,6 +50,6 @@
     "lint": "tslint -p . --type-check -t verbose"
   },
   "peerDependencies": {
-    "@tensorflow/tfjs-core": "~0.11.6"
+    "@tensorflow/tfjs-core": "~0.11.7"
   }
 }

--- a/src/utils/test_utils.ts
+++ b/src/utils/test_utils.ts
@@ -59,7 +59,7 @@ export function expectTensorsValuesInRange(
  * @param tests
  */
 export function describeMathCPUAndGPU(testName: string, tests: () => void) {
-  describeWithFlags(testName, {}, () => {
+  describeWithFlags(testName, test_util.ALL_ENVS, () => {
     beforeEach(() => {
       disposeScalarCache();
     });


### PR DESCRIPTION
Update describeMathCPUAndGPU to use the new test runner. This should have no impact.

See https://github.com/tensorflow/tfjs-core/pull/1090

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/231)
<!-- Reviewable:end -->
