### PR TITLE
Add option yieldEvery to ModelFitConfig; add heuristics for auto yielding

### DIFF
--- a/src/base_callbacks.ts
+++ b/src/base_callbacks.ts
@@ -11,7 +11,7 @@
 /* Original source: keras/callbacks.py */
 
 // tslint:disable:max-line-length
-import {add, div, keep, mul, nextFrame, Scalar, Tensor, tidy} from '@tensorflow/tfjs-core';
+import {add, div, keep, mul, nextFrame, Scalar, Tensor, tidy, util} from '@tensorflow/tfjs-core';
 
 import {getScalar} from './backend/state';
 import {Container} from './engine/container';
@@ -243,14 +243,14 @@ export class ModelTrainingYielder {
     this.batchCount = 0;
     this.batchDurationsMillis = [];
     this.autoYieldEveryBatches = null;
-    this.batchStartMillis = Date.now();
+    this.batchStartMillis = util.now();
   }
 
   /**
    * Find the first Scalar tensor in `logs` and await data() on it.
    *
    * This causes a data download (e.g., from GPU) and therefore clears the
-   * queued operations.
+   * queued operations (e.g., on the GPU).
    */
   private async resolveOneTensorInLogs(logs: UnresolvedLogs) {
     for (const key in logs) {
@@ -287,7 +287,7 @@ export class ModelTrainingYielder {
         // autoYieldEveryBatches has not been determined yet. We are still in
         // the measurement phase.
         await this.resolveOneTensorInLogs(logs);
-        const t = Date.now();
+        const t = util.now();
         await nextFrame();
         // We skip the first few batches for timing, because they usually
         // involve some warm-up time.
@@ -305,7 +305,7 @@ export class ModelTrainingYielder {
             }
           }
         }
-        this.batchStartMillis = Date.now();
+        this.batchStartMillis = util.now();
         this.lastYieldBatchCount = this.batchCount;
       } else {
         // autoYieldEveryBatch has been determined. We perform yielding

--- a/src/base_callbacks.ts
+++ b/src/base_callbacks.ts
@@ -215,7 +215,7 @@ export class CallbackList {
  */
 export class ModelTrainingYielder {
   // How many batches to skip at the beginning of a `Model.fit` call.
-  // The first batches usually are longer than usual because they
+  // The first batches usually are longer than the rest, because they may
   // involve warm-up time.
   readonly SKIP_FIRST_BATCHES = 1;
 
@@ -312,8 +312,8 @@ export class ModelTrainingYielder {
         // accordingly.
         if (this.batchCount - this.lastYieldBatchCount >=
             this.autoYieldEveryBatches) {
-          await this.resolveOneTensorInLogs(logs);
           await nextFrame();
+          await this.resolveOneTensorInLogs(logs);
           this.lastYieldBatchCount = this.batchCount;
         }
       }

--- a/src/base_callbacks.ts
+++ b/src/base_callbacks.ts
@@ -217,14 +217,14 @@ export class ModelTrainingYielder {
   // How many batches to skip at the beginning of a `Model.fit` call.
   // The first batches usually are longer than the rest, because they may
   // involve warm-up time.
-  readonly SKIP_FIRST_BATCHES = 1;
+  static readonly SKIP_FIRST_BATCHES = 1;
 
   // How many batches to average over when calculating the average batch
   // duration.
-  readonly AUTO_YIELD_DECISION_BATCH_COUNT = 2;
+  static readonly DECISION_BATCH_COUNT = 2;
 
   // How many milliseconds to wait before yielding again.
-  readonly AUTO_YIELD_THRESHOLD_MILLIS = 16;
+  static readonly THRESHOLD_MILLIS = 16;
 
   private yieldEvery: YieldEveryOptions;
   private batchCount: number;
@@ -291,15 +291,15 @@ export class ModelTrainingYielder {
         await nextFrame();
         // We skip the first few batches for timing, because they usually
         // involve some warm-up time.
-        if (this.batchCount > this.SKIP_FIRST_BATCHES) {
+        if (this.batchCount > ModelTrainingYielder.SKIP_FIRST_BATCHES) {
           this.batchDurationsMillis.push(t - this.batchStartMillis);
           if (this.batchDurationsMillis.length >=
-              this.AUTO_YIELD_DECISION_BATCH_COUNT) {
+              ModelTrainingYielder.DECISION_BATCH_COUNT) {
             const meanBatchDuration =
                 this.batchDurationsMillis.reduce((dur, prev) => dur + prev) /
                 this.batchDurationsMillis.length;
             this.autoYieldEveryBatches = Math.round(
-                this.AUTO_YIELD_THRESHOLD_MILLIS / meanBatchDuration);
+                ModelTrainingYielder.THRESHOLD_MILLIS / meanBatchDuration);
             if (this.autoYieldEveryBatches < 1) {
               this.autoYieldEveryBatches = 1;
             }

--- a/src/base_callbacks.ts
+++ b/src/base_callbacks.ts
@@ -207,7 +207,7 @@ export class CallbackList {
 }
 
 /**
- * A class that manages when to yield the thread during model training.
+ * A class that manages thread yielding during model training.
  *
  * The lifetime of an instance of `ModelTrainingYielder` is that of a
  * `Model.fit()` call. In other words, each `Model.fit()` call must create

--- a/src/base_callbacks.ts
+++ b/src/base_callbacks.ts
@@ -226,7 +226,6 @@ export class ModelTrainingYielder {
   // How many milliseconds to wait before yielding again.
   readonly AUTO_YIELD_THRESHOLD_MILLIS = 16;
 
-  // TODO(cais): Deduplicate type definition.
   private yieldEvery: YieldEveryOptions;
   private batchCount: number;
   private lastYieldBatchCount: number;

--- a/src/base_callbacks_test.ts
+++ b/src/base_callbacks_test.ts
@@ -27,6 +27,7 @@ describe('BaseLogger Callback', () => {
   it('Records and averages losses in an epoch', async done => {
     const baseLogger = new BaseLogger();
     baseLogger.setParams({metrics: ['loss', 'val_loss']});
+    await baseLogger.onTrainBegin();
     await baseLogger.onEpochBegin(0);
     await baseLogger.onBatchBegin(0);
     await baseLogger.onBatchEnd(0, {batch: 0, size: 10, loss: 5});
@@ -41,10 +42,11 @@ describe('BaseLogger Callback', () => {
         .toBeCloseTo((10 * 5 + 10 * 6 + 5 * 7) / (10 + 10 + 5));
     done();
   });
-  it('Forgets old epochs', async done => {
+  it('Forgets old epochs', async () => {
     const baseLogger = new BaseLogger();
     baseLogger.setParams({metrics: ['loss', 'val_loss']});
     const numOldEpochs = 2;
+    await baseLogger.onTrainBegin();
     for (let i = 0; i < numOldEpochs; ++i) {
       await baseLogger.onEpochBegin(i);
       await baseLogger.onBatchBegin(0);
@@ -64,7 +66,6 @@ describe('BaseLogger Callback', () => {
     expect(epochLog['val_loss'] as number).toEqual(3);
     expect(epochLog['loss'] as number)
         .toBeCloseTo((10 * 5 + 10 * 6 + 5 * 7) / (10 + 10 + 5));
-    done();
   });
 });
 

--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -586,7 +586,7 @@ export interface ModelFitConfig {
    * it can ensure tasks queued in the event loop can be handled in a timely
    * manner.
    *
-   * - The value can also be a string from the closed set of:
+   * - The value is a string from the closed set of:
    *   - 'auto': automatically determine how frequently the yielding happens
    *     by measuring the duration of each batch of training (default).
    *   - 'batch': yield every batch.

--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -581,6 +581,11 @@ export interface ModelFitConfig {
   /**
    * Configures the frequency of yielding the main thread to other tasks.
    *
+   * In the browser environment, yielding the main thread can improve the
+   * responsiveness of the page during training. In the Node.js environment,
+   * it can ensure tasks queued in the event loop can be handled in a timely
+   * manner.
+   *
    * - The value can also be a string from the closed set of:
    *   - 'auto': automatically determine how frequently the yielding happens
    *     by measuring the duration of each batch of training (default).

--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -586,7 +586,7 @@ export interface ModelFitConfig {
    * it can ensure tasks queued in the event loop can be handled in a timely
    * manner.
    *
-   * - The value is a string from the closed set of:
+   * - The value can be one of the following strings:
    *   - 'auto': automatically determine how frequently the yielding happens
    *     by measuring the duration of each batch of training (default).
    *   - 'batch': yield every batch.

--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -586,8 +586,8 @@ export interface ModelFitConfig {
    *     by measuring the duration of each batch of training (default).
    *   - 'batch': yield every batch.
    *   - 'epoch': yield every epoch.
-   *   - 'never': never yield. (Yielding can still happen by `await nextFrame()`
-   *     calls in custom callbacks.)
+   *   - 'never': never yield. (But yielding can still happen through `await
+   *      nextFrame()` calls in custom callbacks.)
    */
   yieldEvery?: YieldEveryOptions;
 }

--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -582,11 +582,12 @@ export interface ModelFitConfig {
    * Configures the frequency of yielding the main thread to other tasks.
    *
    * - The value can also be a string from the closed set of:
-   *   - 'auto': automatically determine how frequently yielding happens
-   *       by measuring the duration of each batch of training (default).
+   *   - 'auto': automatically determine how frequently the yielding happens
+   *     by measuring the duration of each batch of training (default).
    *   - 'batch': yield every batch.
    *   - 'epoch': yield every epoch.
-   *   - 'never': never yield.
+   *   - 'never': never yield. (Yielding can still happen by `await nextFrame()`
+   *     calls in custom callbacks.)
    */
   yieldEvery?: YieldEveryOptions;
 }
@@ -1328,7 +1329,7 @@ export class Model extends Container implements tfc.InferenceModel {
       callbacks?: BaseCallback[], valF?: (data: Tensor[]) => Scalar[],
       valIns?: Tensor[], shuffle?: boolean|string, callbackMetrics?: string[],
       initialEpoch?: number, stepsPerEpoch?: number, validationSteps?: number,
-      yieldEvery?: 'auto'|'batch'|'epoch'|'never'): Promise<History> {
+      yieldEvery?: YieldEveryOptions): Promise<History> {
     if (batchSize == null) {
       batchSize = 32;
     }

--- a/src/engine/training_test.ts
+++ b/src/engine/training_test.ts
@@ -1687,7 +1687,7 @@ describeMathGPU('Model.fit: yieldEvery', () => {
     const ys = ones([numExamples, 1]);
     const history = await model.fit(xs, ys, {epochs, batchSize: numExamples});
     expect(history.history.loss.length).toEqual(epochs);
-    // There are 20 = 40 batches in total. The first 3 batch are for
+    // There are 20 batches in total. The first 3 batch are for
     // measurement, during each of which nextFrame() is called. The remaining
     // 17 batches consists of 2 full collections of 8 batches. So nextFrame()
     // is expected to have been called 3 + 2 = 7 times in total.

--- a/src/engine/training_test.ts
+++ b/src/engine/training_test.ts
@@ -1670,7 +1670,7 @@ describeMathGPU('Model.fit: yieldEvery', () => {
     return model;
   }
 
-  it('auto: 1 batches per epoch; 20 epochs; short batches', async done => {
+  it('auto: 1 batches per epoch; 20 epochs; short batches', async () => {
     const presetBatchTimestamps = [0, 2, 4, 6, 8, 10];
     let counter = 0;
     spyOn(Date, 'now').and.callFake(() => presetBatchTimestamps[counter++]);
@@ -1685,22 +1685,16 @@ describeMathGPU('Model.fit: yieldEvery', () => {
     const model = createDummyModel(inputSize);
     const xs = ones([numExamples, inputSize]);
     const ys = ones([numExamples, 1]);
-    try {
-      const history = await model.fit(xs, ys, {epochs, batchSize: numExamples});
-      expect(history.history.loss.length).toEqual(epochs);
-      // There are 20 = 40 batches in total. The first 3 batch are for
-      // measurement, during each of which nextFrame() is called. The remaining
-      // 17 batches consists of 2 full collections of 8 batches. So nextFrame()
-      // is expected to have been called 3 + 2 = 7 times in total.
-      expect(nextFrameCallCount).toEqual(5);
-    } catch (err) {
-      console.log(err.message);
-      done.fail(err.message);
-    }
-    done();
+    const history = await model.fit(xs, ys, {epochs, batchSize: numExamples});
+    expect(history.history.loss.length).toEqual(epochs);
+    // There are 20 = 40 batches in total. The first 3 batch are for
+    // measurement, during each of which nextFrame() is called. The remaining
+    // 17 batches consists of 2 full collections of 8 batches. So nextFrame()
+    // is expected to have been called 3 + 2 = 7 times in total.
+    expect(nextFrameCallCount).toEqual(5);
   });
 
-  it('auto: 2 batches per epoch; 20 epochs; short batches', async done => {
+  it('auto: 2 batches per epoch; 20 epochs; short batches', async () => {
     const presetBatchTimestamps = [0, 2, 4, 6, 8, 10];
     let counter = 0;
     spyOn(Date, 'now').and.callFake(() => presetBatchTimestamps[counter++]);
@@ -1715,23 +1709,17 @@ describeMathGPU('Model.fit: yieldEvery', () => {
     const model = createDummyModel(inputSize);
     const xs = ones([numExamples, inputSize]);
     const ys = ones([numExamples, 1]);
-    try {
-      const history =
-          await model.fit(xs, ys, {epochs, batchSize: numExamples / 2});
-      expect(history.history.loss.length).toEqual(epochs);
-      // There are 20 * 2 = 40 batches in total. The first 3 batch are for
-      // measurement, during each of which nextFrame() is called. The remaining
-      // 37 batches consists of 4 full collections of 8 batches. So nextFrame()
-      // is expected to have been called 3 + 4 = 7 times in total.
-      expect(nextFrameCallCount).toEqual(7);
-    } catch (err) {
-      console.log(err.message);
-      done.fail(err.message);
-    }
-    done();
+    const history =
+        await model.fit(xs, ys, {epochs, batchSize: numExamples / 2});
+    expect(history.history.loss.length).toEqual(epochs);
+    // There are 20 * 2 = 40 batches in total. The first 3 batch are for
+    // measurement, during each of which nextFrame() is called. The
+    // remaining 37 batches consists of 4 full collections of 8 batches. So
+    // nextFrame() is expected to have been called 3 + 4 = 7 times in total.
+    expect(nextFrameCallCount).toEqual(7);
   });
 
-  it('auto: 1 batches per epoch; 20 epochs; long batches', async done => {
+  it('auto: 1 batches per epoch; 20 epochs; long batches', async () => {
     const presetBatchTimestamps = [0, 20, 40, 60, 80, 100];
     let counter = 0;
     spyOn(Date, 'now').and.callFake(() => presetBatchTimestamps[counter++]);
@@ -1741,25 +1729,19 @@ describeMathGPU('Model.fit: yieldEvery', () => {
     });
 
     const inputSize = 5;
-    const numExamples = 100;
+    const numExamples = 10;
     const epochs = 20;
     const model = createDummyModel(inputSize);
     const xs = ones([numExamples, inputSize]);
     const ys = ones([numExamples, 1]);
-    try {
-      const history = await model.fit(xs, ys, {epochs, batchSize: numExamples});
-      expect(history.history.loss.length).toEqual(epochs);
-      // For long batch durations, `await nextFrame()` should have been called
-      // every batch.
-      expect(nextFrameCallCount).toEqual(epochs);
-    } catch (err) {
-      console.log(err.message);
-      done.fail(err.message);
-    }
-    done();
+    const history = await model.fit(xs, ys, {epochs, batchSize: numExamples});
+    expect(history.history.loss.length).toEqual(epochs);
+    // For long batch durations, `await nextFrame()` should have been called
+    // every batch.
+    expect(nextFrameCallCount).toEqual(epochs);
   });
 
-  it('auto: 2 batches per epoch; 20 epochs; long batches', async done => {
+  it('auto: 2 batches per epoch; 20 epochs; long batches', async () => {
     const presetBatchTimestamps = [0, 20, 40, 60, 80, 100];
     let counter = 0;
     spyOn(Date, 'now').and.callFake(() => presetBatchTimestamps[counter++]);
@@ -1769,26 +1751,20 @@ describeMathGPU('Model.fit: yieldEvery', () => {
     });
 
     const inputSize = 5;
-    const numExamples = 100;
+    const numExamples = 10;
     const epochs = 20;
     const model = createDummyModel(inputSize);
     const xs = ones([numExamples, inputSize]);
     const ys = ones([numExamples, 1]);
-    try {
-      const history =
-          await model.fit(xs, ys, {epochs, batchSize: numExamples / 2});
-      expect(history.history.loss.length).toEqual(epochs);
-      // For long batch durations, `await nextFrame()` should have been called
-      // every batch.
-      expect(nextFrameCallCount).toEqual(epochs * 2);
-    } catch (err) {
-      console.log(err.message);
-      done.fail(err.message);
-    }
-    done();
+    const history =
+        await model.fit(xs, ys, {epochs, batchSize: numExamples / 2});
+    expect(history.history.loss.length).toEqual(epochs);
+    // For long batch durations, `await nextFrame()` should have been called
+    // every batch.
+    expect(nextFrameCallCount).toEqual(epochs * 2);
   });
 
-  it('batch: uneven 9 batches per epoch; 2 epochs', async done => {
+  it('batch: uneven 9 batches per epoch; 2 epochs', async () => {
     let nextFrameCallCount = 0;
     spyOn(tfc, 'nextFrame').and.callFake(async () => {
       nextFrameCallCount++;
@@ -1800,66 +1776,48 @@ describeMathGPU('Model.fit: yieldEvery', () => {
     const model = createDummyModel(inputSize);
     const xs = ones([numExamples, inputSize]);
     const ys = ones([numExamples, 1]);
-    try {
-      const history =
-          await model.fit(xs, ys, {epochs, batchSize: 12, yieldEvery: 'batch'});
-      expect(history.history.loss.length).toEqual(epochs);
-      expect(nextFrameCallCount).toEqual(9 * epochs);
-    } catch (err) {
-      console.log(err.message);
-      done.fail(err.message);
-    }
-    done();
+    const history =
+        await model.fit(xs, ys, {epochs, batchSize: 12, yieldEvery: 'batch'});
+    expect(history.history.loss.length).toEqual(epochs);
+    expect(nextFrameCallCount).toEqual(9 * epochs);
   });
 
-  it('epoch: 10 batches per epoch; 2 epochs', async done => {
+  it('epoch: 10 batches per epoch; 2 epochs', async () => {
     let nextFrameCallCount = 0;
     spyOn(tfc, 'nextFrame').and.callFake(async () => {
       nextFrameCallCount++;
     });
 
     const inputSize = 5;
-    const numExamples = 100;
+    const numExamples = 10;
     const epochs = 2;
     const model = createDummyModel(inputSize);
     const xs = ones([numExamples, inputSize]);
     const ys = ones([numExamples, 1]);
-    try {
-      const history = await model.fit(
-          xs, ys, {epochs, batchSize: numExamples / 10, yieldEvery: 'epoch'});
-      expect(history.history.loss.length).toEqual(epochs);
-      expect(nextFrameCallCount).toEqual(epochs);
-    } catch (err) {
-      console.log(err.message);
-      done.fail(err.message);
-    }
-    done();
+    const history = await model.fit(
+        xs, ys, {epochs, batchSize: numExamples / 10, yieldEvery: 'epoch'});
+    expect(history.history.loss.length).toEqual(epochs);
+    expect(nextFrameCallCount).toEqual(epochs);
   });
 
-  it('never: 2 batches per epoch; 20 epochs', async done => {
+  it('never: 2 batches per epoch; 20 epochs', async () => {
     let nextFrameCallCount = 0;
     spyOn(tfc, 'nextFrame').and.callFake(async () => {
       nextFrameCallCount++;
     });
 
     const inputSize = 5;
-    const numExamples = 100;
+    const numExamples = 10;
     const epochs = 20;
     const model = createDummyModel(inputSize);
     const xs = ones([numExamples, inputSize]);
     const ys = ones([numExamples, 1]);
-    try {
-      const history = await model.fit(
-          xs, ys, {epochs, batchSize: numExamples / 2, yieldEvery: 'never'});
-      expect(history.history.loss.length).toEqual(epochs);
-      // Due to yieldEvery = 'never', no `await nextFrame()` call should have
-      // happened.
-      expect(nextFrameCallCount).toEqual(0);
-    } catch (err) {
-      console.log(err.message);
-      done.fail(err.message);
-    }
-    done();
+    const history = await model.fit(
+        xs, ys, {epochs, batchSize: numExamples / 2, yieldEvery: 'never'});
+    expect(history.history.loss.length).toEqual(epochs);
+    // Due to yieldEvery = 'never', no `await nextFrame()` call should have
+    // happened.
+    expect(nextFrameCallCount).toEqual(0);
   });
 });
 

--- a/src/engine/training_test.ts
+++ b/src/engine/training_test.ts
@@ -14,7 +14,7 @@
 
 // tslint:disable:max-line-length
 import * as tfc from '@tensorflow/tfjs-core';
-import {abs, mean, memory, mul, NamedTensorMap, ones, Scalar, scalar, SGDOptimizer, Tensor, tensor1d, tensor2d, tensor3d, test_util, zeros} from '@tensorflow/tfjs-core';
+import {abs, mean, memory, mul, NamedTensorMap, ones, Scalar, scalar, SGDOptimizer, Tensor, tensor1d, tensor2d, tensor3d, test_util, util, zeros} from '@tensorflow/tfjs-core';
 
 import * as K from '../backend/tfjs_backend';
 import {CustomCallback, CustomCallbackConfig, ModelTrainingYielder} from '../base_callbacks';
@@ -1672,7 +1672,7 @@ describeMathGPU('Model.fit: yieldEvery', () => {
   it('auto: 1 batches per epoch; 20 epochs; short batches', async () => {
     const presetBatchTimestamps = [0, 2, 4, 6, 8, 10];
     let counter = 0;
-    spyOn(Date, 'now').and.callFake(() => presetBatchTimestamps[counter++]);
+    spyOn(util, 'now').and.callFake(() => presetBatchTimestamps[counter++]);
     let nextFrameCallCount = 0;
     spyOn(tfc, 'nextFrame').and.callFake(async () => {
       nextFrameCallCount++;
@@ -1702,7 +1702,7 @@ describeMathGPU('Model.fit: yieldEvery', () => {
   it('auto: 2 batches per epoch; 20 epochs; short batches', async () => {
     const presetBatchTimestamps = [0, 2, 4, 6, 8, 10];
     let counter = 0;
-    spyOn(Date, 'now').and.callFake(() => presetBatchTimestamps[counter++]);
+    spyOn(util, 'now').and.callFake(() => presetBatchTimestamps[counter++]);
     let nextFrameCallCount = 0;
     spyOn(tfc, 'nextFrame').and.callFake(async () => {
       nextFrameCallCount++;
@@ -1733,7 +1733,7 @@ describeMathGPU('Model.fit: yieldEvery', () => {
   it('auto: 1 batches per epoch; 20 epochs; long batches', async () => {
     const presetBatchTimestamps = [0, 20, 40, 60, 80, 100];
     let counter = 0;
-    spyOn(Date, 'now').and.callFake(() => presetBatchTimestamps[counter++]);
+    spyOn(util, 'now').and.callFake(() => presetBatchTimestamps[counter++]);
     let nextFrameCallCount = 0;
     spyOn(tfc, 'nextFrame').and.callFake(async () => {
       nextFrameCallCount++;
@@ -1755,7 +1755,7 @@ describeMathGPU('Model.fit: yieldEvery', () => {
   it('auto: 2 batches per epoch; 20 epochs; long batches', async () => {
     const presetBatchTimestamps = [0, 20, 40, 60, 80, 100];
     let counter = 0;
-    spyOn(Date, 'now').and.callFake(() => presetBatchTimestamps[counter++]);
+    spyOn(util, 'now').and.callFake(() => presetBatchTimestamps[counter++]);
     let nextFrameCallCount = 0;
     spyOn(tfc, 'nextFrame').and.callFake(async () => {
       nextFrameCallCount++;
@@ -1776,6 +1776,9 @@ describeMathGPU('Model.fit: yieldEvery', () => {
   });
 
   it('batch: uneven 9 batches per epoch; 2 epochs', async () => {
+    const presetBatchTimestamps = [0, 2, 4, 6, 8, 10];
+    let counter = 0;
+    spyOn(util, 'now').and.callFake(() => presetBatchTimestamps[counter++]);
     let nextFrameCallCount = 0;
     spyOn(tfc, 'nextFrame').and.callFake(async () => {
       nextFrameCallCount++;

--- a/src/engine/training_test.ts
+++ b/src/engine/training_test.ts
@@ -1679,8 +1679,8 @@ describeMathGPU('Model.fit: yieldEvery', () => {
       nextFrameCallCount++;
     });
 
-    const inputSize = 5;
-    const numExamples = 100;
+    const inputSize = 2;
+    const numExamples = 10;
     const epochs = 20;
     const model = createDummyModel(inputSize);
     const xs = ones([numExamples, inputSize]);
@@ -1705,18 +1705,18 @@ describeMathGPU('Model.fit: yieldEvery', () => {
 
     const inputSize = 5;
     const numExamples = 100;
-    const epochs = 20;
+    const epochs = 10;
     const model = createDummyModel(inputSize);
     const xs = ones([numExamples, inputSize]);
     const ys = ones([numExamples, 1]);
     const history =
         await model.fit(xs, ys, {epochs, batchSize: numExamples / 2});
     expect(history.history.loss.length).toEqual(epochs);
-    // There are 20 * 2 = 40 batches in total. The first 3 batch are for
+    // There are 10 * 2 = 20 batches in total. The first 3 batch are for
     // measurement, during each of which nextFrame() is called. The
-    // remaining 37 batches consists of 4 full collections of 8 batches. So
-    // nextFrame() is expected to have been called 3 + 4 = 7 times in total.
-    expect(nextFrameCallCount).toEqual(7);
+    // remaining 17 batches consists of 2 full collections of 8 batches. So
+    // nextFrame() is expected to have been called 3 + 2 = 7 times in total.
+    expect(nextFrameCallCount).toEqual(5);
   });
 
   it('auto: 1 batches per epoch; 20 epochs; long batches', async () => {
@@ -1730,7 +1730,7 @@ describeMathGPU('Model.fit: yieldEvery', () => {
 
     const inputSize = 5;
     const numExamples = 10;
-    const epochs = 20;
+    const epochs = 4;
     const model = createDummyModel(inputSize);
     const xs = ones([numExamples, inputSize]);
     const ys = ones([numExamples, 1]);
@@ -1752,7 +1752,7 @@ describeMathGPU('Model.fit: yieldEvery', () => {
 
     const inputSize = 5;
     const numExamples = 10;
-    const epochs = 20;
+    const epochs = 4;
     const model = createDummyModel(inputSize);
     const xs = ones([numExamples, inputSize]);
     const ys = ones([numExamples, 1]);
@@ -1770,16 +1770,17 @@ describeMathGPU('Model.fit: yieldEvery', () => {
       nextFrameCallCount++;
     });
 
-    const inputSize = 3;
-    const numExamples = 100;
+    const inputSize = 1;
+    const numExamples = 10;
     const epochs = 2;
     const model = createDummyModel(inputSize);
     const xs = ones([numExamples, inputSize]);
     const ys = ones([numExamples, 1]);
     const history =
-        await model.fit(xs, ys, {epochs, batchSize: 12, yieldEvery: 'batch'});
+        await model.fit(xs, ys, {epochs, batchSize: 4, yieldEvery: 'batch'});
     expect(history.history.loss.length).toEqual(epochs);
-    expect(nextFrameCallCount).toEqual(9 * epochs);
+    // There are `ceil(10 / 4)` batches per epoch.
+    expect(nextFrameCallCount).toEqual(3 * epochs);
   });
 
   it('epoch: 10 batches per epoch; 2 epochs', async () => {
@@ -1808,7 +1809,7 @@ describeMathGPU('Model.fit: yieldEvery', () => {
 
     const inputSize = 5;
     const numExamples = 10;
-    const epochs = 20;
+    const epochs = 4;
     const model = createDummyModel(inputSize);
     const xs = ones([numExamples, inputSize]);
     const ys = ones([numExamples, 1]);


### PR DESCRIPTION
Previously, users have to call await tf.nextFrame() in the callbacks of Model.fit() calls in order
to ensure page responsiveness during long-running Model.fit() calls. 

This PR adds logic to automatically call await tf.nextFrame(). Specifically, a new field is added
to the config object for Model.fit(): `yieldEvery`.

- The default value of 'auto' lets TensorFlow.js measure the batch duration during the first
  several batches and calculate how many batches should pass before calling await
  tf.nextFrame() again.
- The value 'batch' and 'epoch' lets TensorFlow.js call await tf.nextFrame every batch or
  every epoch, respectively.
- The value 'never' disables await tf.nextFrame() calls. It is the legacy behavior. The user
  can still call await tf.nextFrame() in custom callbacks.

The 'auto' approach is a tradeoff between the need to ensure page responsiveness and
the need to prevent short-running Model.fit() calls from slowing down too much.

FEATURE

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/274)
<!-- Reviewable:end -->
