### PR TITLE
Add sanity check on batchSize in Model evaluate, fit & predict

### DIFF
--- a/src/engine/training_test.ts
+++ b/src/engine/training_test.ts
@@ -311,6 +311,25 @@ describeMathCPUAndGPU('Model.predict', () => {
     expect(() => model.predict(xs1))
         .toThrowError(/.*expected.* shape \[null,3,4\].*but got.*\[2,4,3\]/);
   });
+
+  it('Invalid batchSize value leads to Error', () => {
+    const model = tfl.sequential(
+        {layers: [tfl.layers.dense({units: 1, inputShape: [2]})]});
+    const xs = tfc.zeros([5, 2]);
+    expect(() => model.predict(xs, {batchSize: 0}))
+        .toThrowError(
+            /batchSize is required to be a positive integer, but got 0/);
+    expect(() => model.predict(xs, {batchSize: -2}))
+        .toThrowError(
+            /batchSize is required to be a positive integer, but got -2/);
+    expect(() => model.predict(xs, {batchSize: 3.14}))
+        .toThrowError(
+            /batchSize is required to be a positive integer, but got 3\.14/);
+    // tslint:disable-next-line:no-any
+    expect(() => model.predict(xs, {batchSize: 'a' as any}))
+        .toThrowError(
+            /batchSize is required to be a positive integer, but got a/);
+  });
 });
 
 describeMathCPUAndGPU('Model.fit', () => {
@@ -610,7 +629,8 @@ describeMathCPUAndGPU('Model.fit', () => {
            .fit(inputs, targets, {
              batchSize: numSamples,
              epochs: 2,
-             validationData: [zeros(inputs.shape as [number, number]), targets]
+             validationData:
+                 [zeros(inputs.shape as [number, number]), targets]
            })
            .then(history => {
              expect(history.epoch).toEqual([0, 1]);
@@ -1178,8 +1198,8 @@ describeMathCPUAndGPU('Model.fit', () => {
     });
     expect(recordedParams[0].epochs).toEqual(epochs);
     expect(recordedParams[0].initialEpoch).toEqual(0);
-    expect(recordedParams[0].samples).toEqual(
-        Math.round(inputs.shape[0] * (1 - validationSplit)));
+    expect(recordedParams[0].samples)
+        .toEqual(Math.round(inputs.shape[0] * (1 - validationSplit)));
     expect(recordedParams[0].steps).toEqual(null);
     expect(recordedParams[0].batchSize).toEqual(batchSize);
     expect(recordedParams[0].doValidation).toEqual(true);
@@ -1305,6 +1325,23 @@ describeMathCPUAndGPU('Model.fit', () => {
     fitPromise.catch(error => {
       expect(error.message).toContain('You must compile a model before');
     });
+  });
+
+  it('Invalid batchSize leads to Error', async () => {
+    createDenseModelAndData();
+    const badBatchSizeValues: Array<number|string> = [0, -1, 3.14, 'a'];
+    for (const batchSize of badBatchSizeValues) {
+      let errorCaught: Error;
+      try {
+        // tslint:disable-next-line:no-any
+        await model.fit(inputs, targets, {batchSize: batchSize as any});
+      } catch (err) {
+        errorCaught = err;
+      }
+      expect(errorCaught.message)
+          .toEqual(`batchSize is required to be a positive integer, but got ${
+              batchSize}`);
+    }
   });
 });
 
@@ -2010,6 +2047,24 @@ describeMathCPUAndGPU('Model.evaluate', () => {
       });
     }
   }
+
+  it('Invalid batchSize value leads to Error', () => {
+    prepModel();
+    prepData();
+    expect(() => model.evaluate(x, y, {batchSize: 0}))
+        .toThrowError(
+            /batchSize is required to be a positive integer, but got 0/);
+    expect(() => model.evaluate(x, y, {batchSize: -2}))
+        .toThrowError(
+            /batchSize is required to be a positive integer, but got -2/);
+    expect(() => model.evaluate(x, y, {batchSize: 3.14}))
+        .toThrowError(
+            /batchSize is required to be a positive integer, but got 3\.14/);
+    // tslint:disable-next-line:no-any
+    expect(() => model.evaluate(x, y, {batchSize: 'a' as any}))
+        .toThrowError(
+            /batchSize is required to be a positive integer, but got a/);
+  });
 });
 
 describeMathCPUAndGPU('Load weights', () => {


### PR DESCRIPTION
Also fix a bug in Model.fit(), in which if the method call
errors out early on, the Model.isTraining bit is not flipped
back to false.

Fixes: https://github.com/tensorflow/tfjs/issues/641

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/302)
<!-- Reviewable:end -->
