### PR TITLE
Make sure dilationRate is a number for 1D convolutions

### DIFF
--- a/src/layers/convolutional.ts
+++ b/src/layers/convolutional.ts
@@ -354,13 +354,20 @@ export abstract class BaseConv extends Layer {
     this.biasRegularizer = getRegularizer(config.biasRegularizer);
     this.activityRegularizer = getRegularizer(config.activityRegularizer);
     this.dilationRate = config.dilationRate == null ? 1 : config.dilationRate;
-    if (this.rank === 1 &&
-        (Array.isArray(this.dilationRate) &&
-         (this.dilationRate as number[]).length !== 1)) {
-      throw new ValueError(
-          `dilationRate must be a number or an array of a single number ` +
-          `for 1D convolution, but received ` +
-          `${JSON.stringify(this.dilationRate)}`);
+    if (this.rank === 1 && Array.isArray(this.dilationRate)) {
+      if ((this.dilationRate as number[]).length !== 1) {
+        throw new ValueError(
+            `dilationRate must be a number or an array of a single number ` +
+            `for 1D convolution, but received ` +
+            `${JSON.stringify(this.dilationRate)}`);
+      } else {
+        // The tensorflow native backend (via tfjs-node) does not support a
+        // dilationRate as an array of length 1 (which is what is output from
+        // a model converted from Keras). And, in fact, it appears the tfjs-core
+        // makes a number of assumptions about dilationRate either being a
+        // number or an array of length 2. So convert it to a number
+        this.dilationRate = (this.dilationRate as number[])[0];
+      }
     }
     if (this.rank === 2) {
       if (typeof this.dilationRate === 'number') {


### PR DESCRIPTION
BUG

#### Description
When a model is exported from Keras, 1D convolutions contain a dilation rate as an array of length 1. Code in a number of places, however, assumes that the dilationRate is either a number (for 1d convolutions) or an array of length 2. While some places support an array of length 1, others do not. For example, the dilationWidth (which is normally a number) becomes an array of length 1. This causes tfjs-node to fail as it passes the dilationWidth through to native code (as the native code expects dilationWidth to be a number).

The fix here is to convert a dilationRate of length 1 to a number as the layer is instantiated.

---
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md
