### PR TITLE
Improve publish-npm script

### DIFF
--- a/scripts/publish-npm.sh
+++ b/scripts/publish-npm.sh
@@ -32,6 +32,6 @@ fi
 
 yarn build-npm
 ./scripts/make-version # This is for safety in case you forgot to do 2).
-npm publish
 ./scripts/tag-version
+npm publish
 echo 'Yay! Published a new package to npm.'


### PR DESCRIPTION
Don't publish to npm if git tagging fails. This protects us from being in an invalid state (published to npm , but not tagged)

DEV

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/313)
<!-- Reviewable:end -->
