### PR TITLE
Add getConfig() to DepthwiseConv2D layer

### DIFF
--- a/integration_tests/tfjs2keras/tfjs2keras_test.py
+++ b/integration_tests/tfjs2keras/tfjs2keras_test.py
@@ -67,6 +67,9 @@ class Tfjs2KerasExportTest(tf.test.TestCase):
   def testCNN(self):
     self._loadAndTestModel('cnn.json')
 
+  def testDepthwiseCNN(self):
+    self._loadAndTestModel('depthwise_cnn.json')
+
   def testSimpleRNN(self):
     self._loadAndTestModel('simple_rnn.json')
 

--- a/integration_tests/tfjs2keras/tfjs_save.ts
+++ b/integration_tests/tfjs2keras/tfjs_save.ts
@@ -59,7 +59,7 @@ function exportCNNModel(exportPath: string): void {
 function exportDepthwiseCNNModel(exportPath: string): void {
   const model = tfl.sequential();
 
-  // Cover separable and non-separable convoluational layers.
+  // Cover depthwise 2D convoluational layer.
   model.add(tfl.layers.depthwiseConv2d({
     depthMultiplier: 2,
     kernelSize: [3, 3],

--- a/integration_tests/tfjs2keras/tfjs_save.ts
+++ b/integration_tests/tfjs2keras/tfjs_save.ts
@@ -56,6 +56,26 @@ function exportCNNModel(exportPath: string): void {
   fs.writeFileSync(exportPath, model.toJSON());
 }
 
+function exportDepthwiseCNNModel(exportPath: string): void {
+  const model = tfl.sequential();
+
+  // Cover separable and non-separable convoluational layers.
+  model.add(tfl.layers.depthwiseConv2d({
+    depthMultiplier: 2,
+    kernelSize: [3, 3],
+    strides: [2, 2],
+    inputShape: [40, 40, 3],
+    padding: 'valid',
+  }));
+  model.add(tfl.layers.batchNormalization({}));
+  model.add(tfl.layers.activation({activation: 'relu'}));
+  model.add(tfl.layers.dropout({rate: 0.5}));
+  model.add(tfl.layers.maxPooling2d({poolSize: 2}));
+  model.add(tfl.layers.flatten({}));
+  model.add(tfl.layers.dense({units: 100, activation: 'softmax'}));
+  fs.writeFileSync(exportPath, model.toJSON());
+}
+
 // SimpleRNN with embedding.
 function exportSimpleRNNModel(exportPath: string): void {
   const model = tfl.sequential();
@@ -147,6 +167,7 @@ const testDataDir = process.argv[2];
 
 exportMLPModel(join(testDataDir, 'mlp.json'));
 exportCNNModel(join(testDataDir, 'cnn.json'));
+exportDepthwiseCNNModel(join(testDataDir, 'depthwise_cnn.json'));
 exportSimpleRNNModel(join(testDataDir, 'simple_rnn.json'));
 exportGRUModel(join(testDataDir, 'gru.json'));
 exportBidirectionalLSTMModel(join(testDataDir, 'bidirectional_lstm.json'));

--- a/src/layers/convolutional.ts
+++ b/src/layers/convolutional.ts
@@ -387,6 +387,25 @@ export abstract class BaseConv extends Layer {
           `BaseConv expects config.kernelSize to be number or number[] with ` +
           `length 1 or 2, but received ${JSON.stringify(config.kernelSize)}.`);
   }
+
+  getConfig(): serialization.ConfigDict {
+    const config: serialization.ConfigDict = {
+      kernelSize: this.kernelSize,
+      strides: this.strides,
+      padding: this.padding,
+      dataFormat: this.dataFormat,
+      dilationRate: this.dilationRate,
+      activation: serializeActivation(this.activation),
+      useBias: this.useBias,
+      biasInitializer: serializeInitializer(this.biasInitializer),
+      biasRegularizer: serializeRegularizer(this.biasRegularizer),
+      activityRegularizer: serializeRegularizer(this.activityRegularizer),
+      biasConstraint: serializeConstraint(this.biasConstraint)
+    };
+    const baseConfig = super.getConfig();
+    Object.assign(config, baseConfig);
+    return config;
+  }
 }
 
 /**
@@ -495,23 +514,11 @@ export abstract class Conv extends BaseConv {
   }
 
   getConfig(): serialization.ConfigDict {
-    const config: serialization.ConfigDict = {
-      rank: this.rank,
+    const config = {
       filters: this.filters,
-      kernelSize: this.kernelSize,
-      strides: this.strides,
-      padding: this.padding,
-      dataFormat: this.dataFormat,
-      dilationRate: this.dilationRate,
-      activation: serializeActivation(this.activation),
-      useBias: this.useBias,
       kernelInitializer: serializeInitializer(this.kernelInitializer),
-      biasInitializer: serializeInitializer(this.biasInitializer),
       kernelRegularizer: serializeRegularizer(this.kernelRegularizer),
-      biasRegularizer: serializeRegularizer(this.biasRegularizer),
-      activityRegularizer: serializeRegularizer(this.activityRegularizer),
-      kernelConstraint: serializeConstraint(this.kernelConstraint),
-      biasConstraint: serializeConstraint(this.biasConstraint)
+      kernelConstraint: serializeConstraint(this.kernelConstraint)
     };
     const baseConfig = super.getConfig();
     Object.assign(config, baseConfig);

--- a/src/layers/convolutional_depthwise.ts
+++ b/src/layers/convolutional_depthwise.ts
@@ -20,10 +20,10 @@ import {imageDataFormat} from '../backend/common';
 // tslint:disable:max-line-length
 import * as K from '../backend/tfjs_backend';
 import {checkDataFormat, DataFormat} from '../common';
-import {Constraint, ConstraintIdentifier, getConstraint} from '../constraints';
+import {Constraint, ConstraintIdentifier, getConstraint, serializeConstraint} from '../constraints';
 import {ValueError} from '../errors';
-import {getInitializer, Initializer, InitializerIdentifier} from '../initializers';
-import {getRegularizer, Regularizer, RegularizerIdentifier} from '../regularizers';
+import {getInitializer, Initializer, InitializerIdentifier, serializeInitializer} from '../initializers';
+import {getRegularizer, Regularizer, RegularizerIdentifier, serializeRegularizer} from '../regularizers';
 import {Kwargs, Shape} from '../types';
 import {convOutputLength} from '../utils/conv_utils';
 import {getExactlyOneShape, getExactlyOneTensor} from '../utils/types_utils';
@@ -204,6 +204,22 @@ export class DepthwiseConv2D extends BaseConv {
       // In this case, assume 'channelsLast'.
       return [inputShape[0], outRows, outCols, outFilters];
     }
+  }
+
+  getConfig(): serialization.ConfigDict {
+    const config = super.getConfig();
+    delete config['filters'];
+    delete config['kernelInitializer'];
+    delete config['kernelRegularizer'];
+    delete config['kernelConstraint'];
+    config['depthMultiplier'] = this.depthMultiplier;
+    config['depthwiseInitializer'] =
+        serializeInitializer(this.depthwiseInitializer);
+    config['depthwiseRegularizer'] =
+        serializeRegularizer(this.depthwiseRegularizer);
+    config['depthwiseConstraint'] =
+        serializeConstraint(this.depthwiseRegularizer);
+    return config;
   }
 }
 serialization.SerializationMap.register(DepthwiseConv2D);

--- a/src/layers/convolutional_depthwise.ts
+++ b/src/layers/convolutional_depthwise.ts
@@ -208,7 +208,6 @@ export class DepthwiseConv2D extends BaseConv {
 
   getConfig(): serialization.ConfigDict {
     const config = super.getConfig();
-    delete config['rank'];
     config['depthMultiplier'] = this.depthMultiplier;
     config['depthwiseInitializer'] =
         serializeInitializer(this.depthwiseInitializer);

--- a/src/layers/convolutional_depthwise.ts
+++ b/src/layers/convolutional_depthwise.ts
@@ -208,10 +208,7 @@ export class DepthwiseConv2D extends BaseConv {
 
   getConfig(): serialization.ConfigDict {
     const config = super.getConfig();
-    delete config['filters'];
-    delete config['kernelInitializer'];
-    delete config['kernelRegularizer'];
-    delete config['kernelConstraint'];
+    delete config['rank'];
     config['depthMultiplier'] = this.depthMultiplier;
     config['depthwiseInitializer'] =
         serializeInitializer(this.depthwiseInitializer);

--- a/src/layers/convolutional_depthwise_test.ts
+++ b/src/layers/convolutional_depthwise_test.ts
@@ -157,7 +157,6 @@ describeMathCPU('DepthwiseConv2D-Symbolic', () => {
     const tsConfig = convertPythonicToTs(pythonicConfig) as any;
     const layerPrime = tfl.layers.depthwiseConv2d(tsConfig);
     const configPrime = layerPrime.getConfig();
-    console.log(JSON.stringify(configPrime));  // DEBUG
     expect(configPrime.kernelSize).toEqual([3, 3]);
     expect(configPrime.depthMultiplier).toEqual(4);
     expect(configPrime.activation).toEqual('relu');

--- a/src/layers/convolutional_depthwise_test.ts
+++ b/src/layers/convolutional_depthwise_test.ts
@@ -19,6 +19,7 @@ import {Tensor, tensor4d, Tensor4D} from '@tensorflow/tfjs-core';
 import {DataFormat, PaddingMode} from '../common';
 import * as tfl from '../index';
 import {InitializerIdentifier} from '../initializers';
+import {convertPythonicToTs, convertTsToPythonic} from '../utils/serialization_utils';
 import {describeMathCPU, describeMathCPUAndGPU, expectTensorsClose} from '../utils/test_utils';
 
 import {depthwiseConv2d} from './convolutional_depthwise';
@@ -146,6 +147,20 @@ describeMathCPU('DepthwiseConv2D-Symbolic', () => {
     expect(() => depthwiseConvLayer.apply(symbolicInput))
         .toThrowError(
             /Inputs to DepthwiseConv2D should have rank 4\. Received .*/);
+  });
+
+  it('Serialization round trip', () => {
+    const layer = tfl.layers.depthwiseConv2d(
+        {kernelSize: 3, depthMultiplier: 4, activation: 'relu'});
+    const pythonicConfig = convertTsToPythonic(layer.getConfig());
+    // tslint:disable-next-line:no-any
+    const tsConfig = convertPythonicToTs(pythonicConfig) as any;
+    const layerPrime = tfl.layers.depthwiseConv2d(tsConfig);
+    const configPrime = layerPrime.getConfig();
+    console.log(JSON.stringify(configPrime));  // DEBUG
+    expect(configPrime.kernelSize).toEqual([3, 3]);
+    expect(configPrime.depthMultiplier).toEqual(4);
+    expect(configPrime.activation).toEqual('relu');
   });
 });
 


### PR DESCRIPTION
It was previously missing.

To this end, the `getConfig()` of the `BaseConv` and `Conv` classes are reorganized.

Fixes: https://github.com/tensorflow/tfjs/issues/505

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/266)
<!-- Reviewable:end -->
