### PR TITLE
Bump version to 0.7.3

### DIFF
--- a/integration_tests/tfjs2keras/package.json
+++ b/integration_tests/tfjs2keras/package.json
@@ -4,7 +4,7 @@
   "description": "Testing sending models from tfjs-layers to Keras",
   "private": false,
   "dependencies": {
-    "@tensorflow/tfjs-core": "~0.12.8",
+    "@tensorflow/tfjs-core": "~0.12.10",
     "@tensorflow/tfjs-layers": "*",
     "@tensorflow/tfjs-node": "~0.1.11",
     "clang-format": "~1.2.2",

--- a/integration_tests/tfjs2keras/yarn.lock
+++ b/integration_tests/tfjs2keras/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@tensorflow/tfjs-core@~0.12.8":
-  version "0.12.8"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.12.8.tgz#d7bb5fb17da080374a4918aa5cd423378c0cdc0c"
+"@tensorflow/tfjs-core@~0.12.10":
+  version "0.12.10"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.12.10.tgz#8c13b787ea22e085090b1cacb652ad96ae38b74d"
   dependencies:
     "@types/seedrandom" "~2.4.27"
     "@types/webgl-ext" "~0.0.29"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensorflow/tfjs-layers",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "TensorFlow layers API in JavaScript",
   "private": false,
   "main": "dist/index.js",
@@ -10,7 +10,7 @@
   "jsdelivr": "dist/tf-layers.min.js",
   "unpkg": "dist/tf-layers.min.js",
   "devDependencies": {
-    "@tensorflow/tfjs-core": "~0.12.8",
+    "@tensorflow/tfjs-core": "~0.12.10",
     "@types/jasmine": "~2.5.53",
     "clang-format": "~1.2.2",
     "http-server": "~0.10.0",
@@ -45,6 +45,6 @@
     "lint": "tslint -p . -t verbose"
   },
   "peerDependencies": {
-    "@tensorflow/tfjs-core": "~0.12.8"
+    "@tensorflow/tfjs-core": "~0.12.10"
   }
 }

--- a/src/utils/math_utils_test.ts
+++ b/src/utils/math_utils_test.ts
@@ -12,7 +12,7 @@
  * Unit tests for math_utils.
  */
 
-import {expectArraysClose} from '@tensorflow/tfjs-core/dist/test_util';
+import * as tfc from '@tensorflow/tfjs-core';
 
 import * as math_utils from './math_utils';
 import {describeMathCPU} from './test_utils';
@@ -121,7 +121,7 @@ describeMathCPU('median', () => {
   it('does not mutate input array', () => {
     const numbers = [-100, -200, 150, 50];
     math_utils.median(numbers);
-    expectArraysClose(numbers, [-100, -200, 150, 50]);
+    tfc.test_util.expectArraysClose(numbers, [-100, -200, 150, 50]);
   });
 });
 

--- a/src/variables_test.ts
+++ b/src/variables_test.ts
@@ -333,8 +333,9 @@ describeMathCPUAndGPU('OnesLike', () => {
 });
 
 describeMathCPUAndGPU('eye (I-matrix builder)', () => {
-  it('Variable Zero sized 2D matrix', () => {
-    expect(() => V.eyeVariable(0)).toThrowError(/Shapes can not be <= 0./);
+  it('Variable Zero sized 2D matrix works', () => {
+    const v = V.eyeVariable(0);
+    expect(v.shape).toEqual([0, 0]);
   });
   it('Variable 1 sized 2D matrix', () => {
     const I = V.eyeVariable(1);

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,5 +1,5 @@
 /** @license See the LICENSE file. */
 
 // This code is auto-generated, do not modify this file!
-const version = '0.7.2';
+const version = '0.7.3';
 export {version};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@tensorflow/tfjs-core@~0.12.8":
-  version "0.12.8"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.12.8.tgz#d7bb5fb17da080374a4918aa5cd423378c0cdc0c"
+"@tensorflow/tfjs-core@~0.12.10":
+  version "0.12.10"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.12.10.tgz#8c13b787ea22e085090b1cacb652ad96ae38b74d"
   dependencies:
     "@types/seedrandom" "~2.4.27"
     "@types/webgl-ext" "~0.0.29"


### PR DESCRIPTION
Depend on tfjs-core 0.12.10

Also in this PR: Update a test related to 0-sizes 2D tensors, which used to be forbidden, but now is allowed, due to changes in tfjs-core.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/284)
<!-- Reviewable:end -->
