### PR TITLE
Let Sequential.fromConfig() handle non-array config objects

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -822,7 +822,7 @@ export class Sequential extends Model {
       cls: serialization.SerializableConstructor<T>,
       config: serialization.ConfigDict): T {
     let configArray: serialization.ConfigDictArray;
-    let additionalModelConfig: serialization.ConfigDict = {};
+    let extraModelConfig: serialization.ConfigDict = {};
     if (config instanceof Array) {
       if (!(config[0].className != null) ||
             config[0]['className'] === 'Merge') {
@@ -836,10 +836,10 @@ export class Sequential extends Model {
           `it must be an Object that contains the 'layers' field.`);
       configArray = config['layers'] as serialization.ConfigDictArray;
       delete config['layers'];
-      additionalModelConfig = config;
+      extraModelConfig = config;
     }
 
-    const model = new cls({additionalModelConfig});
+    const model = new cls(extraModelConfig);
     if (!(model instanceof Sequential)) {
       throw new NotImplementedError(
           `Sequential.fromConfig called on non-Sequential input: ${model}`);

--- a/src/models.ts
+++ b/src/models.ts
@@ -21,7 +21,7 @@ import {getSourceInputs, Layer, Node, SymbolicTensor} from './engine/topology';
 import {Model, ModelCompileConfig, ModelEvaluateConfig} from './engine/training';
 import {ModelFitDatasetConfig, ModelEvaluateDatasetConfig} from './engine/training_dataset';
 import {ModelFitConfig} from './engine/training_tensors';
-import {RuntimeError, ValueError} from './errors';
+import {RuntimeError, ValueError, NotImplementedError} from './errors';
 import {deserialize} from './layers/serialization';
 import {Kwargs, NamedTensorMap, Shape} from './types';
 import {JsonDict} from './types';
@@ -823,7 +823,7 @@ export class Sequential extends Model {
       config: serialization.ConfigDict): T {
     const model = new cls({});
     if (!(model instanceof Sequential)) {
-      throw new ValueError(
+      throw new NotImplementedError(
           `Sequential.fromConfig called on non-Sequential input: ${model}`);
     }
     let configArray: serialization.ConfigDictArray;

--- a/src/models.ts
+++ b/src/models.ts
@@ -821,12 +821,8 @@ export class Sequential extends Model {
   static fromConfig<T extends serialization.Serializable>(
       cls: serialization.SerializableConstructor<T>,
       config: serialization.ConfigDict): T {
-    const model = new cls({});
-    if (!(model instanceof Sequential)) {
-      throw new NotImplementedError(
-          `Sequential.fromConfig called on non-Sequential input: ${model}`);
-    }
     let configArray: serialization.ConfigDictArray;
+    let additionalModelConfig: serialization.ConfigDict = {};
     if (config instanceof Array) {
       if (!(config[0].className != null) ||
             config[0]['className'] === 'Merge') {
@@ -839,6 +835,14 @@ export class Sequential extends Model {
           `When the config data for a Sequential model is not an Array, ` +
           `it must be an Object that contains the 'layers' field.`);
       configArray = config['layers'] as serialization.ConfigDictArray;
+      delete config['layers'];
+      additionalModelConfig = config;
+    }
+
+    const model = new cls({additionalModelConfig});
+    if (!(model instanceof Sequential)) {
+      throw new NotImplementedError(
+          `Sequential.fromConfig called on non-Sequential input: ${model}`);
     }
 
     for (const conf of configArray) {

--- a/src/models_test.ts
+++ b/src/models_test.ts
@@ -9,6 +9,7 @@
  */
 
 import {DataType, io, ones, randomNormal, Scalar, scalar, serialization, sum, Tensor, tensor1d, tensor2d, zeros} from '@tensorflow/tfjs-core';
+import {ConfigDict} from '@tensorflow/tfjs-core/dist/serialization';
 
 import {Model} from './engine/training';
 import * as tfl from './index';
@@ -489,6 +490,49 @@ describeMathCPU('modelFromJSON', () => {
     expect(serializedModel['keras_version'])
         .toEqual(`tfjs-layers ${layersVersion}`);
   });
+
+  it('Load sequential model with non-array config', async () => {
+    const modelTopology: {} = {
+      'class_name': 'Sequential',
+      'keras_version': '2.1.6-tf',
+      'config': {
+        'layers': [{
+          'class_name': 'Dense',
+          'config': {
+            'kernel_initializer': {
+              'class_name': 'VarianceScaling',
+              'config': {
+                'distribution': 'uniform',
+                'scale': 1.0,
+                'seed': null,
+                'mode': 'fan_avg'
+              }
+            },
+            'name': 'dense_1',
+            'kernel_constraint': null,
+            'bias_regularizer': null,
+            'bias_constraint': null,
+            'dtype': 'float32',
+            'activation': 'sigmoid',
+            'trainable': true,
+            'kernel_regularizer': null,
+            'bias_initializer': {'class_name': 'Zeros', 'config': {}},
+            'units': 1,
+            'batch_input_shape': [null, 4],
+            'use_bias': true,
+            'activity_regularizer': null
+          }
+        }]
+      },
+      'backend': 'tensorflow'
+    };
+    const model =
+        deserialize(convertPythonicToTs(modelTopology) as ConfigDict) as Model;
+    expect(model.inputs.length).toEqual(1);
+    expect(model.inputs[0].shape).toEqual([null, 4]);
+    expect(model.outputs.length).toEqual(1);
+    expect(model.outputs[0].shape).toEqual([null, 1]);
+  });
 });
 
 describeMathCPU('loadModel from URL', () => {
@@ -680,6 +724,71 @@ describeMathCPU('loadModel from URL', () => {
              done.fail(err.stack);
            });
      });
+
+  it('load topology and weights: non-array Sequential config', async done => {
+    const modelTopology =
+        JSON.parse(JSON.stringify(fakeNonArrayConfigSequentialModelFromHDF5))
+            .modelTopology;
+    const weightsManifest: io.WeightsManifestConfig = [
+      {
+        'paths': ['weight_0'],
+        'weights':
+            [{'name': `dense_1/kernel`, 'dtype': 'float32', 'shape': [10, 2]}],
+      },
+      {
+        'paths': ['weight_1'],
+        'weights': [{'name': `dense_1/bias`, 'dtype': 'float32', 'shape': [2]}],
+      },
+      {
+        'paths': ['weight_2'],
+        'weights':
+            [{'name': `dense_2/kernel`, 'dtype': 'float32', 'shape': [2, 1]}],
+      },
+      {
+        'paths': ['weight_3'],
+        'weights': [{'name': `dense_2/bias`, 'dtype': 'float32', 'shape': [1]}],
+      }
+    ];
+    spyOn(window, 'fetch').and.callFake((path: string) => {
+      if (path === 'model/model.json') {
+        return new Response(JSON.stringify({
+          modelTopology,
+          weightsManifest,
+        }));
+      } else if (path === 'model/weight_0') {
+        return new Response(
+            ones([10, 2], 'float32').dataSync() as Float32Array);
+      } else if (path === 'model/weight_1') {
+        return new Response(zeros([2], 'float32').dataSync() as Float32Array);
+      } else if (path === 'model/weight_2') {
+        return new Response(
+            zeros([2, 1], 'float32').dataSync() as Float32Array);
+      } else if (path === 'model/weight_3') {
+        return new Response(ones([1], 'float32').dataSync() as Float32Array);
+      } else {
+        throw new Error(`Invalid path: ${path}`);
+      }
+    });
+
+    loadModelInternal('model/model.json')
+        .then(model => {
+          expect(model.layers.length).toEqual(2);
+          expect(model.inputs.length).toEqual(1);
+          expect(model.inputs[0].shape).toEqual([null, 10]);
+          expect(model.outputs.length).toEqual(1);
+          expect(model.outputs[0].shape).toEqual([null, 1]);
+          const weightValues = model.getWeights();
+          expect(weightValues.length).toEqual(4);
+          expectTensorsClose(weightValues[0], ones([10, 2]));
+          expectTensorsClose(weightValues[1], zeros([2]));
+          expectTensorsClose(weightValues[2], zeros([2, 1]));
+          expectTensorsClose(weightValues[3], ones([1]));
+          done();
+        })
+        .catch(err => {
+          done.fail(err.stack);
+        });
+  });
 
 
   it('load topology and weights with browserHTTPRequest with requestInit',
@@ -1143,10 +1252,8 @@ describeMathCPUAndGPU('Sequential', () => {
 
   it('throws error if adding layer would result in negative shape', () => {
     const model = tfl.sequential();
-    model.add(tfl.layers.activation({
-      inputShape: [4, 4, 1],
-      activation: 'relu'
-    }));
+    model.add(
+        tfl.layers.activation({inputShape: [4, 4, 1], activation: 'relu'}));
     const layer = tfl.layers.conv2d({
       filters: 1,
       kernelSize: [10, 10],
@@ -1439,6 +1546,72 @@ const fakeSequentialModelFromHDF5: ModelAndWeightsConfig = {
         }
       ]
     },
+  }
+};
+
+const fakeNonArrayConfigSequentialModelFromHDF5: ModelAndWeightsConfig = {
+  modelTopology: {
+    'backend': 'tensorflow',
+    'keras_version': '2.1.6-tf',
+    'model_config': {
+      'class_name': 'Sequential',
+      'config': {
+        'layers': [
+          {
+            'class_name': 'Dense',
+            'config': {
+              'kernel_initializer': {
+                'class_name': 'VarianceScaling',
+                'config': {
+                  'distribution': 'uniform',
+                  'scale': 1.0,
+                  'seed': null,
+                  'mode': 'fan_avg'
+                }
+              },
+              'name': 'dense_1',
+              'kernel_constraint': null,
+              'bias_regularizer': null,
+              'bias_constraint': null,
+              'dtype': 'float32',
+              'activation': 'relu',
+              'trainable': true,
+              'kernel_regularizer': null,
+              'bias_initializer': {'class_name': 'Zeros', 'config': {}},
+              'units': 2,
+              'batch_input_shape': [null, 10],
+              'use_bias': true,
+              'activity_regularizer': null
+            }
+          },
+          {
+            'class_name': 'Dense',
+            'config': {
+              'kernel_initializer': {
+                'class_name': 'VarianceScaling',
+                'config': {
+                  'distribution': 'uniform',
+                  'scale': 1.0,
+                  'seed': null,
+                  'mode': 'fan_avg'
+                }
+              },
+              'name': 'dense_2',
+              'kernel_constraint': null,
+              'bias_regularizer': null,
+              'bias_constraint': null,
+              'activation': 'sigmoid',
+              'trainable': true,
+              'kernel_regularizer': null,
+              'bias_initializer': {'class_name': 'Zeros', 'config': {}},
+              'units': 1,
+              'use_bias': true,
+              'activity_regularizer': null
+            }
+          }
+        ]
+      },
+    }
   }
 };
 

--- a/src/models_test.ts
+++ b/src/models_test.ts
@@ -496,6 +496,7 @@ describeMathCPU('modelFromJSON', () => {
       'class_name': 'Sequential',
       'keras_version': '2.1.6-tf',
       'config': {
+        'name': 'BarSequential123',
         'layers': [{
           'class_name': 'Dense',
           'config': {
@@ -528,6 +529,7 @@ describeMathCPU('modelFromJSON', () => {
     };
     const model =
         deserialize(convertPythonicToTs(modelTopology) as ConfigDict) as Model;
+    expect(model.name.indexOf('BarSequential123')).toEqual(0);
     expect(model.inputs.length).toEqual(1);
     expect(model.inputs[0].shape).toEqual([null, 4]);
     expect(model.outputs.length).toEqual(1);
@@ -772,6 +774,7 @@ describeMathCPU('loadModel from URL', () => {
 
     loadModelInternal('model/model.json')
         .then(model => {
+          expect(model.name.indexOf('Foo123Sequential')).toEqual(0);
           expect(model.layers.length).toEqual(2);
           expect(model.inputs.length).toEqual(1);
           expect(model.inputs[0].shape).toEqual([null, 10]);
@@ -1556,6 +1559,7 @@ const fakeNonArrayConfigSequentialModelFromHDF5: ModelAndWeightsConfig = {
     'model_config': {
       'class_name': 'Sequential',
       'config': {
+        'name': 'Foo123Sequential',
         'layers': [
           {
             'class_name': 'Dense',


### PR DESCRIPTION
Previously, it was assumed that the config object passed to a
Sequential model during serialization is always an array (of
layer configs). But in TensorFlow r1.11, a change was made to
the serialization of Sequential, such that the config is now
an object with the 'layers' field.

This PR makes sure that TensorFlow.js is able to load such
serialized Sequential models without error.

BUG

Fixes: https://github.com/tensorflow/tfjs/issues/744

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/332)
<!-- Reviewable:end -->
