### PR TITLE
Remove qr() from tfjs_backend.ts

### DIFF
--- a/src/backend/tfjs_backend.ts
+++ b/src/backend/tfjs_backend.ts
@@ -14,10 +14,10 @@
 
 // tslint:disable:max-line-length
 import * as tfc from '@tensorflow/tfjs-core';
-import {dispose, onesLike as coreOnesLike, Scalar, scalar, Tensor, Tensor1D, tensor1d, Tensor2D, tensor2d, Tensor3D, Tensor4D, tidy, util, where, zerosLike as coreZerosLike} from '@tensorflow/tfjs-core';
+import {onesLike as coreOnesLike, Scalar, scalar, Tensor, Tensor1D, tensor1d, Tensor2D, Tensor3D, Tensor4D, tidy, util, where, zerosLike as coreZerosLike} from '@tensorflow/tfjs-core';
 
-import {checkDataFormat, DataFormat} from '../common';
 import {disposeScalarCache, getScalar} from '../backend/state';
+import {checkDataFormat, DataFormat} from '../common';
 import {NotImplementedError, ValueError} from '../errors';
 import {HasShape, Shape} from '../types';
 import * as math_utils from '../utils/math_utils';
@@ -421,100 +421,6 @@ export function sign(x: Tensor): Tensor {
             tfc.greater(x, coreZerosLike(x)), onesLikeX,
             tfc.mul(getScalar(-1), onesLikeX)));
   });
-}
-
-/**
- * Compute QR decomposition of m-by-n matrix using Householder transformation.
- *
- * Requires `m >= n`.
- *
- * Implementation based on
- *   [http://www.cs.cornell.edu/~bindel/class/cs6210-f09/lec18.pdf]
- * (http://www.cs.cornell.edu/~bindel/class/cs6210-f09/lec18.pdf)
- *
- * @param x The 2D `Tensor` (matrix) to be QR-decomposed. Must have
- *   `x.shape[0] >= x.shape[1]`.
- * @return An `Array` of two `Tensor`s: `[Q, R]`, where `Q` is a unitary
- *   matrix of size `[x.shape[0], x.shape[0]]`. `R` has the same shape as
- *   `x`.
- * @throws ValueError if `x.shape[0] < x.shape[1]`, or if `x`'s rank is not 2.
- */
-export function qr(x: Tensor2D): [Tensor, Tensor] {
-  const [qOuter, rOuter]: [Tensor, Tensor] = tidy((): [Tensor, Tensor] => {
-    // TODO(cais): Extend support to >2D as in `tf.qr` and move this
-    // function to the core.
-    if (x.shape.length !== 2) {
-      throw new ValueError(
-          `qr() requires a 2D Tensor, but got a ${x.shape.length}D Tensor.`);
-    }
-    if (x.shape[0] < x.shape[1]) {
-      throw new ValueError(
-          `qr() requires x.shape[0] >= x.shape[1], but got shape: [${
-              x.shape}]`);
-    }
-
-    const m = x.shape[0];
-    const n = x.shape[1];
-
-    let q = tfc.eye(m) as Tensor2D;  // Orthogonal transform so far.
-    let r = x.clone();               // Transformed matrix so far.
-
-    const one2D = tensor2d([[1]], [1, 1]);
-    let w: Tensor2D = one2D.clone();
-
-    for (let j = 0; j < n; ++j) {
-      // This tidy within the for-loop ensures we clean up temporary
-      // tensors as soon as they are no longer needed.
-      const rTemp = r;
-      const wTemp = w;
-      const qTemp = q;
-      [w, r, q] = tidy((): [Tensor2D, Tensor2D, Tensor2D] => {
-        // Find H = I - tau * w * w', to put zeros below R(j, j).
-        const rjEnd1 = r.slice([j, j], [m - j, 1]);
-        const normX = tfc.norm(rjEnd1);
-        const rjj = r.slice([j, j], [1, 1]);
-        const s = tfc.neg(sign(rjj)) as Tensor2D;
-        const u1 = rjj.sub(tfc.mul(s, normX)) as Tensor2D;
-        const wPre = tfc.div(rjEnd1, u1);
-        if (wPre.shape[0] === 1) {
-          w = one2D.clone();
-        } else {
-          w = one2D.concat(
-                  wPre.slice([1, 0], [wPre.shape[0] - 1, wPre.shape[1]]), 0) as
-              Tensor2D;
-        }
-        const tau = tfc.neg(tfc.div(tfc.matMul(s, u1), normX)) as Tensor2D;
-
-        // -- R := HR, Q := QH.
-        const rjEndAll = r.slice([j, 0], [m - j, n]);
-        const tauTimesW = tau.mul(w) as Tensor2D;
-        if (j === 0) {
-          r = rjEndAll.sub(tauTimesW.matMul(w.transpose().matMul(rjEndAll)));
-        } else {
-          r = r.slice([0, 0], [j, n])
-                  .concat(
-                      rjEndAll.sub(
-                          tauTimesW.matMul(w.transpose().matMul(rjEndAll))),
-                      0) as Tensor2D;
-        }
-        const qAllJEnd = q.slice([0, j], [m, q.shape[1] - j]);
-        if (j === 0) {
-          q = qAllJEnd.sub(qAllJEnd.matMul(w).matMul(tauTimesW.transpose()));
-        } else {
-          q = q.slice([0, 0], [m, j])
-                  .concat(
-                      qAllJEnd.sub(
-                          qAllJEnd.matMul(w).matMul(tauTimesW.transpose())),
-                      1) as Tensor2D;
-        }
-        return [w, r, q];
-      });
-      dispose([rTemp, wTemp, qTemp]);
-    }
-
-    return [q, r];
-  });
-  return [qOuter, rOuter];
 }
 
 /**

--- a/src/backend/tfjs_backend_test.ts
+++ b/src/backend/tfjs_backend_test.ts
@@ -14,7 +14,7 @@
 
 // tslint:disable:max-line-length
 import * as tfc from '@tensorflow/tfjs-core';
-import {DataType, memory, scalar, tensor1d, tensor2d, tensor3d, tensor4d, zeros} from '@tensorflow/tfjs-core';
+import {DataType, scalar, tensor1d, tensor2d, tensor3d, tensor4d, zeros} from '@tensorflow/tfjs-core';
 
 import {SymbolicTensor} from '../engine/topology';
 import {range} from '../utils/math_utils';
@@ -583,73 +583,6 @@ describeMathCPUAndGPU('sign', () => {
   it('2D', () => {
     const x = tensor2d([[1, 2, -1], [0, 3, -4]], [2, 3]);
     expectTensorsClose(K.sign(x), tensor2d([[1, 1, -1], [0, 1, -1]], [2, 3]));
-  });
-});
-
-
-describeMathCPUAndGPU('qr', () => {
-  it('1x1', () => {
-    const x = tensor2d([[10]], [1, 1]);
-    const [q, r] = K.qr(x);
-    expectTensorsClose(q, tensor2d([[-1]], [1, 1]));
-    expectTensorsClose(r, tensor2d([[-10]], [1, 1]));
-  });
-
-  it('2x2', () => {
-    const x = tensor2d([[1, 3], [-2, -4]], [2, 2]);
-    const [q, r] = K.qr(x);
-    expectTensorsClose(
-        q, tensor2d([[-0.4472, -0.8944], [0.8944, -0.4472]], [2, 2]));
-    expectTensorsClose(r, tensor2d([[-2.2361, -4.9193], [0, -0.8944]], [2, 2]));
-  });
-
-  it('3x3', () => {
-    const x = tensor2d([[1, 3, 2], [-2, 0, 7], [8, -9, 4]], [3, 3]);
-    const [q, r] = K.qr(x);
-    expectTensorsClose(
-        q,
-        tensor2d(
-            [
-              [-0.1204, 0.8729, 0.4729], [0.2408, -0.4364, 0.8669],
-              [-0.9631, -0.2182, 0.1576]
-            ],
-            [3, 3]));
-    expectTensorsClose(
-        r,
-        tensor2d(
-            [[-8.3066, 8.3066, -2.4077], [0, 4.5826, -2.1822], [0, 0, 7.6447]],
-            [3, 3]));
-  });
-
-  it('3x2', () => {
-    const x = tensor2d([[1, 2], [3, -3], [-2, 1]], [3, 2]);
-    const [q, r] = K.qr(x);
-    expectTensorsClose(
-        q,
-        tensor2d(
-            [
-              [-0.2673, 0.9221, 0.2798], [-0.8018, -0.3738, 0.4663],
-              [0.5345, -0.0997, 0.8393]
-            ],
-            [3, 3]));
-    expectTensorsClose(
-        r, tensor2d([[-3.7417, 2.4054], [0, 2.8661], [0, 0]], [3, 2]));
-  });
-
-  it('does not leak memory', () => {
-    const x = tensor2d([[1, 3], [-2, -4]], [2, 2]);
-    // The first call to qr creates and keeps internal singleton tensors.
-    // Subsequent calls should always create exactly two tensors.
-    K.qr(x);
-    // Count before real call.
-    const numTensors = memory().numTensors;
-    K.qr(x);
-    expect(memory().numTensors).toEqual(numTensors + 2);
-  });
-
-  it('Incorrect shape leads to error', () => {
-    const x = tensor2d([[1, 2, 3], [-3, -2, 1]], [2, 3]);
-    expect(() => K.qr(x)).toThrowError(/requires.*shape/);
   });
 });
 


### PR DESCRIPTION
The function is moved to `tf.linalg.qr()` in tfjs-core.

See: https://github.com/tensorflow/tfjs-core/pull/1128

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/253)
<!-- Reviewable:end -->
