### PR TITLE
Re-enable tfjs2keras integ test by upgrading tfjs-node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,6 @@ matrix:
       node_js: "8"
       stage: integ
       script:
-        - echo 'yarn test-integ is disabled currently (https://github.com/tensorflow/tfjs/issues/679)'
+        - yarn test-integ
       git:
         depth: 5

--- a/integration_tests/tfjs2keras/package.json
+++ b/integration_tests/tfjs2keras/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@tensorflow/tfjs-core": "0.12.18",
     "@tensorflow/tfjs-layers": "*",
-    "@tensorflow/tfjs-node": "0.1.14",
+    "@tensorflow/tfjs-node": "0.1.15",
     "clang-format": "~1.2.2",
     "tsify": "~3.0.1",
     "tslint": "~5.6.0",

--- a/integration_tests/tfjs2keras/yarn.lock
+++ b/integration_tests/tfjs2keras/yarn.lock
@@ -15,9 +15,9 @@
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-0.7.2.tgz#3a8c083255c72da272245ae5b435c66af9573eb8"
 
-"@tensorflow/tfjs-node@0.1.14":
-  version "0.1.14"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-node/-/tfjs-node-0.1.14.tgz#570c9227e0723f06faf6c43c1ddf349ef418385d"
+"@tensorflow/tfjs-node@0.1.15":
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-node/-/tfjs-node-0.1.15.tgz#f39992b26b7f7da2f0432c8ab3b20c60d1d1db89"
   dependencies:
     adm-zip "^0.4.11"
     bindings "~1.3.0"


### PR DESCRIPTION
from 0.1.14 to 0.1.15

Fixes: https://github.com/tensorflow/tfjs/issues/679

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/319)
<!-- Reviewable:end -->
