### PR TITLE
Remove import from dist-internal modules

### DIFF
--- a/src/utils/math_utils_test.ts
+++ b/src/utils/math_utils_test.ts
@@ -12,7 +12,7 @@
  * Unit tests for math_utils.
  */
 
-import {expectArraysClose} from '@tensorflow/tfjs-core/dist/test_util';
+import * as tfc from '@tensorflow/tfjs-core';
 
 import * as math_utils from './math_utils';
 import {describeMathCPU} from './test_utils';
@@ -121,7 +121,7 @@ describeMathCPU('median', () => {
   it('does not mutate input array', () => {
     const numbers = [-100, -200, 150, 50];
     math_utils.median(numbers);
-    expectArraysClose(numbers, [-100, -200, 150, 50]);
+    tfc.test_util.expectArraysClose(numbers, [-100, -200, 150, 50]);
   });
 });
 


### PR DESCRIPTION
Fixes https://github.com/tensorflow/tfjs/issues/575

Note that we can't remove the only remaining one dist-internal import (jasmine_util.describeWithFlags) due to tfjs-core bundle size issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/283)
<!-- Reviewable:end -->
