### PR TITLE
Optimize `Add`, `Multiply` and `Average` layers

### DIFF
--- a/src/engine/executor.ts
+++ b/src/engine/executor.ts
@@ -176,37 +176,72 @@ export function execute(
 }
 
 function executeInternal(
-    fetch: SymbolicTensor, internalFeedDict: FeedDict,
-    kwargs?: Kwargs): Tensor {
-  if (internalFeedDict.hasKey(fetch)) {
-    return internalFeedDict.getValue(fetch);
+    fetch: SymbolicTensor, feedDict: FeedDict, kwargs?: Kwargs): Tensor {
+  if (feedDict.hasKey(fetch)) {
+    return feedDict.getValue(fetch);
   }
-  if (fetch.sourceLayer instanceof InputLayer) {
-    throw new ValueError(
-        `Missing a feed value for SymbolicTensor from InputLayer ` +
-        `'${InputLayer.name}'`);
+  const queue: SymbolicTensor[] = [fetch];
+  // The queue only holds unseen tensors.
+  const seen = new Set<number>();
+  let idx = 0;
+
+  const start: SymbolicTensor[] = [];
+  while (idx < queue.length) {
+    const t = queue[idx++];
+    seen.add(t.id);
+    t.inputs.forEach(input => {
+      if (!feedDict.hasKey(input)) {
+        if (input.sourceLayer instanceof InputLayer) {
+          throw new ValueError(
+              `Missing a feed value for SymbolicTensor from InputLayer ` +
+              `'${InputLayer.name}'`);
+        }
+        // Nodes in the queue are guaranteed to be unseen.
+        if (!seen.has(input.id)) {
+          queue.push(input);
+        }
+      } else if (!seen.has(input.id)) {
+        start.push(input);
+      }
+    });
   }
 
-  const inputs = fetch.inputs;
-  const inputValues: Tensor[] = [];
-  for (const input of inputs) {
-    // Recursive call.
-    const inputVal = executeInternal(input, internalFeedDict, kwargs) as Tensor;
-    inputValues.push(inputVal);
+  idx = 0;
+  const seenForward = new Set<number>();
+  while (idx < start.length) {
+    const t = start[idx++];
+    seenForward.add(t.id);
+    const outputs: SymbolicTensor[] = [];
+    t.sourceLayer.outboundNodes.forEach(
+        node => outputs.push(...node.outputTensors));
+    outputs.forEach(out => {
+      // Nodes in the queue are guaranteed to be unseen on the forward queue
+      // and seen in the backwards queue.
+      if (seen.has(out.id) && !seenForward.has(out.id)) {
+        start.push(out);
+      }
+    });
   }
 
-  let output =
-      fetch.sourceLayer.apply(inputValues, kwargs) as Tensor | Tensor[];
-  if (!Array.isArray(output)) {
-    output = [output];
+  let outVals: Tensor[] = null;
+  for (let i = 0; i < start.length; ++i) {
+    const t = start[i];
+    if (t.sourceLayer instanceof InputLayer) {
+      outVals = [feedDict.getValue(t)];
+      continue;
+    }
+    const inVals = t.inputs.map(input => feedDict.getValue(input));
+    outVals = t.sourceLayer.apply(inVals, kwargs) as Tensor[];
+    if (!Array.isArray(outVals)) {
+      outVals = [outVals];
+    }
+    let outputs = getNodeOutputs(t);
+    if (!Array.isArray(outputs)) {
+      outputs = [outputs];
+    }
+    outputs.forEach((out, i) => feedDict.add(out, outVals[i]));
   }
-  const layerOutputs = getNodeOutputs(fetch);
-  const outputSymbolicTensors =
-      Array.isArray(layerOutputs) ? layerOutputs : [layerOutputs];
-  for (let i = 0; i < outputSymbolicTensors.length; ++i) {
-    internalFeedDict.add(outputSymbolicTensors[i], output[i]);
-  }
-  return output.length === 1 ? output[0] : output[fetch.outputTensorIndex];
+  return outVals.length === 1 ? outVals[0] : outVals[fetch.outputTensorIndex];
 }
 
 /**

--- a/src/layers/merge.ts
+++ b/src/layers/merge.ts
@@ -15,9 +15,9 @@
 import * as tfc from '@tensorflow/tfjs-core';
 import {serialization, Tensor, tidy, util} from '@tensorflow/tfjs-core';
 
+import {getScalar} from '../backend/state';
 import * as K from '../backend/tfjs_backend';
 import {Layer, LayerConfig, SymbolicTensor} from '../engine/topology';
-import {getScalar} from '../backend/state';
 import {NotImplementedError, ValueError} from '../errors';
 import {Kwargs, Shape} from '../types';
 import * as generic_utils from '../utils/generic_utils';
@@ -256,9 +256,9 @@ export class Add extends Merge {
 
   protected mergeFunction(inputs: Tensor[]): Tensor {
     return tidy(() => {
-      let output = tfc.zeros(inputs[0].shape);
-      for (const input of inputs) {
-        output = tfc.add(output, input);
+      let output = inputs[0].clone();
+      for (let i = 1; i < inputs.length; ++i) {
+        output = tfc.add(output, inputs[i]);
       }
       return output;
     });
@@ -348,9 +348,9 @@ export class Multiply extends Merge {
 
   protected mergeFunction(inputs: Tensor[]): Tensor {
     return tidy(() => {
-      let output = tfc.ones(inputs[0].shape);
-      for (const input of inputs) {
-        output = tfc.mul(output, input);
+      let output = inputs[0].clone();
+      for (let i = 1; i < inputs.length; ++i) {
+        output = tfc.mul(output, inputs[i]);
       }
       return output;
     });
@@ -439,9 +439,9 @@ export class Average extends Merge {
 
   protected mergeFunction(inputs: Tensor[]): Tensor {
     return tidy(() => {
-      let output = tfc.zeros(inputs[0].shape);
-      for (const input of inputs) {
-        output = tfc.add(output, input);
+      let output = inputs[0].clone();
+      for (let i = 1; i < inputs.length; ++i) {
+        output = tfc.add(output, inputs[i]);
       }
       return tfc.mul(getScalar(1 / inputs.length), output);
     });


### PR DESCRIPTION
Profiling a real model revealed that `Add`, `Multiply` and `Average` layers were allocating a zero/ones tensor for the initial value, on the cpu. This causes unnecessary uploads to the gpu and one extra shader call.

This PR removes that initial value and treats the first tensor in the list as the initial value.

PERF

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/293)
<!-- Reviewable:end -->
