### PR TITLE
Metrics: Adds precision to the api

### DIFF
--- a/src/exports_metrics.ts
+++ b/src/exports_metrics.ts
@@ -60,6 +60,17 @@ export function categoricalCrossentropy(yTrue: Tensor, yPred: Tensor): Tensor {
  * @doc {
  *   heading: 'Metrics',
  *   namespace: 'metrics',
+ *   useDocsFrom: 'precision'
+ * }
+ */
+export function precision(yTrue: Tensor, yPred: Tensor): Tensor {
+  return metrics.precision(yTrue, yPred);
+}
+
+/**
+ * @doc {
+ *   heading: 'Metrics',
+ *   namespace: 'metrics',
  *   useDocsFrom: 'cosineProximity'
  * }
  */

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -84,7 +84,7 @@ function truePositives(yTrue: Tensor, yPred: Tensor): Tensor {
   return tidy(() => {
     const one = tfc.scalar(1);
     return K.cast(
-        tfc.logicalAnd(yTrue.equal(one), yPred.equal(one)).sum(), 'float32')
+        tfc.logicalAnd(yTrue.equal(one), yPred.equal(one)).sum(), 'float32');
   });
 }
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -129,16 +129,13 @@ function falsePositives(yTrue: Tensor, yPred: Tensor): Tensor {
  * precision.print();
  * ```
  *
- * @param yTrue The ground truth values. Will be casted to `bool`.
- * @param yPred The predicted values. Will be casted to `bool`.
+ * @param yTrue The ground truth values. Expected to be contain only 0-1 values.
+ * @param yPred The predicted values. Expected to be contain only 0-1 values.
  * @return Precision Tensor.
  */
 export function precision(yTrue: Tensor, yPred: Tensor): Tensor {
   return tidy(() => {
     const zero = getScalar(0);
-
-    yTrue = yTrue.cast('bool');
-    yPred = yPred.cast('bool');
 
     const tp = truePositives(yTrue, yPred);
     const fp = falsePositives(yTrue, yPred);

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -82,19 +82,21 @@ export function categoricalAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
 
 function truePositives(yTrue: Tensor, yPred: Tensor): Tensor {
   return tidy(() => {
-    const one = tfc.scalar(1);
-    return K.cast(
-        tfc.logicalAnd(yTrue.equal(one), yPred.equal(one)).sum(), 'float32');
+    const one = getScalar(1);
+    return tfc.logicalAnd(yTrue.equal(one), yPred.equal(one))
+        .sum()
+        .cast('float32');
   });
 }
 
 
 function falsePositives(yTrue: Tensor, yPred: Tensor): Tensor {
   return tidy(() => {
-    const one = tfc.scalar(1);
-    const zero = tfc.scalar(0);
-    return K.cast(
-        tfc.logicalAnd(yTrue.equal(zero), yPred.equal(one)).sum(), 'float32');
+    const one = getScalar(1);
+    const zero = getScalar(0);
+    return tfc.logicalAnd(yTrue.equal(zero), yPred.equal(one))
+        .sum()
+        .cast('float32');
   });
 }
 
@@ -128,22 +130,21 @@ function falsePositives(yTrue: Tensor, yPred: Tensor): Tensor {
  * ```
  *
  * @param yTrue Binary Tensor of truth: one-hot encoding of categories.
- * @param yPred Binary Tensor of prediction: probabilities or logits for the
- *   same categories as in `yTrue`.
+ * @param yPred Binary Tensor of prediction: one-hot encoding for the same
+ *   categories as in `yTrue`.
  * @return Precision Tensor.
  */
 export function precision(yTrue: Tensor, yPred: Tensor): Tensor {
   return tidy(() => {
-    const zero = tfc.scalar(0);
+    const zero = getScalar(0);
 
     const tp = truePositives(yTrue, yPred);
     const fp = falsePositives(yTrue, yPred);
 
     const denominator = tp.add(fp);
 
-    return K.cast(
-        tfc.where(tfc.greater(denominator, zero), tp.div(denominator), zero),
-        'float32');
+    return tfc.where(tfc.greater(denominator, zero), tp.div(denominator), zero)
+        .cast('float32');
   });
 }
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -129,14 +129,16 @@ function falsePositives(yTrue: Tensor, yPred: Tensor): Tensor {
  * precision.print();
  * ```
  *
- * @param yTrue Binary Tensor of truth: one-hot encoding of categories.
- * @param yPred Binary Tensor of prediction: one-hot encoding for the same
- *   categories as in `yTrue`.
+ * @param yTrue The ground truth values. Will be casted to `bool`.
+ * @param yPred The predicted values. Will be casted to `bool`.
  * @return Precision Tensor.
  */
 export function precision(yTrue: Tensor, yPred: Tensor): Tensor {
   return tidy(() => {
     const zero = getScalar(0);
+
+    yTrue = yTrue.cast('bool');
+    yPred = yPred.cast('bool');
 
     const tp = truePositives(yTrue, yPred);
     const fp = falsePositives(yTrue, yPred);

--- a/src/metrics_test.ts
+++ b/src/metrics_test.ts
@@ -141,6 +141,57 @@ describeMathCPUAndGPU('categoricalCrossentropy metric', () => {
   });
 });
 
+describeMathCPUAndGPU('precision metric', () => {
+  it('1D', () => {
+    const x = tensor1d([0, 0, 0, 1]);
+    const y = tensor1d([0, 0, 0, 1]);
+    const precision = tfl.metrics.precision(x, y);
+    expect(precision.dtype).toEqual('float32');
+    expectTensorsClose(precision, scalar(1));
+  });
+  it('2D', () => {
+    // Use the following Python code to generate the reference values:
+    // ```python
+    //
+    // import tensorflow as tf
+    // import numpy as np
+    //
+    // with tf.Session() as session:
+    // prediction = tf.constant([
+    //   [0, 0, 1],
+    //   [1, 0, 0],
+    //   [1, 0, 0],
+    //   [0, 1, 0]
+    // ])
+    // labels = tf.constant([
+    //   [0, 0, 1],
+    //   [0, 0, 1],
+    //   [1, 0, 0],
+    //   [0, 1, 0]
+    // ])
+    //
+    // output = tf.metrics.precision(
+    //   labels,
+    //   prediction
+    // )
+    //
+    // init = tf.group(
+    //   tf.global_variables_initializer(),
+    //   tf.local_variables_initializer()
+    // )
+    // session.run(init)
+    //
+    // result = session.run(output)
+    // print(result[0])
+    // ```
+    const x = tensor2d([[0, 0, 1], [0, 0, 1], [1, 0, 0], [0, 1, 0]]);
+    const y = tensor2d([[0, 0, 1], [1, 0, 0], [1, 0, 0], [0, 1, 0]]);
+    const precision = tfl.metrics.precision(x, y);
+    expect(precision.dtype).toEqual('float32');
+    expectTensorsClose(precision, scalar(0.75));
+  });
+});
+
 describe('metrics.get', () => {
   it('valid name, not alias', () => {
     expect(get('binaryAccuracy') === get('categoricalAccuracy')).toEqual(false);

--- a/src/metrics_test.ts
+++ b/src/metrics_test.ts
@@ -157,38 +157,43 @@ describeMathCPUAndGPU('precision metric', () => {
     // import numpy as np
     //
     // with tf.Session() as session:
-    // prediction = tf.constant([
-    //   [0, 0, 1],
-    //   [1, 0, 0],
-    //   [1, 0, 0],
-    //   [0, 1, 0]
-    // ])
-    // labels = tf.constant([
-    //   [0, 0, 1],
-    //   [0, 0, 1],
-    //   [1, 0, 0],
-    //   [0, 1, 0]
-    // ])
+    //     labels = tf.constant([
+    //       [0, 0, 1],
+    //       [0, 0, 1],
+    //       [1, 0, 0],
+    //       [0, 1, 0]
+    //     ])
+    //     prediction = tf.constant([
+    //       [0, 0, 1],
+    //       [1, 0, 0],
+    //       [1, 0, 0],
+    //       [0, 1, 0]
+    //     ])
     //
-    // output = tf.metrics.precision(
-    //   labels,
-    //   prediction
-    // )
+    //     output = tf.metrics.precision(
+    //       labels,
+    //       prediction
+    //     )
     //
-    // init = tf.group(
-    //   tf.global_variables_initializer(),
-    //   tf.local_variables_initializer()
-    // )
-    // session.run(init)
+    //     init = tf.local_variables_initializer()
+    //     session.run(init)
     //
-    // result = session.run(output)
-    // print(result[0])
+    //     result = session.run(output)
+    //     print(result[0])
     // ```
     const x = tensor2d([[0, 0, 1], [0, 0, 1], [1, 0, 0], [0, 1, 0]]);
     const y = tensor2d([[0, 0, 1], [1, 0, 0], [1, 0, 0], [0, 1, 0]]);
     const precision = tfl.metrics.precision(x, y);
     expect(precision.dtype).toEqual('float32');
     expectTensorsClose(precision, scalar(0.75));
+  });
+
+  it('2D edge case', () => {
+    const x = tensor2d([[0, 0, 1], [0, 0, 1], [1, 0, 0], [0, 1, 0]]);
+    const y = tensor2d([[0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]]);
+    const precision = tfl.metrics.precision(x, y);
+    expect(precision.dtype).toEqual('float32');
+    expectTensorsClose(precision, scalar(0));
   });
 });
 


### PR DESCRIPTION
#### Description
<!--
Please describe the pull request here.
Also, if this is an issue/bug fix, please add the issue link for reference here.
-->
This PR adds the precision metric to the API. Currently, it doesn't take [weights](https://www.tensorflow.org/api_docs/python/tf/metrics/precision) into account. `truePositives` and `falsePositives` are currently internal operations which can be exposed as well.

---
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/320)
<!-- Reviewable:end -->
