### PR TITLE
Allow tf.layers.batchNormalization() to take no arg

### DIFF
--- a/integration_tests/tfjs2keras/package.json
+++ b/integration_tests/tfjs2keras/package.json
@@ -4,7 +4,7 @@
   "description": "Testing sending models from tfjs-layers to Keras",
   "private": false,
   "dependencies": {
-    "@tensorflow/tfjs-core": "~0.12.15",
+    "@tensorflow/tfjs-core": "0.12.15",
     "@tensorflow/tfjs-layers": "*",
     "@tensorflow/tfjs-node": "~0.1.13",
     "clang-format": "~1.2.2",

--- a/integration_tests/tfjs2keras/yarn.lock
+++ b/integration_tests/tfjs2keras/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@tensorflow/tfjs-core@~0.12.14":
-  version "0.12.14"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.12.14.tgz#cb7ab5e2fe5bc548a3ace9f8803546b18ad48b8a"
+"@tensorflow/tfjs-core@0.12.15":
+  version "0.12.15"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.12.15.tgz#b6c09dfe99cffd298745a694347b29a2c5aa9871"
   dependencies:
     "@types/seedrandom" "~2.4.27"
     "@types/webgl-ext" "~0.0.29"

--- a/src/exports_layers.ts
+++ b/src/exports_layers.ts
@@ -403,7 +403,7 @@ export function multiply(config?: LayerConfig): Layer {
  *   configParamIndices: [0]
  * }
  */
-export function batchNormalization(config: BatchNormalizationLayerConfig):
+export function batchNormalization(config?: BatchNormalizationLayerConfig):
     Layer {
   return new BatchNormalization(config);
 }

--- a/src/layers/normalization.ts
+++ b/src/layers/normalization.ts
@@ -292,8 +292,12 @@ export class BatchNormalization extends Layer {
   private movingVariance: LayerVariable;
   private stepCount: number;
 
-  constructor(config: BatchNormalizationLayerConfig) {
+  constructor(config?: BatchNormalizationLayerConfig) {
+    if (config == null) {
+      config = {};
+    }
     super(config);
+
     this.supportsMasking = true;
     this.axis = config.axis == null ? -1 : config.axis;
     this.momentum = config.momentum == null ? 0.99 : config.momentum;

--- a/src/layers/normalization_test.ts
+++ b/src/layers/normalization_test.ts
@@ -312,6 +312,11 @@ describeMathCPU('BatchNormalization Layers: Symbolic', () => {
         .toThrowError(
             /Axis 0 of input tensor should have a defined dimension.*/);
   });
+
+  it('batchNormalization constructor works without arg', () => {
+    const layer = tfl.layers.batchNormalization();
+    expect(layer.getConfig().axis).toEqual(-1);
+  });
 });
 
 describeMathCPUAndGPU('BatchNormalization Layers: Tensor', () => {

--- a/src/losses.ts
+++ b/src/losses.ts
@@ -13,8 +13,8 @@ import * as tfc from '@tensorflow/tfjs-core';
 import {scalar, Tensor, Tensor1D, tidy} from '@tensorflow/tfjs-core';
 
 import {epsilon} from './backend/common';
-import * as K from './backend/tfjs_backend';
 import {getScalar} from './backend/state';
+import * as K from './backend/tfjs_backend';
 import {ValueError} from './errors';
 import {LossOrMetricFn} from './types';
 
@@ -338,7 +338,13 @@ export function get(identifierOrFn: string|LossOrMetricFn): LossOrMetricFn {
     if (identifierOrFn in lossesMap) {
       return lossesMap[identifierOrFn];
     }
-    throw new ValueError(`Unknown loss ${identifierOrFn}`);
+    let errMsg = `Unknown loss ${identifierOrFn}`;
+    if (identifierOrFn.toLowerCase().includes('softmaxcrossentropy')) {
+      errMsg = `Unknown loss ${identifierOrFn}. ` +
+          'Use "categoricalCrossentropy" as the string name for ' +
+          'tf.losses.softmaxCrossEntropy';
+    }
+    throw new ValueError(errMsg);
   } else {
     return identifierOrFn;
   }


### PR DESCRIPTION
Previously an explicitly arg (e.g., even it is just `{}`) is always
required. This PR relaxes that.

BUG

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/308)
<!-- Reviewable:end -->
