### PR TITLE
check typeof dataset.iterator instead of instanceof

### DIFF
--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -822,9 +822,7 @@ export class Model extends Container implements tfc.InferenceModel {
   //   available.
   /**
    * Evaluate model using a dataset object.
-   * 
    * Note: Unlike `evaluate()`, this method is asynchronous (`async`);
-   * 
    * @param dataset A dataset object. Its `iterator()` method is expected
    *   to generate a dataset iterator object, the `next()` method of which
    *   is expected to produce data batches for evaluation. The return value
@@ -842,8 +840,8 @@ export class Model extends Container implements tfc.InferenceModel {
    * @doc {heading: 'Models', subheading: 'Classes', configParamIndices: [2]}
    */
   async evaluateDataset<T extends TensorContainer>(
-      dataset: Dataset<T>, config: ModelEvaluateDatasetConfig):
-      Promise<Scalar|Scalar[]> {
+      dataset: Dataset<T>,
+      config: ModelEvaluateDatasetConfig): Promise<Scalar|Scalar[]> {
     this.makeTestFunction();
     return evaluateDataset(this, dataset, config);
   }

--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -822,7 +822,9 @@ export class Model extends Container implements tfc.InferenceModel {
   //   available.
   /**
    * Evaluate model using a dataset object.
+   *
    * Note: Unlike `evaluate()`, this method is asynchronous (`async`);
+   *
    * @param dataset A dataset object. Its `iterator()` method is expected
    *   to generate a dataset iterator object, the `next()` method of which
    *   is expected to produce data batches for evaluation. The return value

--- a/src/engine/training_dataset.ts
+++ b/src/engine/training_dataset.ts
@@ -273,8 +273,7 @@ export async function fitDataset<T extends TensorContainer>(
     let valXs: tfc.Tensor|tfc.Tensor[];
     let valYs: tfc.Tensor|tfc.Tensor[];
     if (doValidation) {
-      if (typeof (config.validationData as Dataset<T>).iterator ===
-          'function') {
+      if (isDatasetObject(config.validationData)) {
         tfc.util.assert(
             config.validationBatches > 0 &&
                 Number.isInteger(config.validationBatches),
@@ -364,8 +363,7 @@ export async function fitDataset<T extends TensorContainer>(
         // Epoch finished. Perform validation.
         if (stepsDone >= config.batchesPerEpoch && doValidation) {
           let valOuts: tfc.Scalar[];
-          if (typeof (config.validationData as Dataset<T>).iterator ===
-              'function') {
+          if (isDatasetObject(config.validationData)) {
             valOuts = toList(await model.evaluateDataset(
                 validationDataIterator, {batches: config.validationBatches}));
           } else {
@@ -396,6 +394,18 @@ export async function fitDataset<T extends TensorContainer>(
   } finally {
     model.isTraining = false;
   }
+}
+
+// Check if provided object is a Dataset object by checking it's .iterator
+// element.
+function isDatasetObject<T extends TensorContainer>(
+    dataset:
+        [
+          tfc.Tensor|tfc.Tensor[]|TensorMap, tfc.Tensor|tfc.Tensor[]|TensorMap
+        ]|[tfc.Tensor | tfc.Tensor[] | TensorMap,
+           tfc.Tensor | tfc.Tensor[] | TensorMap,
+           tfc.Tensor | tfc.Tensor[] | TensorMap]|Dataset<T>) {
+  return (typeof (dataset as Dataset<T>).iterator === 'function');
 }
 
 export async function evaluateDataset<T extends TensorContainer>(

--- a/src/engine/training_dataset.ts
+++ b/src/engine/training_dataset.ts
@@ -404,8 +404,15 @@ function isDatasetObject<T extends TensorContainer>(
           tfc.Tensor|tfc.Tensor[]|TensorMap, tfc.Tensor|tfc.Tensor[]|TensorMap
         ]|[tfc.Tensor | tfc.Tensor[] | TensorMap,
            tfc.Tensor | tfc.Tensor[] | TensorMap,
-           tfc.Tensor | tfc.Tensor[] | TensorMap]|Dataset<T>) {
+           tfc.Tensor | tfc.Tensor[] | TensorMap]|Dataset<T>): boolean {
   return (typeof (dataset as Dataset<T>).iterator === 'function');
+}
+
+// Check if provided object is a LazyIterator object by checking it's .next
+// element.
+function isLazyIteratorObject<T extends TensorContainer>(
+    iterator: Dataset<T>|LazyIterator<T>): boolean {
+  return (typeof (iterator as LazyIterator<T>).next === 'function');
 }
 
 export async function evaluateDataset<T extends TensorContainer>(
@@ -422,8 +429,7 @@ export async function evaluateDataset<T extends TensorContainer>(
       config.batches > 0 && Number.isInteger(config.batches),
       'Test loop expects `batches` to be a positive integer, but ' +
           `received ${JSON.stringify(config.batches)}`);
-  const dataIterator =
-      (typeof (dataset as LazyIterator<T>).next === 'function') ?
+  const dataIterator = isLazyIteratorObject(dataset) ?
       dataset as LazyIterator<T>:
       await (dataset as Dataset<T>).iterator();
   // Keeps track of number of examples used in this evaluation.


### PR DESCRIPTION
#### Description
`instanceof Dataset` and `instanceof LazyIterator` does not work for duplicate interfaces. So this PR use
`if ( typeof (datasetOrTensor as Dataset).iterator === 'function' )` to replace `if ( datasetOrTensor instanceof Dataset )`
`if ( type (iteratorOrDataset as LazyIterator).next === 'function' )` to replace `if ( iteratorOrDataset instanceof LazyIterator )`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/352)
<!-- Reviewable:end -->
