### PR TITLE
Two small improvements to benchmarks scripts

### DIFF
--- a/integration_tests/benchmarks/build-benchmarks.sh
+++ b/integration_tests/benchmarks/build-benchmarks.sh
@@ -19,10 +19,14 @@ set -e
 DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 DEMO_PORT=8000
+SKIP_PY_BENCHMAKRS=0
 while true; do
   if [[ "$1" == "--port" ]]; then
     DEMO_PORT=$2
     shift 2
+  elif [[ "$1" == "--skip_py_benchmarks" ]]; then
+    SKIP_PY_BENCHMAKRS=1
+    shift
   elif [[ -z "$1" ]]; then
     break
   else
@@ -39,8 +43,10 @@ DATA_ROOT="${DEMO_DIR}/dist/data"
 
 # Make sure you install the tensorflowjs pip package first.
 
-echo Running Python Keras benchmarks...
-python "${DEMO_DIR}/python/benchmarks.py" "${DATA_ROOT}"
+if [[ "${SKIP_PY_BENCHMAKRS}" == 0 ]]; then
+  echo Running Python Keras benchmarks...
+  python "${DEMO_DIR}/python/benchmarks.py" "${DATA_ROOT}"
+fi
 
 cd ${DEMO_DIR}
 yarn
@@ -53,4 +59,4 @@ echo "  http://localhost:${DEMO_PORT}/dist"
 echo "-----------------------------------------------------------"
 echo
 
-node_modules/http-server/bin/http-server -p "${DEMO_PORT}"
+node_modules/http-server/bin/http-server -p "${DEMO_PORT}" dist/

--- a/integration_tests/benchmarks/yarn.lock
+++ b/integration_tests/benchmarks/yarn.lock
@@ -980,12 +980,12 @@ caniuse-api@^1.5.2:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30000852"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000852.tgz#c37a706048f8d81f87946a7c13f39ed636876659"
+  version "1.0.30000855"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000855.tgz#34f88bf1577aa505395e48e412dc21f7dd41ef3b"
 
 caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000844:
-  version "1.0.30000852"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000852.tgz#8b7510cec030cac7842e52beca2bf292af65f935"
+  version "1.0.30000855"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000855.tgz#d5a26a9093b932d6266bf4ed9294b41b84945d14"
 
 canvas-prebuilt@^1.6:
   version "1.6.0"
@@ -4999,8 +4999,8 @@ vega-runtime@2:
     vega-util "1"
 
 vega-scale@2, vega-scale@^2.1:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/vega-scale/-/vega-scale-2.2.0.tgz#676c0aa2e744ee378bc5dc3fc1251d249f468d40"
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/vega-scale/-/vega-scale-2.3.0.tgz#0f47ec4c12e3d16035ec6cce8092ce517990bbbc"
   dependencies:
     d3-array "^1.2.1"
     d3-interpolate "^1.2.0"


### PR DESCRIPTION
1. Add the option to skip running the Python Keras part:
   `--skip_py_benchmarks`
2. http-server should serve from the dist/ folder, not the dist/..
   folder. The latter has uncompiled javascript files that the
   cannot be run by the browser.

Fixes: https://github.com/tensorflow/tfjs/issues/253

DEV Small improvements to the build-benchmarks script.



<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/237)
<!-- Reviewable:end -->
