### PR TITLE
Update benchmarks to use latest published layers

### DIFF
--- a/integration_tests/benchmarks/README.md
+++ b/integration_tests/benchmarks/README.md
@@ -4,6 +4,9 @@ These benchmarks measure the inference and training speed of models of
 varying size and architecture, comparing TensorFlow.js in the browser with
 Python Keras backed by TensorFlow.
 
+NOTE: This benchmark requires that you have Tensor and Keras installed in your
+Python environment since it compares timing in Python to timing in the browser.
+
 To launch the benchmarks, do
 
 ```sh

--- a/integration_tests/benchmarks/build-benchmarks.sh
+++ b/integration_tests/benchmarks/build-benchmarks.sh
@@ -42,14 +42,8 @@ DATA_ROOT="${DEMO_DIR}/dist/data"
 echo Running Python Keras benchmarks...
 python "${DEMO_DIR}/python/benchmarks.py" "${DATA_ROOT}"
 
-echo Building local TensorFlow.js Layers NPM package...
-cd ../..
-yarn build
-yarn link
-
 cd ${DEMO_DIR}
 yarn
-yarn link "@tensorflow/tfjs-layers"
 yarn build
 
 echo

--- a/integration_tests/benchmarks/index.html
+++ b/integration_tests/benchmarks/index.html
@@ -40,10 +40,16 @@ https://opensource.org/licenses/MIT.
     <span id="status">Standing by.</span>
   </div>
   <div>
+    TensorFlow.js Core version:<span class="metadata" id="tfjs-core-version"></span>
+  </div>
+  <div>
+    TensorFlow.js Layers version:<span class="metadata" id="tfjs-layers-version"></span>
+  </div>
+  <div>
     Python Keras version:<span class="metadata" id="pyKerasVersion"></span>
   </div>
   <div>
-    TensorFlow version:<span class="metadata" id="tfVersion"></span>
+    TensorFlow Python version:<span class="metadata" id="tfVersion"></span>
   </div>
   <div>
     TensorFlow uses GPU:<span class="metadata" id="tfUsesGPU"></span>
@@ -53,7 +59,6 @@ https://opensource.org/licenses/MIT.
     * Number of cores
     * Browser name
     * WebGL version
-    * tfjs / tfjs-layers version
   -->
 
   <table id='resultsTable'>

--- a/integration_tests/benchmarks/package.json
+++ b/integration_tests/benchmarks/package.json
@@ -9,8 +9,8 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs-core": "0.0.2",
-    "@tensorflow/tfjs-layers": "0.2.0",
+    "@tensorflow/tfjs-core": "0.11.6",
+    "@tensorflow/tfjs-layers": "0.6.6",
     "vega-embed": "~3.0.0"
   },
   "scripts": {

--- a/integration_tests/benchmarks/ui.js
+++ b/integration_tests/benchmarks/ui.js
@@ -8,6 +8,9 @@
  * =============================================================================
  */
 
+import * as tfc from '@tensorflow/tfjs-core';
+import * as tfl from '@tensorflow/tfjs-layers';
+
 export function status(statusText) {
   document.getElementById('status').textContent = statusText;
 }
@@ -16,6 +19,8 @@ export function setMetadata(metadata) {
   document.getElementById('pyKerasVersion').textContent = metadata.keras_version;
   document.getElementById('tfVersion').textContent = metadata.tensorflow_version;
   document.getElementById('tfUsesGPU').textContent = metadata.tensorflow_uses_gpu;
+  document.getElementById('tfjs-core-version').textContent = tfc.version_core;
+  document.getElementById('tfjs-layers-version').textContent = tfl.version_layers;
 }
 
 export function setRunBenchmarksFunction(runAllBenchmarks) {

--- a/integration_tests/benchmarks/yarn.lock
+++ b/integration_tests/benchmarks/yarn.lock
@@ -2,18 +2,15 @@
 # yarn lockfile v1
 
 
-"@tensorflow/tfjs-core@0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.0.2.tgz#3275ec114db4cc89ca729ffad67a25849236aa61"
+"@tensorflow/tfjs-core@0.11.6":
+  version "0.11.6"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.11.6.tgz#3ffeb48fc499de3dabd36d0939f241d39a84f4af"
   dependencies:
     seedrandom "~2.4.3"
-    utf8 "~2.1.2"
 
-"@tensorflow/tfjs-layers@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-0.2.0.tgz#87114fe7e680b5cb87ca05f0119a21d2578f6b7f"
-  dependencies:
-    underscore "~1.8.3"
+"@tensorflow/tfjs-layers@0.6.6":
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-0.6.6.tgz#6869c86ed01905271ebe707d6324ba04119b73ab"
 
 "@types/json-stable-stringify@^1.0.32":
   version "1.0.32"
@@ -4646,10 +4643,6 @@ uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
 
-underscore@~1.8.3:
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
-
 unicode-trie@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/unicode-trie/-/unicode-trie-0.3.1.tgz#d671dddd89101a08bac37b6a5161010602052085"
@@ -4725,10 +4718,6 @@ use@^3.1.0:
 utf8-byte-length@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz#f45f150c4c66eee968186505ab93fcbb8ad6bf61"
-
-utf8@~2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/utf8/-/utf8-2.1.2.tgz#1fa0d9270e9be850d9b05027f63519bf46457d96"
 
 util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Fixes https://github.com/tensorflow/tfjs/issues/416

Benchmarks in layer were out of date and not working.

Part of the solution is to not `yarn link` to the current master branch because it creates duplicate backend and hard to keep in sync. Instead we link to specific version on npm. For those interested in making changes to layers and re-running benchmarks can use `yalc/yarn` locally on their machine.

Also show tf.js core and layers version numbers on the benchmarks page since there is confusion as to which version the benchmarks are using. See version field in https://github.com/tensorflow/tfjs/issues/416 which points to TF Python version, not the tfjs version.

BUG
