### PR TITLE
reset_states() -> resetStates() in inline documentation

### DIFF
--- a/src/layers/recurrent.ts
+++ b/src/layers/recurrent.ts
@@ -355,7 +355,7 @@ export interface RNNLayerConfig extends BaseRNNLayerConfig {
  *       It should be a tuple of integers, e.g. `(32, 10, 100)`.
  *     - specify `shuffle=False` when calling fit().
  *
- *   To reset the states of your model, call `.reset_states()` on either
+ *   To reset the states of your model, call `.resetStates()` on either
  *   a specific layer, or on your entire model.
  *
  * Note on specifying the initial state of RNNs


### PR DESCRIPTION
#### Description

Fix incorrect method name for `resetStates()` in inline docs likely left over from python migration. This documentation shows up in the latest version of the official API docs [here](https://js.tensorflow.org/api/0.12.5/#layers.rnn). I was banging my head against the wall for a while after reading those docs with a `TypeError: model.reset_states is not a function` before realizing the method had been renamed to fit the JavaScript naming convention. Thanks again for the recent addition of stateful RNNs @caisq :clap:!

DOC

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/306)
<!-- Reviewable:end -->
