### PR TITLE
fix: Cropping2D gives wrong output shape with non-square tensor

### DIFF
--- a/src/layers/convolutional.ts
+++ b/src/layers/convolutional.ts
@@ -1122,15 +1122,17 @@ export class Cropping2D extends Layer {
   computeOutputShape(inputShape: Shape): Shape {
     if (this.dataFormat === 'channelsFirst')
       return [
-        inputShape[0], inputShape[1],
+        inputShape[0],
+        inputShape[1],
         inputShape[2] - this.cropping[0][0] - this.cropping[0][1],
-        inputShape[2] - this.cropping[1][0] - this.cropping[1][1]
+        inputShape[3] - this.cropping[1][0] - this.cropping[1][1]
       ];
     else
       return [
         inputShape[0],
         inputShape[1] - this.cropping[0][0] - this.cropping[0][1],
-        inputShape[2] - this.cropping[1][0] - this.cropping[1][1], inputShape[3]
+        inputShape[2] - this.cropping[1][0] - this.cropping[1][1],
+        inputShape[3]
       ];
   }
 

--- a/src/layers/convolutional_test.ts
+++ b/src/layers/convolutional_test.ts
@@ -968,6 +968,24 @@ describe('Cropping2D Layer', () => {
 
     expectTensorsClose(layer.apply(x, null) as Tensor, y);
   });
+
+  it('check with non-square tensor', () => {
+    const layer = tfl.layers.cropping2D(
+        {cropping: [[1, 1], [1, 1]], dataFormat: 'channelsFirst'});
+    const x = tensor4d(
+        [
+          [[[1, 2, 3, 4], [3, 4, 5, 6], [6, 7, 8, 9]]],
+        ],
+        [1, 1, 3, 4]);
+    const y = tensor4d(
+        [
+          [[[4, 5]]],
+        ],
+        [1, 1, 1, 2]);
+      
+    expect(layer.computeOutputShape(x.shape)).toEqual(y.shape);
+    expectTensorsClose(layer.apply(x, null) as Tensor, y);
+  });
 });
 
 describeMathCPU('UpSampling2D Layer: Symbolic', () => {


### PR DESCRIPTION
#### Description

Small fix for a bug I encountered with the Cropping2D layer, when used with rectangular images.