### PR TITLE
Add new method dispose() to tf.layers.Layer and tf.Model

### DIFF
--- a/src/engine/container.ts
+++ b/src/engine/container.ts
@@ -638,29 +638,29 @@ export abstract class Container extends Layer {
   }
 
   /**
-   * Attempt to dispose a Container's weights.
+   * Attempt to dispose a Model's weights.
    *
-   * This method decrease the reference count of the Container object by 1.
+   * This method decrease the reference count of the Model object by 1.
    *
-   * A Container is reference-counted. Its reference count is incremented by 1
+   * A Model is reference-counted. Its reference count is incremented by 1
    * when it is first constructed and when it is used as a Layer of another
-   * Container.
+   * Model.
    *
-   * If the reference count of a Container becomes 0, the `dispose` method of
+   * If the reference count of a Model becomes 0, the `dispose` method of
    * all its constituent `Layer`s will be called.
    *
    * Note: If the reference count is greater than 0 after the decrement, the
    * `dispose` method of its constituent `Layer`s will *not* be called.
    *
-   * After a Container is disposed, it cannot be used in calls such as
+   * After a Model is disposed, it cannot be used in calls such as
    * 'predict`, `evaluate` or `fit` anymore.
    *
    * @returns A DisposeResult Object with the following fields:
-   *   - refCountAfterDispose: The reference count of the Container after this
+   *   - refCountAfterDispose: The reference count of the Model after this
    *     `dispose()` call.
    *   - numDisposedVariables: Number of `tf.Variable`s (i.e., weights) disposed
    *     during this `dispose()` call.
-   * @throws {Error} If the layer is not built yet, or if the Container has
+   * @throws {Error} If the layer is not built yet, or if the Model has
    *   already been disposed.
    */
   dispose(): DisposeResult {

--- a/src/engine/container.ts
+++ b/src/engine/container.ts
@@ -23,7 +23,7 @@ import {batchSetValue, LayerVariable} from '../variables';
 import {version as layersVersion} from '../version';
 
 import {InputLayer} from './input_layer';
-import {Layer, Node, SymbolicTensor} from './topology';
+import {Layer, Node, SymbolicTensor, DisposeResult} from './topology';
 
 /**
  * Converts layers weights to a format suitable for TensorFlow.js Layers.
@@ -638,25 +638,44 @@ export abstract class Container extends Layer {
   }
 
   /**
-   * Decrease the reference count of the Container object by 1.
+   * Attempt to dispose a Container's weights.
+   *
+   * This method decrease the reference count of the Container object by 1.
    *
    * A Container is reference-counted. Its reference count is incremented by 1
    * when it is first constructed and when it is used as a Layer of another
    * Container.
    *
-   * If the reference count of a Container becomes 0, the `decRef` method of
-   * all its constituent Layer will be called.
+   * If the reference count of a Container becomes 0, the `dispose` method of
+   * all its constituent `Layer`s will be called.
+   *
+   * Note: If the reference count is greater than 0 after the decrement, the
+   * `dispose` method of its constituent `Layer`s will *not* be called.
    *
    * After a Container is disposed, it cannot be used in calls such as
    * 'predict`, `evaluate` or `fit` anymore.
+   *
+   * @returns A DisposeResult Object with the following fields:
+   *   - refCountAfterDispose: The reference count of the Container after this
+   *     `dispose()` call.
+   *   - numDisposedVariables: Number of `tf.Variable`s (i.e., weights) disposed
+   *     during this `dispose()` call.
+   * @throws {Error} If the layer is not built yet, or if the Container has
+   *   already been disposed.
    */
-  decRef(): void {
+  dispose(): DisposeResult {
     this.assertNotDisposed();
+    const result: DisposeResult = {
+      refCountAfterDispose: null,
+      numDisposedVariables: 0
+    };
     if (--this._refCount === 0) {
       for (const layer of this.layers) {
-        layer.decRef();
+        result.numDisposedVariables += layer.dispose().numDisposedVariables;
       }
     }
+    result.refCountAfterDispose = this._refCount;
+    return result;
   }
 
   get trainableWeights(): LayerVariable[] {

--- a/src/engine/container_test.ts
+++ b/src/engine/container_test.ts
@@ -8,7 +8,7 @@
  * =============================================================================
  */
 
-import {ones, scalar, Tensor, zeros} from '@tensorflow/tfjs-core';
+import {memory, ones, scalar, Tensor, zeros} from '@tensorflow/tfjs-core';
 
 import * as tfl from '../index';
 import {describeMathCPUAndGPU, expectTensorsClose} from '../utils/test_utils';
@@ -465,5 +465,171 @@ describe('getSourceInputs()', () => {
     const output2 = layer.apply(input2) as tfl.SymbolicTensor;
     expect(getSourceInputs(output1)).toEqual([input1]);
     expect(getSourceInputs(output2)).toEqual([input2]);
+  });
+});
+
+describeMathCPUAndGPU('Model-decRef', () => {
+  it('Dispose Sequential model frees memory', () => {
+    const model = tfl.sequential();
+    model.add(
+        tfl.layers.dense({units: 2, inputShape: [3], activation: 'relu'}));
+    model.add(tfl.layers.dense({units: 1}));
+    model.build([3, 3]);
+
+    const numTensors0 = memory().numTensors;
+    model.decRef();
+    // The four weight variables of the two layers should have been disposed.
+    expect(memory().numTensors).toEqual(numTensors0 - 4);
+  });
+
+  it('Dispose Sequential model twice leads to Error', () => {
+    const model = tfl.sequential();
+    model.add(
+        tfl.layers.dense({units: 2, inputShape: [3], activation: 'relu'}));
+    model.add(tfl.layers.dense({units: 1}));
+    model.build([3, 3]);
+
+    model.decRef();
+    expect(() => model.decRef()).toThrowError(/Container .* already disposed/);
+  });
+
+  it('Using disposed Sequential model leads to Error', async () => {
+    const model = tfl.sequential();
+    model.add(
+        tfl.layers.dense({units: 2, inputShape: [3], activation: 'relu'}));
+    model.add(tfl.layers.dense({units: 1, activation: 'sigmoid'}));
+    model.build([3, 3]);
+    model.compile({loss: 'meanSquaredError', optimizer: 'sgd'});
+    model.decRef();
+
+    const xs = zeros([3, 3]);
+    const ys = zeros([3, 1]);
+    expect(() => model.predict(xs)).toThrowError(/already disposed/);
+    expect(() => model.evaluate(xs, ys)).toThrowError(/already disposed/);
+    let errorCaughtDuringFit = false;
+    try {
+      await model.fit(xs, ys);
+    } catch (err) {
+      errorCaughtDuringFit = true;
+    }
+    expect(errorCaughtDuringFit).toEqual(true);
+  });
+
+  it('Dispose functional model frees memory', () => {
+    const input = tfl.input({shape: [4]});
+    const dense1 =
+        tfl.layers.dense({units: 3}).apply(input) as tfl.SymbolicTensor;
+    const dense2 = tfl.layers.dense({units: 2, useBias: false}).apply(input) as
+        tfl.SymbolicTensor;
+    const model = tfl.model({inputs: [input], outputs: [dense1, dense2]});
+    // Call predict once to make sure that the model's weights are initialized.
+    model.predict(zeros([2, 4]));
+
+    const numTensors0 = memory().numTensors;
+    model.decRef();
+
+    // The 2 + 1 = 3 weight variables of the two layers should have been
+    // disposed.
+    expect(memory().numTensors).toEqual(numTensors0 - 3);
+  });
+
+  it('Dispose functional model twice leads to Error', () => {
+    const input = tfl.input({shape: [4]});
+    const dense1 =
+        tfl.layers.dense({units: 3}).apply(input) as tfl.SymbolicTensor;
+    const dense2 = tfl.layers.dense({units: 2, useBias: false}).apply(input) as
+        tfl.SymbolicTensor;
+    const model = tfl.model({inputs: [input], outputs: [dense1, dense2]});
+    // Call predict once to make sure that the model's weights are  initialized.
+    model.predict(zeros([2, 4]));
+
+    model.decRef();
+    expect(() => model.decRef()).toThrowError(/Container .* already disposed/);
+  });
+
+  it('Layer shared between two functional models is not disposed', () => {
+    const input1 = tfl.input({shape: [4]});
+    const input2 = tfl.input({shape: [4]});
+    const sharedDenseLayer = tfl.layers.dense({units: 3, activation: 'relu'});
+    const nonSharedDenseLayer1 = tfl.layers.dense({units: 1, useBias: false});
+    const nonSharedDenseLayer2 = tfl.layers.dense({units: 1, useBias: false});
+    const output1 = nonSharedDenseLayer1.apply(
+                        sharedDenseLayer.apply(input1)) as tfl.SymbolicTensor;
+    const output2 = nonSharedDenseLayer2.apply(
+                        sharedDenseLayer.apply(input2)) as tfl.SymbolicTensor;
+
+    const model1 = tfl.model({inputs: [input1], outputs: [output1]});
+    const model2 = tfl.model({inputs: [input2], outputs: [output2]});
+
+    // Call predict once to make sure that both models' weights are initialized.
+    model1.predict(zeros([2, 4]));
+    model2.predict(zeros([2, 4]));
+    const xs = zeros([2, 4]);
+
+    const numTensors0 = memory().numTensors;
+    model1.decRef();
+
+    // After model1 is decRef'ed, only the single weight of
+    // `nonSharedDenseLayer1` should have been freed.
+    expect(memory().numTensors).toEqual(numTensors0 - 1);
+
+    // At this point, calling predict() on model1 should fail, but doing the
+    // same on model2 should still work.
+    expect(() => model1.predict(xs)).toThrowError(/already disposed/);
+    const ys = model2.predict(xs) as Tensor;
+    expect(ys.shape).toEqual([2, 1]);
+    ys.dispose();
+
+    model2.decRef();
+
+    // After model2 is decRef'ed, the single weight of `nonSharedDenseLayer2`
+    // and the two weights o `sharedDenseLayer` should be freed.
+    expect(memory().numTensors).toEqual(numTensors0 - 4);
+
+    // At this point, calling predict() on both model1 and model2 should fail.
+    expect(() => model1.predict(xs)).toThrowError(/already disposed/);
+    expect(() => model2.predict(xs)).toThrowError(/already disposed/);
+  });
+
+  it('Disposing nested sequential model preserves the inner model', () => {
+    const innerModel = tfl.sequential();
+    innerModel.add(tfl.layers.reshape({targetShape: [10], inputShape: [2, 5]}));
+    innerModel.add(tfl.layers.dense({units: 6, activation: 'relu'}));
+    innerModel.add(tfl.layers.dense({units: 4, activation: 'relu'}));
+
+    const outerModel = tfl.sequential();
+    outerModel.add(
+        tfl.layers.reshape({targetShape: [2, 5], inputShape: [5, 2]}));
+    outerModel.add(innerModel);
+    outerModel.add(tfl.layers.dense({units: 3, activation: 'softmax'}));
+
+    const xsOuter = zeros([1, 5, 2]);
+    const xsInner = zeros([1, 2, 5]);
+    outerModel.predict(xsOuter);  // Call predict() to initialize the weights.
+    const numTensors0 = memory().numTensors;
+
+    outerModel.decRef();
+
+    // Calling decRef on the outer model should have freed the two weights that
+    // belong to only the outer model and not to the inner model.
+    expect(memory().numTensors).toEqual(numTensors0 - 2);
+
+    // Calling decRef on the outer model again should lead to Error.
+    expect(() => outerModel.decRef())
+        .toThrowError(/Container .* already disposed/);
+    // Calling predict on the outer model should fail.
+    expect(() => outerModel.predict(xsOuter)).toThrowError(/already disposed/);
+
+    // At this point, the inner model is still usable.
+    const ysInner = innerModel.predict(xsInner) as Tensor;
+    expect(ysInner.shape).toEqual([1, 4]);
+    ysInner.dispose();
+
+    // Calling decRef on innerModel should finally freed all the weights.
+    innerModel.decRef();
+    expect(memory().numTensors).toEqual(numTensors0 - 6);
+
+    // At this point, the inner model should have become unusable.
+    expect(() => innerModel.predict(xsInner)).toThrowError(/already disposed/);
   });
 });

--- a/src/engine/input_layer.ts
+++ b/src/engine/input_layer.ts
@@ -14,7 +14,7 @@ import {getUid} from '../backend/state';
 import {ValueError} from '../errors';
 import {Kwargs, Shape} from '../types';
 
-import {Layer, Node, SymbolicTensor} from './topology';
+import {Layer, Node, SymbolicTensor, DisposeResult} from './topology';
 
 /**
  * Constructor arguments for InputLayer.
@@ -138,9 +138,12 @@ export class InputLayer extends Layer {
         `InputLayer's apply() method. InputLayer name: ${this.name}`);
   }
 
-  decRef(): void {
-    // decRef() for InputLayer is overridden as no-op.
-    return;
+  dispose(): DisposeResult {
+    // dispose() for InputLayer is overridden as no-op.
+    return {
+      refCountAfterDispose: this._refCount,
+      numDisposedVariables: 0
+    };
   }
 
   getConfig(): serialization.ConfigDict {

--- a/src/engine/input_layer.ts
+++ b/src/engine/input_layer.ts
@@ -138,6 +138,11 @@ export class InputLayer extends Layer {
         `InputLayer's apply() method. InputLayer name: ${this.name}`);
   }
 
+  decRef(): void {
+    // decRef() for InputLayer is overridden as no-op.
+    return;
+  }
+
   getConfig(): serialization.ConfigDict {
     return {
       batchInputShape: this.batchInputShape,

--- a/src/engine/topology.ts
+++ b/src/engine/topology.ts
@@ -184,6 +184,9 @@ export interface NodeConfig {
   outputShapes: Shape|Shape[];
 }
 
+/**
+ * The type of the return value of Layer.dispose() and Container.dispose().
+ */
 export interface DisposeResult {
   /**
    * Reference count after the dispose call.

--- a/src/engine/topology_test.ts
+++ b/src/engine/topology_test.ts
@@ -975,10 +975,16 @@ describeMathCPUAndGPU('Layer-decRef', () => {
         .toThrowError(/Layer .* is already disposed/);
   });
 
-  it('decRef() call works on Input Layer',
-     () => {
+  it('decRef() call works on Input Layer', () => {
+    const input = tfl.layers.input({shape: [2, 3]}) as tfl.SymbolicTensor;
+    const output = tfl.layers.reshape({targetShape: [3, 2]}).apply(input) as
+        tfl.SymbolicTensor;
+    const model = tfl.model({inputs: [input], outputs: [output]});
 
-     });
+    model.decRef();
+    expect(() => model.predict(zeros([1, 2, 3])))
+        .toThrowError(/already disposed/);
+  });
 });
 
 // TODO(cais): Maybe remove this test once loadWeightsFromJson is removed

--- a/src/engine/topology_test.ts
+++ b/src/engine/topology_test.ts
@@ -896,18 +896,20 @@ describeMathCPU('Layer', () => {
   });
 });
 
-describeMathCPUAndGPU('Layer-decRef', () => {
+describeMathCPUAndGPU('Layer-dispose', () => {
   it('Dispose Dense Layer before build leads to Error', () => {
     const dense = tfl.layers.dense({units: 1, inputShape: [4]});
-    expect(() => dense.decRef()).toThrowError(/has not been built/);
+    expect(() => dense.dispose()).toThrowError(/has not been built/);
   });
 
   it('Dispose Dense Layer after one tensor call frees memory', () => {
     const dense = tfl.layers.dense({units: 1, inputShape: [4]});
     dense.apply(zeros([2, 4]));
     const numTensors0 = memory().numTensors;
-    dense.decRef();
+    const result = dense.dispose();
 
+    expect(result.refCountAfterDispose).toEqual(0);
+    expect(result.numDisposedVariables).toEqual(2);
     // Two variables should have been freed: the kernel and the bias.
     expect(memory().numTensors).toEqual(numTensors0 - 2);
   });
@@ -915,8 +917,11 @@ describeMathCPUAndGPU('Layer-decRef', () => {
   it('Symbolic apply() call after Dense disposal leads to Error', () => {
     const dense = tfl.layers.dense({units: 1, inputShape: [4]});
     dense.apply(zeros([2, 4]));
-    dense.decRef();  // This decRef() call should dispose the layer.
+    const result = dense.dispose();
+    // This dispose() call should dispose the layer.
 
+    expect(result.refCountAfterDispose).toEqual(0);
+    expect(result.numDisposedVariables).toEqual(2);
     expect(
         () => dense.apply(
             new tfl.SymbolicTensor('float32', [2, 4], null, [], {})))
@@ -926,7 +931,7 @@ describeMathCPUAndGPU('Layer-decRef', () => {
   it('Non-symbolic apply() call after Dense disposal leads to Error', () => {
     const dense = tfl.layers.dense({units: 1, inputShape: [4]});
     dense.apply(zeros([2, 4]));
-    dense.decRef();  // This decRef() call should dispose the layer.
+    dense.dispose();  // This dispose() call should dispose the layer.
 
     expect(() => dense.apply(ones([2, 4])))
         .toThrowError(/Layer .* is already disposed/);
@@ -938,27 +943,31 @@ describeMathCPUAndGPU('Layer-decRef', () => {
     dense.apply(new tfl.SymbolicTensor('float32', [2, 4], null, [], {}));
     const numTensors0 = memory().numTensors;
 
-    dense.decRef();
-    // After the first decRef call, no memory should have been freed.
+    const result1 = dense.dispose();
+    // After the first dispose call, no memory should have been freed.
     expect(memory().numTensors).toEqual(numTensors0);
+    expect(result1.refCountAfterDispose).toEqual(1);
+    expect(result1.numDisposedVariables).toEqual(0);
 
-    dense.decRef();
-    // After the second decRef call, memory for the kernel and the bias should
+    const result2 = dense.dispose();
+    // After the second dispose call, memory for the kernel and the bias should
     // have been freed.
     expect(memory().numTensors).toEqual(numTensors0 - 2);
+    expect(result2.refCountAfterDispose).toEqual(0);
+    expect(result2.numDisposedVariables).toEqual(2);
   });
 
-  it('Calling decRef on already-disposed Layer leads to Error', () => {
+  it('Calling dispose on already-disposed Layer leads to Error', () => {
     const dense = tfl.layers.dense({units: 1, inputShape: [4]});
     dense.apply(zeros([2, 4]));
-    dense.decRef();
-    expect(() => dense.decRef()).toThrowError(/Layer .* is already disposed/);
+    dense.dispose();
+    expect(() => dense.dispose()).toThrowError(/Layer .* is already disposed/);
   });
 
   it('Symbolic apply() call after Flatten disposal leads to Error', () => {
     const dense = tfl.layers.flatten();
     dense.apply(zeros([2, 3, 4]));
-    dense.decRef();  // This decRef() call should dispose the layer.
+    dense.dispose();  // This dispose() call should dispose the layer.
 
     expect(
         () => dense.apply(
@@ -969,19 +978,22 @@ describeMathCPUAndGPU('Layer-decRef', () => {
   it('Non-symbolic apply() call after Flatten disposal leads to Error', () => {
     const dense = tfl.layers.flatten();
     dense.apply(zeros([2, 3, 4]));
-    dense.decRef();  // This decRef() call should dispose the layer.
+    dense.dispose();  // This dispose() call should dispose the layer.
 
     expect(() => dense.apply(zeros([2, 3, 4])))
         .toThrowError(/Layer .* is already disposed/);
   });
 
-  it('decRef() call works on Input Layer', () => {
+  it('dispose() call works on Input Layer', () => {
     const input = tfl.layers.input({shape: [2, 3]}) as tfl.SymbolicTensor;
     const output = tfl.layers.reshape({targetShape: [3, 2]}).apply(input) as
         tfl.SymbolicTensor;
     const model = tfl.model({inputs: [input], outputs: [output]});
 
-    model.decRef();
+    const result = model.dispose();
+    // This model, consiting of only an input layer and a reshape layer, does
+    // not have any weights to dispose.
+    expect(result.numDisposedVariables).toEqual(0);
     expect(() => model.predict(zeros([1, 2, 3])))
         .toThrowError(/already disposed/);
   });

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -79,6 +79,7 @@ export class LayerVariable {
    * be reflected by future calls to this method.
    */
   read(): Tensor {
+    this.assertNotDisposed();
     return this.val;
   }
 
@@ -91,12 +92,27 @@ export class LayerVariable {
    */
   write(newVal: Tensor) {
     // TODO(cais): Once  TF.js Core supports Tensor.dtype, check dtype match.
+    this.assertNotDisposed();
     checkShapesMatch(this.val, newVal);
     this.val.assign(newVal);
     if (this.constraint != null) {
       this.val.assign(this.constraint.apply(this.val));
     }
     return this;
+  }
+
+  /**
+   * Dispose this LayersVariable instance from memory.
+   */
+  dispose(): void {
+    this.assertNotDisposed();
+    this.val.dispose();
+  }
+
+  protected assertNotDisposed(): void {
+    if (this.val.isDisposed) {
+      throw new Error(`LayersVariable ${this.name} is already disposed.`);
+    }
   }
 }
 

--- a/src/variables_test.ts
+++ b/src/variables_test.ts
@@ -139,6 +139,32 @@ describeMathCPU('Variable', () => {
     const v2 = new V.LayerVariable(scalar(1), null, 'foo');
     expect(v1.id).not.toEqual(v2.id);
   });
+
+  it('dispose() frees memory', () => {
+    const v = new V.LayerVariable(tensor1d([10, -10]), null, 'gralk');
+    const numTensors0 = tfc.memory().numTensors;
+    v.dispose();
+    expect(tfc.memory().numTensors).toEqual(numTensors0 - 1);
+  });
+
+  it('Disposing LayersVariable twices leads to Error', () => {
+    const v = new V.LayerVariable(tensor1d([10, -10]), null, 'gralk');
+    v.dispose();
+    expect(() => v.dispose()).toThrowError(/LayersVariable .*gralk.* disposed/);
+  });
+
+  it('read() after dispose() leads to Error', () => {
+    const v = new V.LayerVariable(tensor1d([10, -10]), null, 'gralk');
+    v.dispose();
+    expect(() => v.read()).toThrowError(/LayersVariable .*gralk.* disposed/);
+  });
+
+  it('write() after dispose() leads to Error', () => {
+    const v = new V.LayerVariable(tensor1d([10, -10]), null, 'gralk');
+    v.dispose();
+    expect(() => v.write(tensor1d([20, -20])))
+        .toThrowError(/LayersVariable .*gralk.* disposed/);
+  });
 });
 
 describeMathCPUAndGPU('Create Variable', () => {


### PR DESCRIPTION
FEATURE

This allows a layer or a model to release the memory (e.g., WebGL
textures) allocated for its weights.

Usage example:

```js
const model = tf.sequential();
model.add(tf.layers.dense({
  units: 10, activation: 'relu', inputShape: [20]}));
model.add(tf.layers.dense({units: 3, activation: 'softmax'}));
model.summary();

model.decRef();
// This disposes the four weights that belong to the model's layers.
```

We use reference counting because layers may be shared among multiple
models. Also, a model may be nested under other models.

When the reference counter of a layer or model decreases to zero, its
weights will be disposed. After that, the layer or model cannot be used
in `apply`, `predict`, `evaluate`, `fit` or `save` calls anymore.

Fixes: https://github.com/tensorflow/tfjs/issues/533

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/282)
<!-- Reviewable:end -->
