### PR TITLE
Add printout to the code snippet for tf.loadModel

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -172,7 +172,8 @@ export interface ModelPredictConfig {
  *
  * ```js
  * const model = await
- *     tf.loadModel('https://storage.googleapis.com/tfjs-models/tfjs/iris_v1/model.json')
+ *     tf.loadModel('https://storage.googleapis.com/tfjs-models/tfjs/iris_v1/model.json');
+ * model.summary();
  * ```
  *
  * @param pathOrIOHandler Can be either of the two formats


### PR DESCRIPTION
Currently, the code snippet at the js.tensorflow.org website doesn't print anything to the console, which is confusing (see https://js.tensorflow.org/api/0.12.5/#loadModel). This PR fixes it by printing the model summary after the model is loaded.

DOC


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/301)
<!-- Reviewable:end -->
