### PR TITLE
Clarifies error message for tf.losses.softmaxCrossEntropy as string

### DIFF
--- a/src/losses.ts
+++ b/src/losses.ts
@@ -13,8 +13,8 @@ import * as tfc from '@tensorflow/tfjs-core';
 import {scalar, Tensor, Tensor1D, tidy} from '@tensorflow/tfjs-core';
 
 import {epsilon} from './backend/common';
-import * as K from './backend/tfjs_backend';
 import {getScalar} from './backend/state';
+import * as K from './backend/tfjs_backend';
 import {ValueError} from './errors';
 import {LossOrMetricFn} from './types';
 
@@ -338,7 +338,13 @@ export function get(identifierOrFn: string|LossOrMetricFn): LossOrMetricFn {
     if (identifierOrFn in lossesMap) {
       return lossesMap[identifierOrFn];
     }
-    throw new ValueError(`Unknown loss ${identifierOrFn}`);
+    let errMsg = `Unknown loss ${identifierOrFn}`;
+    if (identifierOrFn.toLowerCase().includes('softmaxcrossentropy')) {
+      errMsg = `Unknown loss ${identifierOrFn}. ` +
+          'Use "categoricalCrossentropy" as the string name for ' +
+          'tf.losses.softmaxCrossEntropy';
+    }
+    throw new ValueError(errMsg);
   } else {
     return identifierOrFn;
   }


### PR DESCRIPTION
#### Description
FEATURE : Minor error message improvement for a confusing tf.losses case.  softmaxCrossEntropy is known as "categoricalCrossentropy"

---
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/307)
<!-- Reviewable:end -->
