### PR TITLE
No-scheme relative path should be routed to HTTP handler only in browser

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -203,7 +203,7 @@ export async function loadModelInternal(pathOrIOHandler: string|
     const handlers = io.getLoadHandlers(pathOrIOHandler);
     if (handlers.length === 0 && ENV.get('IS_BROWSER')) {
       // For backward compatibility: if no load handler can be found,
-      // assume it is a relative http path. This only applies to the
+      // assume it is a relative http path. This applies only to the
       // browser environment.
       handlers.push(io.browserHTTPRequest(pathOrIOHandler));
     }

--- a/src/models.ts
+++ b/src/models.ts
@@ -11,7 +11,7 @@
 /* Original source keras/models.py */
 
 // tslint:disable:max-line-length
-import {doc, io, Scalar, serialization, Tensor} from '@tensorflow/tfjs-core';
+import {doc, ENV, io, Scalar, serialization, Tensor} from '@tensorflow/tfjs-core';
 
 import * as K from './backend/tfjs_backend';
 import {History} from './callbacks';
@@ -201,14 +201,19 @@ export async function loadModelInternal(pathOrIOHandler: string|
                                         io.IOHandler): Promise<Model> {
   if (typeof pathOrIOHandler === 'string') {
     const handlers = io.getLoadHandlers(pathOrIOHandler);
-    if (handlers.length === 0) {
+    if (handlers.length === 0 && ENV.get('IS_BROWSER')) {
       // For backward compatibility: if no load handler can be found,
-      // assume it is a relative http path.
+      // assume it is a relative http path. This only applies to the
+      // browser environment.
       handlers.push(io.browserHTTPRequest(pathOrIOHandler));
-    } else if (handlers.length > 1) {
+    }
+    if (handlers.length > 1) {
       throw new ValueError(
           `Found more than one (${handlers.length}) load handlers for ` +
           `URL '${pathOrIOHandler}'`);
+    } else if (handlers.length === 0) {
+      throw new ValueError(
+          `Cannot find any load handlers for path string '${pathOrIOHandler}'`);
     }
     pathOrIOHandler = handlers[0];
   }

--- a/src/models.ts
+++ b/src/models.ts
@@ -212,8 +212,14 @@ export async function loadModelInternal(pathOrIOHandler: string|
           `Found more than one (${handlers.length}) load handlers for ` +
           `URL '${pathOrIOHandler}'`);
     } else if (handlers.length === 0) {
-      throw new ValueError(
-          `Cannot find any load handlers for path string '${pathOrIOHandler}'`);
+      let errorMsg =
+          `Cannot find any load handlers for path string '${pathOrIOHandler}'.`;
+      if (ENV.get('IS_NODE')) {
+        errorMsg +=
+            ' For Node.js, a URL scheme (e.g., file://, http://, https://)' +
+            'is required.';
+      }
+      throw new ValueError(errorMsg);
     }
     pathOrIOHandler = handlers[0];
   }
@@ -331,8 +337,8 @@ export class Sequential extends Model {
    * ```
    * @param layer Layer instance.
    *
-   * @exception ValueError In case the `layer` argument does not know its input
-   *   shape.
+   * @exception ValueError In case the `layer` argument does not know its
+   * input shape.
    * @exception ValueError In case the `layer` argument has multiple output
    *   tensors, or is already connected somewhere else (forbidden in
    *   `Sequential` models).


### PR DESCRIPTION
* Currently, a call like tf.loadModel('./model.json') will be routed
  to tf.io.browserHTTPRequest regardless of whether the environment is
  browser or node.js. This will cause issues for node.js.
  This change makes it so that this routing of relative paths to
  browserHTTPRequest (using browser `fetch`) is done only in the
  browser. This implies that paths without a scheme is not supported.
  In other words, in node.js, a path given to tf.loadModel must have a
  scheme, e.g., tf.loadModel('file://./mode.json'),
  tf.loadModel('https://localhost/model.json').

Towards: https://github.com/tensorflow/tfjs/issues/343

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/234)
<!-- Reviewable:end -->
