### PR TITLE
Some performance optimization for RNNs

### DIFF
--- a/src/layers/recurrent.ts
+++ b/src/layers/recurrent.ts
@@ -186,7 +186,7 @@ export function rnn(
   for (let t = 0; t < timeSteps; ++t) {
     let currentInput = K.sliceAlongFirstAxis(inputs, t, 1);
     currentInput = currentInput.reshape(currentInput.shape.slice(1));
-    const stepOutputs = stepFunction(currentInput, states);
+    const stepOutputs = tfc.tidy(() => stepFunction(currentInput, states));
     lastOutput = stepOutputs[0];
     if (t === 0) {
       outputs = lastOutput.expandDims(1);
@@ -199,12 +199,7 @@ export function rnn(
     // at the end, once the backend function is available.
     states = stepOutputs[1];
   }
-
-  return [
-    lastOutput,
-    outputs,
-    states
-  ];
+  return [lastOutput, outputs, states];
 }
 
 

--- a/src/layers/recurrent.ts
+++ b/src/layers/recurrent.ts
@@ -118,12 +118,16 @@ export function standardizeArgs(
  * @param constants An Array of constant values passed at each step.
  * @param unroll Whether to unroll the RNN or to use a symbolic loop. *Not*
  *   applicable to this imperative deeplearn.js backend. Its value is ignored.
- * @param inputLength Not relevant in this deeplearn.js backend.
+ * @param needPerStepOutputs Whether the per-step outputs are to be
+ *   concatenated into a single tensor and returned (as the second return
+ *   value). Default: `false`.
  * @returns An Array: `[lastOutput, outputs, newStates]`.
  *   lastOutput: the lastest output of the RNN, of shape `[samples, ...]`.
  *   outputs: tensor with shape `[samples, time, ...]` where each entry
  *     `output[s, t]` is the output of the step function at time `t` for sample
- *     `s`.
+ *     `s`. This return value is provided if and only if the
+ *     `needPerStepOutputs` is set as `true`. If it is set as `false`, this
+ *     return value will be `undefined`.
  *   newStates: Array of tensors, latest states returned by the step function,
  *      of shape `(samples, ...)`.
  * @throws ValueError If input dimension is less than 3.

--- a/src/layers/recurrent.ts
+++ b/src/layers/recurrent.ts
@@ -120,7 +120,10 @@ export function standardizeArgs(
  *   applicable to this imperative deeplearn.js backend. Its value is ignored.
  * @param needPerStepOutputs Whether the per-step outputs are to be
  *   concatenated into a single tensor and returned (as the second return
- *   value). Default: `false`.
+ *   value). Default: `false`. This arg is included so that the relatively
+ *   expensive concatenation of the stepwise outputs can be omitted unless
+ *   the stepwise outputs need to be kept (e.g., for an LSTM layer of which
+ *   `returnSequence` is `true`.)
  * @returns An Array: `[lastOutput, outputs, newStates]`.
  *   lastOutput: the lastest output of the RNN, of shape `[samples, ...]`.
  *   outputs: tensor with shape `[samples, time, ...]` where each entry

--- a/src/layers/recurrent_test.ts
+++ b/src/layers/recurrent_test.ts
@@ -49,7 +49,13 @@ describeMathCPUAndGPU('rnn', () => {
     const inputs = tensor3d(
         [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
     const initialStates = [tfc.zeros([2, 4])];
-    const rnnOutputs = rnn(rnnStepForTest, inputs, initialStates);
+    const rnnOutputs = rnn(
+        rnnStepForTest, inputs, initialStates,
+        false /* goBackwards */,
+        null /* mask */,
+        null /* constants */,
+        false /* unroll */,
+        true /* needPerStepOutputs */);
     const lastOutput = rnnOutputs[0];
     const outputs = rnnOutputs[1];
     const newStates = rnnOutputs[2];
@@ -88,7 +94,13 @@ describeMathCPUAndGPU('rnn', () => {
         [[[1, 2], [3, 4], [5, 6]], [[10, 20], [30, 40], [50, 60]]], [2, 3, 2]);
     // The two state tensors have different shapes.
     const initialStates = [tfc.zeros([2, 4]), tfc.ones([2, 3])];
-    const rnnOutputs = rnn(rnnStepForTest, inputs, initialStates);
+    const rnnOutputs = rnn(
+        rnnStepForTest, inputs, initialStates,
+        false /* goBackwards */,
+        null /* mask */,
+        null /* constants */,
+        false /* unroll */,
+        true /* needPerStepOutputs */);
     const lastOutput = rnnOutputs[0];
     const outputs = rnnOutputs[1];
     const newStates = rnnOutputs[2];
@@ -134,7 +146,13 @@ describeMathCPUAndGPU('rnn', () => {
         [2, 3, 2, 1]);
     // The two state tensors have different shapes.
     const initialStates = [tfc.zeros([2, 4]), tfc.ones([2, 3])];
-    const rnnOutputs = rnn(rnnStepForTest, inputs, initialStates);
+    const rnnOutputs = rnn(
+        rnnStepForTest, inputs, initialStates,
+        false /* goBackwards */,
+        null /* mask */,
+        null /* constants */,
+        false /* unroll */,
+        true /* needPerStepOutputs */);
     const lastOutput = rnnOutputs[0];
     const outputs = rnnOutputs[1];
     const newStates = rnnOutputs[2];

--- a/src/layers/wrappers.ts
+++ b/src/layers/wrappers.ts
@@ -233,7 +233,9 @@ export class TimeDistributed extends Wrapper {
         return [output, []];
       };
       const rnnOutputs =
-          rnn(step, inputs, [], false, null, null, false, inputs.shape[1]);
+          rnn(step, inputs, [], false /* goBackwards */, null /* mask */,
+              null /* constants */, false /* unroll */,
+              true /* needPerStepOutputs */);
       const y = rnnOutputs[1];
       // TODO(cais): Add activity regularization.
       // TODO(cais): Add useLearningPhase.
@@ -257,9 +259,9 @@ export interface BidirectionalLayerConfig extends WrapperLayerConfig {
   layer: RNN;
 
   /**
-   * Mode by which outputs of the forward and backward RNNs are combinied.
-   * If `null` or `undefined`, the output will not be combined, they will be
-   * returned as an `Array`.
+   * Mode by which outputs of the forward and backward RNNs are
+   * combinied. If `null` or `undefined`, the output will not be
+   * combined, they will be returned as an `Array`.
    */
   mergeMode?: BidirectionalMergeMode;
 }
@@ -278,13 +280,13 @@ export class Bidirectional extends Wrapper {
     super(config);
 
     // Note: When creating `this.forwardLayer`, the original Layer object
-    //   (`config.layer`) ought to be cloned. This is why we call `getConfig()`
-    //   followed by `deserialize()`. Without this cloning, the layer names
-    //   saved during serialization will incorrectly contain the 'forward_'
-    //   prefix.
-    //   In Python Keras, this is done using `copy.copy` (shallow copy), which
-    //   does not have a simple equivalent in JavaScript. JavaScript's
-    //   `Object.assign()` does not copy methods.
+    //   (`config.layer`) ought to be cloned. This is why we call
+    //   `getConfig()` followed by `deserialize()`. Without this cloning,
+    //   the layer names saved during serialization will incorrectly contain
+    //   the 'forward_' prefix. In Python Keras, this is done using
+    //   `copy.copy` (shallow copy), which does not have a simple equivalent
+    //   in JavaScript. JavaScript's `Object.assign()` does not copy
+    //   methods.
     const layerConfig = config.layer.getConfig();
     this.forwardLayer =
         deserialize(
@@ -441,12 +443,12 @@ export class Bidirectional extends Wrapper {
       const fullInput = [inputs].concat(additionalInputs);
       const fullInputSpec = this.inputSpec.concat(additionalSpecs);
       // Perform the call temporarily and replace inputSpec.
-      // Note: with initial states symbolic calls and non-symbolic calls to this
-      // method differ in how the initial states are passed. For symbolic calls,
-      // the initial states are passed in the first arg, as an Array of
-      // SymbolicTensors; for non-symbolic calls, they are passed in the second
-      // arg as a part of the kwargs. Hence the need to temporarily modify
-      // inputSpec here.
+      // Note: with initial states symbolic calls and non-symbolic calls to
+      // this method differ in how the initial states are passed. For
+      // symbolic calls, the initial states are passed in the first arg, as
+      // an Array of SymbolicTensors; for non-symbolic calls, they are
+      // passed in the second arg as a part of the kwargs. Hence the need to
+      // temporarily modify inputSpec here.
       // TODO(cais): Make refactoring so that this hacky code below is no
       // longer needed.
       const originalInputSpec = this.inputSpec;


### PR DESCRIPTION
* Keep the per-step outputs and concatenate them as a return value, if and only if it is necessary to do so. To this end, add arg `needPerStepOutputs` to the helper method rnn().
* Add `tidy()` call around the step-function call in `rnn()`.

Related:
* Clean up the signature of the helper method `rnn()`.

Benchmarking results, using the lstm-text-generation example (https://github.com/tensorflow/tfjs-examples/tree/master/lstm-text-generation):
  * Inference:
    * 7% reduction in inference time at LSTM layer size 128
    * 4% reduction at size 256
  * Training: 
    * 13% reduction in training time at LSTM layer size 128
    * 0.5% reduction at size 256

PERF

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/321)
<!-- Reviewable:end -->
