### PR TITLE
Add unit test for backwards Bidirectional LSTM

### DIFF
--- a/src/layers/wrappers_test.ts
+++ b/src/layers/wrappers_test.ts
@@ -346,6 +346,8 @@ describeMathCPUAndGPU('Bidirectional Layer: Tensor', () => {
     model.fit(x, y)
         .then(history => {
           expect(history.history.loss[0]).toBeCloseTo(0.0901649);
+          expectTensorsClose(
+              model.predict(x) as Tensor, tensor2d([[0.6927189, 0.66077083]]));
           done();
         })
         .catch(err => {
@@ -399,6 +401,8 @@ describeMathCPUAndGPU('Bidirectional Layer: Tensor', () => {
     model.fit(x, y)
         .then(history => {
           expect(history.history.loss[0]).toBeCloseTo(0.0766952);
+          expectTensorsClose(
+              model.predict(x) as Tensor, tensor2d([[0.6767467]]));
           done();
         })
         .catch(err => {

--- a/src/layers/wrappers_test.ts
+++ b/src/layers/wrappers_test.ts
@@ -331,8 +331,7 @@ describeMathCPUAndGPU('Bidirectional Layer: Tensor', () => {
       kernelInitializer: 'ones',
       recurrentInitializer: 'ones',
       biasInitializer: 'ones',
-      goBackwards: true,
-      inputShape: [2, 2]
+      goBackwards: true
     }) as RNN;
     const bidi = tfl.layers.bidirectional(
         {layer: lstm, inputShape: [2, 2], mergeMode: 'concat'});
@@ -381,8 +380,7 @@ describeMathCPUAndGPU('Bidirectional Layer: Tensor', () => {
       kernelInitializer: 'ones',
       recurrentInitializer: 'ones',
       biasInitializer: 'ones',
-      goBackwards: true,
-      inputShape: [2, 2]
+      goBackwards: true
     }) as RNN;
     const bidi = tfl.layers.bidirectional(
         {layer: lstm, inputShape: [2, 2], mergeMode: 'ave'});

--- a/src/layers/wrappers_test.ts
+++ b/src/layers/wrappers_test.ts
@@ -326,7 +326,7 @@ describeMathCPUAndGPU('Bidirectional Layer: Tensor', () => {
   // history = model.fit(x, y)
   // print(history.history)
   // ```
-  it('Backwards LSTM: predict and fit', done => {
+  it('Backwards LSTM: predict and fit: concat', done => {
     const lstm = tfl.layers.lstm({
       units: 1,
       kernelInitializer: 'ones',
@@ -347,6 +347,59 @@ describeMathCPUAndGPU('Bidirectional Layer: Tensor', () => {
     model.fit(x, y)
         .then(history => {
           expect(history.history.loss[0]).toBeCloseTo(0.0901649);
+          done();
+        })
+        .catch(err => {
+          done.fail(err.stack);
+        });
+  });
+
+  // The golden values in the test below can be obtained with the following
+  // Python Keras code.
+  //
+  // ```python
+  // import keras
+  // import numpy
+  //
+  // rnn = keras.layers.LSTM(
+  //     1,
+  //     kernel_initializer='ones',
+  //     recurrent_initializer='ones',
+  //     bias_initializer='ones',
+  //     go_backwards=True)
+  // bidi = keras.layers.Bidirectional(
+  //     rnn, merge_mode='ave', input_shape=[2, 2])
+  // model = keras.Sequential([bidi])
+  // model.compile(loss='mean_squared_error', optimizer='sgd')
+  //
+  // x = np.array([[[0.1, 0.2],
+  //               [-0.1, 0.1]]])
+  // y = np.array([[0.4]])
+  // print(model.predict(x))
+  //
+  // history = model.fit(x, y)
+  // print(history.history)
+  // ```
+  it('Backwards LSTM: predict and fit: ave', done => {
+    const lstm = tfl.layers.lstm({
+      units: 1,
+      kernelInitializer: 'ones',
+      recurrentInitializer: 'ones',
+      biasInitializer: 'ones',
+      goBackwards: true,
+      inputShape: [2, 2]
+    }) as RNN;
+    const bidi = tfl.layers.bidirectional(
+        {layer: lstm, inputShape: [2, 2], mergeMode: 'ave'});
+    const model = tfl.sequential({layers: [bidi]});
+    model.compile({loss: 'meanSquaredError', optimizer: 'sgd'});
+
+    const x = tensor3d([[[0.1, 0.2], [-0.1, 0.1]]]);
+    const y = tensor2d([[0.4]]);
+    expectTensorsClose(model.predict(x) as Tensor, tensor2d([[0.676939]]));
+    model.fit(x, y)
+        .then(history => {
+          expect(history.history.loss[0]).toBeCloseTo(0.0766952);
           done();
         })
         .catch(err => {

--- a/src/layers/wrappers_test.ts
+++ b/src/layers/wrappers_test.ts
@@ -247,7 +247,7 @@ describeMathCPUAndGPU('Bidirectional Layer: Tensor', () => {
         kernelInitializer: 'ones',
         recurrentInitializer: 'ones',
         useBias: false,
-        returnState,
+        returnState
       }),
       mergeMode,
     });
@@ -298,7 +298,6 @@ describeMathCPUAndGPU('Bidirectional Layer: Tensor', () => {
     expectTensorsClose(
         y[2], tensor2d([[-0.9842659, -0.9842659, -0.9842659]], [1, 3]));
   });
-
 
   // The golden values in the test below can be obtained with the following
   // Python Keras code.

--- a/src/layers/wrappers_test.ts
+++ b/src/layers/wrappers_test.ts
@@ -325,7 +325,7 @@ describeMathCPUAndGPU('Bidirectional Layer: Tensor', () => {
   // history = model.fit(x, y)
   // print(history.history)
   // ```
-  it('Backwards LSTM: predict and fit: concat', done => {
+  it('Backwards LSTM: predict and fit: concat', async () => {
     const lstm = tfl.layers.lstm({
       units: 1,
       kernelInitializer: 'ones',
@@ -343,16 +343,10 @@ describeMathCPUAndGPU('Bidirectional Layer: Tensor', () => {
     const y = tensor2d([[0.3, 0.5]]);
     expectTensorsClose(
         model.predict(x) as Tensor, tensor2d([[0.69299805, 0.66088]]));
-    model.fit(x, y)
-        .then(history => {
-          expect(history.history.loss[0]).toBeCloseTo(0.0901649);
-          expectTensorsClose(
-              model.predict(x) as Tensor, tensor2d([[0.6927189, 0.66077083]]));
-          done();
-        })
-        .catch(err => {
-          done.fail(err.stack);
-        });
+    const history = await model.fit(x, y);
+    expect(history.history.loss[0]).toBeCloseTo(0.0901649);
+    expectTensorsClose(
+        model.predict(x) as Tensor, tensor2d([[0.6927189, 0.66077083]]));
   });
 
   // The golden values in the test below can be obtained with the following


### PR DESCRIPTION
Background: b/74429960

Before Bidirectional layers with LSTMs whose goBackwards property was
set to `True` did not work properly. That was four months ago. Since
then, the issues seems to have resolved itself.
This PR adds a unit test for that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/268)
<!-- Reviewable:end -->
