### PR TITLE
Add test and guard for circular model weight assignment.

### DIFF
--- a/src/engine/training_test.ts
+++ b/src/engine/training_test.ts
@@ -1086,6 +1086,36 @@ describeMathCPUAndGPU('Model.fit', () => {
         });
   });
 
+  it('and then set weights to new weights', async done => {
+    createDenseModelAndData(false, 'l1l2');
+    model.compile({optimizer: 'SGD', loss: 'meanSquaredError'});
+    model.fit(inputs, targets, {batchSize: numSamples, epochs: 2})
+        .then(history => {
+          const w = zeros([4, 1]);
+          model.layers[1].setWeights([w]);
+          expectTensorsClose(model.layers[1].getWeights()[0], w);
+          done();
+        })
+        .catch(err => {
+          done.fail(err.stack);
+        });
+  });
+
+  it('and then set weights to own weights', async done => {
+    createDenseModelAndData(false, 'l1l2');
+    model.compile({optimizer: 'SGD', loss: 'meanSquaredError'});
+    model.fit(inputs, targets, {batchSize: numSamples, epochs: 2})
+        .then(history => {
+          const w = model.layers[1].getWeights()[0];
+          model.layers[1].setWeights([w]);
+          expectTensorsClose(model.layers[1].getWeights()[0], w);
+          done();
+        })
+        .catch(err => {
+          done.fail(err.stack);
+        });
+  });
+
   class StopAfterNEpochs extends tfl.Callback {
     private readonly epochsToTrain: number;
     constructor(epochsToTrain: number) {

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -94,7 +94,10 @@ export class LayerVariable {
     // TODO(cais): Once  TF.js Core supports Tensor.dtype, check dtype match.
     this.assertNotDisposed();
     checkShapesMatch(this.val, newVal);
-    this.val.assign(newVal);
+    // Skip updating if this is the exact same tensor.
+    if (this.val.id !== newVal.id) {
+      this.val.assign(newVal);
+    }
     if (this.constraint != null) {
       this.val.assign(this.constraint.apply(this.val));
     }

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -97,9 +97,9 @@ export class LayerVariable {
     // Skip updating if this is the exact same tensor.
     if (this.val.id !== newVal.id) {
       this.val.assign(newVal);
-    }
-    if (this.constraint != null) {
-      this.val.assign(this.constraint.apply(this.val));
+      if (this.constraint != null) {
+        this.val.assign(this.constraint.apply(this.val));
+      }
     }
     return this;
   }


### PR DESCRIPTION
#### Description
Fixes tfjs#465 "Manually setting weights for mode" in the case of setting weights to weights the model already owns.  Previously the TFJS infrastructure was discarding needed weights.

Adds unit tests covering the behavior (fit model, assign weights to weights the model already owns, check the weights).

---
##### For repository owners only:

BUG: fixes tfjs-union#465

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/285)
<!-- Reviewable:end -->
