### PR TITLE
Some fixes and improvements to integration_tests/benchmarks

### DIFF
--- a/integration_tests/benchmarks/index.html
+++ b/integration_tests/benchmarks/index.html
@@ -40,6 +40,9 @@ https://opensource.org/licenses/MIT.
     <span id="status">Standing by.</span>
   </div>
   <div>
+    Benchmark timestamp:<span class="metadata" id="benchmark-timestamp"></span>
+  </div>
+  <div>
     TensorFlow.js Core version:<span class="metadata" id="tfjs-core-version"></span>
   </div>
   <div>

--- a/integration_tests/benchmarks/package.json
+++ b/integration_tests/benchmarks/package.json
@@ -9,12 +9,11 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs-core": "^0.11.6",
-    "@tensorflow/tfjs-layers": "^0.6.6",
+    "@tensorflow/tfjs-core": "^0.12.8",
+    "@tensorflow/tfjs-layers": "^0.7.2",
     "vega-embed": "~3.0.0"
   },
   "scripts": {
-    "preinstall": "yarn upgrade --pattern @tensorflow",
     "watch": "NODE_ENV=development parcel --no-hmr --open index.html ",
     "build": "NODE_ENV=production parcel build index.html  --no-minify --public-url ./",
     "lint": "eslint ./*.js"

--- a/integration_tests/benchmarks/ui.js
+++ b/integration_tests/benchmarks/ui.js
@@ -16,6 +16,7 @@ export function status(statusText) {
 }
 
 export function setMetadata(metadata) {
+  document.getElementById('benchmark-timestamp').textContent = new Date().toISOString();
   document.getElementById('pyKerasVersion').textContent = metadata.keras_version;
   document.getElementById('tfVersion').textContent = metadata.tensorflow_version;
   document.getElementById('tfUsesGPU').textContent = metadata.tensorflow_uses_gpu;

--- a/integration_tests/benchmarks/yarn.lock
+++ b/integration_tests/benchmarks/yarn.lock
@@ -2,19 +2,34 @@
 # yarn lockfile v1
 
 
-"@tensorflow/tfjs-core@^0.11.6":
-  version "0.11.7"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.11.7.tgz#b12f074b534e57ebbfc4dbc9935083ddb6e195d8"
+"@tensorflow/tfjs-core@^0.12.8":
+  version "0.12.8"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.12.8.tgz#d7bb5fb17da080374a4918aa5cd423378c0cdc0c"
   dependencies:
+    "@types/seedrandom" "~2.4.27"
+    "@types/webgl-ext" "~0.0.29"
+    "@types/webgl2" "~0.0.4"
     seedrandom "~2.4.3"
 
-"@tensorflow/tfjs-layers@^0.6.6":
-  version "0.6.6"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-0.6.6.tgz#6869c86ed01905271ebe707d6324ba04119b73ab"
+"@tensorflow/tfjs-layers@^0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-0.7.2.tgz#3a8c083255c72da272245ae5b435c66af9573eb8"
 
 "@types/json-stable-stringify@^1.0.32":
   version "1.0.32"
   resolved "https://registry.yarnpkg.com/@types/json-stable-stringify/-/json-stable-stringify-1.0.32.tgz#121f6917c4389db3923640b2e68de5fa64dda88e"
+
+"@types/seedrandom@~2.4.27":
+  version "2.4.27"
+  resolved "https://registry.yarnpkg.com/@types/seedrandom/-/seedrandom-2.4.27.tgz#9db563937dd86915f69092bc43259d2f48578e41"
+
+"@types/webgl-ext@~0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/webgl-ext/-/webgl-ext-0.0.29.tgz#4d479baf1124795f53d54bdc85b386e0f194d90a"
+
+"@types/webgl2@~0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@types/webgl2/-/webgl2-0.0.4.tgz#c3b0f9d6b465c66138e84e64cb3bdf8373c2c279"
 
 abbrev@1:
   version "1.1.1"


### PR DESCRIPTION
* The `yarn pre-install` step was causing "outdated lock file error"
  before. The step is not necessary. This PR removes it.
* Add an ISO-format timestamp to benchmark page.
* Update tfjs-core and tfjs-layers to the latest versions.

DEV

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/275)
<!-- Reviewable:end -->
