### PR TITLE
Two improvements to Model.fit()

### DIFF
--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -1473,7 +1473,6 @@ export class Model extends Container implements tfc.InferenceModel {
       }
       // TODO(cais): Run validation at the end of the epoch.
       await callbackList.onEpochEnd(epoch, epochLogs);
-      console.log(`Checking: stopTraining = ${this.stopTraining_}`);  // DEBUG
       if (this.stopTraining_) {
         break;
       }
@@ -1862,9 +1861,37 @@ export class Model extends Container implements tfc.InferenceModel {
     return namedWeights;
   }
 
+  /**
+   * Setter used for force stopping of Model.fit() (i.e., training).
+   *
+   * Example:
+   *
+   * ```js
+   * const input = tf.input({shape: [10]});
+   * const output = tf.layers.dense({units: 1}).apply(input);
+   * const model = tf.model({inputs: [input], outputs: [output]});
+   * model.compile({loss: 'meanSquaredError', optimizer: 'sgd'});
+   * const xs = tf.ones([8, 10]);
+   * const ys = tf.zeros([8, 1]);
+   *
+   * const history = await model.fit(xs, ys, {
+   *   epochs: 10,
+   *   callbacks: {
+   *     onEpochEnd: async (epoch, logs) => {
+   *       if (epoch === 2) {
+   *         model.stopTraining = true;
+   *       }
+   *     }
+   *   }
+   * });
+   *
+   * // There should be only 3 values in the loss array, instead of 10 values,
+   * // due to the stopping after 3 epochs.
+   * console.log(history.history.loss);
+   * ```
+   */
   set stopTraining(stop: boolean) {
     this.stopTraining_ = stop;
-    console.log(`Setting stopTraining_ to ${this.stopTraining_}`);  // DEBUG
   }
 
   /**

--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -656,7 +656,7 @@ export class Model extends Container implements tfc.InferenceModel {
 
   // A public property that can be set by Callbacks to order early stopping
   // during `fit()` calls.
-  stopTraining: boolean;
+  private stopTraining_: boolean;
   private isTraining: boolean;
 
   metrics: string[]|{[outputName: string]: string};
@@ -1397,7 +1397,7 @@ export class Model extends Container implements tfc.InferenceModel {
       metrics: callbackMetrics,
     });
     await callbackList.onTrainBegin();
-    this.stopTraining = false;
+    this.stopTraining_ = false;
     // TODO(cais): Take care of callbacks.validation_data as in PyKeras.
 
     // TODO(cais): Pre-convert feeds for performance as in PyKeras.
@@ -1463,7 +1463,7 @@ export class Model extends Container implements tfc.InferenceModel {
           await callbackList.onBatchEnd(batchIndex, batchLogs);
           disposeTensorsInLogs(batchLogs);
 
-          if (this.stopTraining) {
+          if (this.stopTraining_) {
             break;
           }
           // TODO(cais): return outs as list of Tensor.
@@ -1473,7 +1473,8 @@ export class Model extends Container implements tfc.InferenceModel {
       }
       // TODO(cais): Run validation at the end of the epoch.
       await callbackList.onEpochEnd(epoch, epochLogs);
-      if (this.stopTraining) {
+      console.log(`Checking: stopTraining = ${this.stopTraining_}`);  // DEBUG
+      if (this.stopTraining_) {
         break;
       }
     }
@@ -1859,6 +1860,11 @@ export class Model extends Container implements tfc.InferenceModel {
       namedWeights[weights[i].originalName] = weightValues[i];
     }
     return namedWeights;
+  }
+
+  set stopTraining(stop: boolean) {
+    this.stopTraining_ = stop;
+    console.log(`Setting stopTraining_ to ${this.stopTraining_}`);  // DEBUG
   }
 
   /**

--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -653,7 +653,6 @@ export class Model extends Container implements tfc.InferenceModel {
   private testFunction: (data: Tensor[]) => Scalar[];
   history: History;
 
-
   // A public property that can be set by Callbacks to order early stopping
   // during `fit()` calls.
   private stopTraining_: boolean;

--- a/src/engine/training_test.ts
+++ b/src/engine/training_test.ts
@@ -1201,29 +1201,27 @@ describeMathCPUAndGPU('Model.fit', () => {
         .catch(err => done.fail(err.stack));
   });
 
-  fit('Stop training using non-class object callback function', async () => {
-    console.log('==== BEGIN ====');  // DEBUG
+  it('Stop Model.fit() using non-class object callback function', async () => {
     createDenseModelAndData();
 
     model.compile({optimizer: 'SGD', loss: 'meanSquaredError'});
-    // Use batchSize === numSamples to get exactly one batch.
 
     let numEpochsDone = 0;
-    await model.fit(inputs, targets, {
-      epochs: 8,
+    const epochs = 8;
+    const stopAfterEpoch = 3;
+    const history = await model.fit(inputs, targets, {
+      epochs,
       callbacks: {
         onEpochEnd: async (epoch, logs) => {
-          console.log(`epoch: ${epoch}`);  // DEBUG
           numEpochsDone++;
-          console.log(`numEpochsDone = ${numEpochsDone}`);  // DEBUG
-          if (epoch === 3) {
+          if (epoch === stopAfterEpoch) {
             model.stopTraining = true;
           }
         }
       }
     });
-    expect(numEpochsDone).toEqual(3);
-    console.log('==== END ====');  // DEBUG
+    expect(numEpochsDone).toEqual(stopAfterEpoch + 1);
+    expect(history.history.loss.length).toEqual(stopAfterEpoch + 1);
   });
 
   it('Invalid dict loss: nonexistent output name', () => {

--- a/src/engine/training_test.ts
+++ b/src/engine/training_test.ts
@@ -1209,7 +1209,7 @@ describeMathCPUAndGPU('Model.fit', () => {
     let numEpochsDone = 0;
     const epochs = 8;
     const stopAfterEpoch = 3;
-    const history = await model.fit(inputs, targets, {
+    let history = await model.fit(inputs, targets, {
       epochs,
       callbacks: {
         onEpochEnd: async (epoch, logs) => {
@@ -1222,6 +1222,10 @@ describeMathCPUAndGPU('Model.fit', () => {
     });
     expect(numEpochsDone).toEqual(stopAfterEpoch + 1);
     expect(history.history.loss.length).toEqual(stopAfterEpoch + 1);
+
+    // Check that model.fit can still be called after force stopping.
+    history = await model.fit(inputs, targets, {epochs: 2});
+    expect(history.history.loss.length).toEqual(2);
   });
 
   it('Invalid dict loss: nonexistent output name', () => {

--- a/src/models.ts
+++ b/src/models.ts
@@ -754,6 +754,40 @@ export class Sequential extends Model {
     return model;
   }
 
+  /**
+   * Setter used for force stopping of Model.fit() (i.e., training).
+   *
+   * Example:
+   *
+   * ```js
+   * const model = tf.sequential();
+   * model.add(tf.layers.dense({units: 1, inputShape: [10]}));
+   * model.compile({loss: 'meanSquaredError', optimizer: 'sgd'});
+   * const xs = tf.ones([8, 10]);
+   * const ys = tf.zeros([8, 1]);
+   *
+   * const history = await model.fit(xs, ys, {
+   *   epochs: 10,
+   *   callbacks: {
+   *     onEpochEnd: async (epoch, logs) => {
+   *       if (epoch === 2) {
+   *         model.stopTraining = true;
+   *       }
+   *     }
+   *   }
+   * });
+   *
+   * // There should be only 3 values in the loss array, instead of 10 values,
+   * // due to the stopping after 3 epochs.
+   * console.log(history.history.loss);
+   * ```
+   */
+  set stopTraining(stop: boolean) {
+    // TODO(cais): When refactoring to remove the composition pattern happens,
+    // remove this method overriding.
+    this.model.stopTraining = stop;
+  }
+
   // TODO(cais): Override get trainableWeights() here
 
   // tslint:disable-next-line:no-any

--- a/src/models_test.ts
+++ b/src/models_test.ts
@@ -1204,14 +1204,8 @@ describeMathCPUAndGPU('Sequential', () => {
     const inputSize = 4;
     const xs = ones([batchSize, inputSize]);
     const ys = ones([batchSize, 1]);
-    const denseLayer1 = tfl.layers.dense({
-      units: 3,
-      useBias: false,
-      kernelInitializer: 'ones',
-      inputShape: [inputSize]
-    });
-    const denseLayer2 =
-        tfl.layers.dense({units: 1, useBias: false, kernelInitializer: 'ones'});
+    const denseLayer1 = tfl.layers.dense({units: 3, inputShape: [inputSize]});
+    const denseLayer2 = tfl.layers.dense({units: 1});
     const model = tfl.sequential({layers: [denseLayer1, denseLayer2]});
     model.compile({optimizer: 'sgd', loss: 'meanSquaredError'});
     // Do not call `await` below, so the two fit() calls may interleave.
@@ -1233,14 +1227,8 @@ describeMathCPUAndGPU('Sequential', () => {
     const inputSize = 4;
     const xs = ones([batchSize, inputSize]);
     const ys = ones([batchSize, 1]);
-    const denseLayer1 = tfl.layers.dense({
-      units: 3,
-      useBias: false,
-      kernelInitializer: 'ones',
-      inputShape: [inputSize]
-    });
-    const denseLayer2 =
-        tfl.layers.dense({units: 1, useBias: false, kernelInitializer: 'ones'});
+    const denseLayer1 = tfl.layers.dense({units: 3, inputShape: [inputSize]});
+    const denseLayer2 = tfl.layers.dense({units: 1});
     const model = tfl.sequential({layers: [denseLayer1, denseLayer2]});
     model.compile({optimizer: 'sgd', loss: 'meanSquaredError'});
 

--- a/src/models_test.ts
+++ b/src/models_test.ts
@@ -17,7 +17,7 @@ import {deserialize} from './layers/serialization';
 import {loadModelInternal, ModelAndWeightsConfig, modelFromJSON} from './models';
 import {JsonDict} from './types';
 import {convertPythonicToTs} from './utils/serialization_utils';
-import {describeMathCPU, expectTensorsClose, describeMathCPUAndGPU} from './utils/test_utils';
+import {describeMathCPU, describeMathCPUAndGPU, expectTensorsClose} from './utils/test_utils';
 import {version as layersVersion} from './version';
 
 
@@ -214,8 +214,7 @@ describeMathCPU('Nested model topology', () => {
     const outerModel = tfl.sequential({
       layers: [
         innerModel,
-        tfl.layers.dense(
-            {units: 1, kernelInitializer: 'zeros', useBias: false})
+        tfl.layers.dense({units: 1, kernelInitializer: 'zeros', useBias: false})
       ]
     });
 
@@ -766,11 +765,9 @@ describeMathCPU('loadModel from URL', () => {
          const weightsManifest: io.WeightsManifestConfig = [
            {
              'paths': ['weight_0'],
-             'weights': [{
-               'name': `dense_6/kernel`,
-               'dtype': 'float32',
-               'shape': [32, 32]
-             }],
+             'weights': [
+               {'name': `dense_6/kernel`, 'dtype': 'float32', 'shape': [32, 32]}
+             ],
            },
            {
              'paths': ['weight_1'],
@@ -1147,8 +1144,8 @@ describeMathCPUAndGPU('Sequential', () => {
   for (const dtype of dtypes) {
     it(`predict() works with input dtype ${dtype}.`, () => {
       const embModel = tfl.sequential();
-      embModel.add(tfl.layers.embedding(
-        {inputShape: [1], inputDim: 10, outputDim: 2}));
+      embModel.add(
+          tfl.layers.embedding({inputShape: [1], inputDim: 10, outputDim: 2}));
       const x = tensor2d([[0], [0], [1]], [3, 1], dtype as DataType);
       const y = embModel.predict(x) as Tensor;
       expect(y.dtype).toBe('float32');
@@ -1156,12 +1153,12 @@ describeMathCPUAndGPU('Sequential', () => {
 
     it(`fit() works with input dtype ${dtype}.`, () => {
       const embModel = tfl.sequential();
-      embModel.add(tfl.layers.embedding(
-        {inputShape: [1], inputDim: 10, outputDim: 2}));
-        embModel.compile({optimizer: 'sgd', loss: 'meanSquaredError'});
-        const x = tensor2d([[0]], [1, 1], dtype as DataType);
-        const y = tensor2d([[0.5, 0.5]], [1, 2], 'float32');
-        embModel.fit(x, y);
+      embModel.add(
+          tfl.layers.embedding({inputShape: [1], inputDim: 10, outputDim: 2}));
+      embModel.compile({optimizer: 'sgd', loss: 'meanSquaredError'});
+      const x = tensor2d([[0]], [1, 1], dtype as DataType);
+      const y = tensor2d([[0.5, 0.5]], [1, 2], 'float32');
+      embModel.fit(x, y);
     });
   }
 
@@ -1200,6 +1197,35 @@ describeMathCPUAndGPU('Sequential', () => {
     const history = await model.fit(xs, ys, {batchSize, epochs: 2});
     expect(history.history['loss'][0]).toBe(121);
     expect(history.history['loss'][1]).toBeCloseTo(0.015178224071860313);
+  });
+
+  it('calling fit twice in a row leads to error', async () => {
+    const batchSize = 5;
+    const inputSize = 4;
+    const xs = ones([batchSize, inputSize]);
+    const ys = ones([batchSize, 1]);
+    const denseLayer1 = tfl.layers.dense({
+      units: 3,
+      useBias: false,
+      kernelInitializer: 'ones',
+      inputShape: [inputSize]
+    });
+    const denseLayer2 =
+        tfl.layers.dense({units: 1, useBias: false, kernelInitializer: 'ones'});
+    const model = tfl.sequential({layers: [denseLayer1, denseLayer2]});
+    model.compile({optimizer: 'sgd', loss: 'meanSquaredError'});
+    // Do not call `await` below, so the two fit() calls may interleave.
+    model.fit(xs, ys, {batchSize, epochs: 8});
+
+    let errorCaught: Error;
+    try {
+      await model.fit(xs, ys);
+    } catch (err) {
+      errorCaught = err;
+    }
+    expect(errorCaught.message)
+        .toEqual(
+            'Cannot start training because another fit() call is ongoing.');
   });
 
   it('Calling evaluate before compile leads to error', () => {


### PR DESCRIPTION
FEATURE

1. Make Model.fit() (including Sequential.fit()) is called with another fit() call ongoing, an error
    will immediately be thrown.
2. Make force stopping of fit() calls through `stopTraining = true` work from not only class objects,
    but also non-class object function callbacks.

Also:
- Add doc string and code snippet to the stopTraining setters.

Fixes: https://github.com/tensorflow/tfjs/issues/558

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/288)
<!-- Reviewable:end -->
