### PR TITLE
LSTM and GRU performance: Replace tf.slice with tf.split

### DIFF
--- a/src/layers/recurrent.ts
+++ b/src/layers/recurrent.ts
@@ -1547,94 +1547,36 @@ export class GRUCell extends RNNCell {
       let z: Tensor;
       let r: Tensor;
       let hh: Tensor;
-      if (this.implementation === 1) {
-        const kernelZ = K.sliceAlongLastAxis(this.kernel.read(), 0, this.units);
-        const kernelR =
-            K.sliceAlongLastAxis(this.kernel.read(), this.units, this.units);
-        const kernelH = K.sliceAlongLastAxis(
-            this.kernel.read(), this.units * 2, this.units);
-        const recurrentKernelZ =
-            K.sliceAlongLastAxis(this.recurrentKernel.read(), 0, this.units);
-        const recurrentKernelR = K.sliceAlongLastAxis(
-            this.recurrentKernel.read(), this.units, this.units);
-        const recurrentKernelH = K.sliceAlongLastAxis(
-            this.recurrentKernel.read(), this.units * 2, this.units);
 
-        let inputsZ: Tensor, inputsR: Tensor, inputsH: Tensor;
-        if (0 < this.dropout && this.dropout < 1) {
-          inputsZ = tfc.mul(inputs, dpMask[0]);
-          inputsR = tfc.mul(inputs, dpMask[1]);
-          inputsH = tfc.mul(inputs, dpMask[2]);
-        } else {
-          inputsZ = inputs;
-          inputsR = inputs;
-          inputsH = inputs;
-        }
-
-        let xZ = K.dot(inputsZ, kernelZ);
-        let xR = K.dot(inputsR, kernelR);
-        let xH = K.dot(inputsH, kernelH);
-        if (this.useBias) {
-          const biasZ = K.sliceAlongFirstAxis(this.bias.read(), 0, this.units);
-          const biasR =
-              K.sliceAlongFirstAxis(this.bias.read(), this.units, this.units);
-          const biasH = K.sliceAlongFirstAxis(
-              this.bias.read(), this.units * 2, this.units);
-          xZ = K.biasAdd(xZ, biasZ);
-          xR = K.biasAdd(xR, biasR);
-          xH = K.biasAdd(xH, biasH);
-        }
-
-        let hTMinus1Z: Tensor;
-        let hTMinus1R: Tensor;
-        let hTMinus1H: Tensor;
-        if (0 < this.recurrentDropout && this.recurrentDropout < 1) {
-          hTMinus1Z = tfc.mul(hTMinus1, recDpMask[0]);
-          hTMinus1R = tfc.mul(hTMinus1, recDpMask[1]);
-          hTMinus1H = tfc.mul(hTMinus1, recDpMask[2]);
-        } else {
-          hTMinus1Z = hTMinus1;
-          hTMinus1R = hTMinus1;
-          hTMinus1H = hTMinus1;
-        }
-        z = this.recurrentActivation.apply(
-            tfc.add(xZ, K.dot(hTMinus1Z, recurrentKernelZ)));
-        r = this.recurrentActivation.apply(
-            tfc.add(xR, K.dot(hTMinus1R, recurrentKernelR)));
-        hh = this.activation.apply(
-            tfc.add(xH, K.dot(tfc.mul(r, hTMinus1H), recurrentKernelH)));
-      } else {
-        if (0 < this.dropout && this.dropout < 1) {
-          inputs = tfc.mul(inputs, dpMask[0]);
-        }
-        let matrixX = K.dot(inputs, this.kernel.read());
-        if (this.useBias) {
-          matrixX = K.biasAdd(matrixX, this.bias.read());
-        }
-        if (0 < this.dropout && this.dropout < 1) {
-          hTMinus1 = tfc.mul(hTMinus1, recDpMask[0]);
-        }
-        const matrixInner = K.dot(
-            hTMinus1,
-            K.sliceAlongLastAxis(
-                this.recurrentKernel.read(), 0, 2 * this.units));
-
-        const xZ = K.sliceAlongLastAxis(matrixX, 0, this.units);
-        const xR = K.sliceAlongLastAxis(matrixX, this.units, this.units);
-        const recurrentZ = K.sliceAlongLastAxis(matrixInner, 0, this.units);
-        const recurrentR =
-            K.sliceAlongLastAxis(matrixInner, this.units, this.units);
-
-        z = this.recurrentActivation.apply(tfc.add(xZ, recurrentZ));
-        r = this.recurrentActivation.apply(tfc.add(xR, recurrentR));
-
-        const xH = K.sliceAlongLastAxis(matrixX, 2 * this.units, this.units);
-        const recurrentH = K.dot(
-            tfc.mul(r, hTMinus1),
-            K.sliceAlongLastAxis(
-                this.recurrentKernel.read(), 2 * this.units, this.units));
-        hh = this.activation.apply(tfc.add(xH, recurrentH));
+      if (0 < this.dropout && this.dropout < 1) {
+        inputs = tfc.mul(inputs, dpMask[0]);
       }
+      let matrixX = K.dot(inputs, this.kernel.read());
+      if (this.useBias) {
+        matrixX = K.biasAdd(matrixX, this.bias.read());
+      }
+      if (0 < this.dropout && this.dropout < 1) {
+        hTMinus1 = tfc.mul(hTMinus1, recDpMask[0]);
+      }
+      const matrixInner = K.dot(
+          hTMinus1,
+          K.sliceAlongLastAxis(this.recurrentKernel.read(), 0, 2 * this.units));
+
+      const xZ = K.sliceAlongLastAxis(matrixX, 0, this.units);
+      const xR = K.sliceAlongLastAxis(matrixX, this.units, this.units);
+      const recurrentZ = K.sliceAlongLastAxis(matrixInner, 0, this.units);
+      const recurrentR =
+          K.sliceAlongLastAxis(matrixInner, this.units, this.units);
+
+      z = this.recurrentActivation.apply(tfc.add(xZ, recurrentZ));
+      r = this.recurrentActivation.apply(tfc.add(xR, recurrentR));
+
+      const xH = K.sliceAlongLastAxis(matrixX, 2 * this.units, this.units);
+      const recurrentH = K.dot(
+          tfc.mul(r, hTMinus1),
+          K.sliceAlongLastAxis(
+              this.recurrentKernel.read(), 2 * this.units, this.units));
+      hh = this.activation.apply(tfc.add(xH, recurrentH));
 
       const h = tfc.add(
           tfc.mul(z, hTMinus1), tfc.mul(tfc.add(getScalar(1), tfc.neg(z)), hh));
@@ -2078,103 +2020,27 @@ export class LSTMCell extends RNNCell {
       let f: Tensor;
       let c: Tensor;
       let o: Tensor;
-      if (this.implementation === 1) {
-        const kernelI = K.sliceAlongLastAxis(this.kernel.read(), 0, this.units);
-        const kernelF =
-            K.sliceAlongLastAxis(this.kernel.read(), this.units, this.units);
-        const kernelC = K.sliceAlongLastAxis(
-            this.kernel.read(), this.units * 2, this.units);
-        const kernelO = K.sliceAlongLastAxis(
-            this.kernel.read(), this.units * 3, this.units);
-        const recurrentKernelI =
-            K.sliceAlongLastAxis(this.recurrentKernel.read(), 0, this.units);
-        const recurrentKernelF = K.sliceAlongLastAxis(
-            this.recurrentKernel.read(), this.units, this.units);
-        const recurrentKernelC = K.sliceAlongLastAxis(
-            this.recurrentKernel.read(), this.units * 2, this.units);
-        const recurrentKernelO = K.sliceAlongLastAxis(
-            this.recurrentKernel.read(), this.units * 3, this.units);
-
-        let inputsI: Tensor, inputsF: Tensor, inputsC: Tensor, inputsO: Tensor;
-        if (0 < this.dropout && this.dropout < 1) {
-          inputsI = tfc.mul(inputs, dpMask[0]);
-          inputsF = tfc.mul(inputs, dpMask[1]);
-          inputsC = tfc.mul(inputs, dpMask[2]);
-          inputsO = tfc.mul(inputs, dpMask[3]);
-        } else {
-          inputsI = inputs;
-          inputsF = inputs;
-          inputsC = inputs;
-          inputsO = inputs;
-        }
-
-        let xI = K.dot(inputsI, kernelI);
-        let xF = K.dot(inputsF, kernelF);
-        let xC = K.dot(inputsC, kernelC);
-        let xO = K.dot(inputsO, kernelO);
-        if (this.useBias) {
-          const biasI = K.sliceAlongFirstAxis(this.bias.read(), 0, this.units);
-          const biasF =
-              K.sliceAlongFirstAxis(this.bias.read(), this.units, this.units);
-          const biasC = K.sliceAlongFirstAxis(
-              this.bias.read(), this.units * 2, this.units);
-          const biasO = K.sliceAlongFirstAxis(
-              this.bias.read(), this.units * 3, this.units);
-          xI = K.biasAdd(xI, biasI);
-          xF = K.biasAdd(xF, biasF);
-          xC = K.biasAdd(xC, biasC);
-          xO = K.biasAdd(xO, biasO);
-        }
-
-        let hTMinus1I: Tensor, hTMinus1F: Tensor, hTMinus1C: Tensor,
-            hTMinus1O: Tensor;
-        if (0 < this.recurrentDropout && this.recurrentDropout < 1) {
-          hTMinus1I = tfc.mul(hTMinus1, recDpMask[0]);
-          hTMinus1F = tfc.mul(hTMinus1, recDpMask[1]);
-          hTMinus1C = tfc.mul(hTMinus1, recDpMask[2]);
-          hTMinus1O = tfc.mul(hTMinus1, recDpMask[3]);
-        } else {
-          hTMinus1I = hTMinus1;
-          hTMinus1F = hTMinus1;
-          hTMinus1C = hTMinus1;
-          hTMinus1O = hTMinus1;
-        }
-        i = this.recurrentActivation.apply(
-            tfc.add(xI, K.dot(hTMinus1I, recurrentKernelI)));
-        f = this.recurrentActivation.apply(
-            tfc.add(xF, K.dot(hTMinus1F, recurrentKernelF)));
-        c = tfc.add(
-            tfc.mul(f, cTMinus1),
-            tfc.mul(
-                i,
-                this.activation.apply(
-                    tfc.add(xC, K.dot(hTMinus1C, recurrentKernelC)))));
-        o = this.recurrentActivation.apply(
-            tfc.add(xO, K.dot(hTMinus1O, recurrentKernelO)));
-      } else {
-        if (0 < this.dropout && this.dropout < 1) {
-          inputs = tfc.mul(inputs, dpMask[0]);
-        }
-        let z = K.dot(inputs, this.kernel.read());
-        if (0 < this.recurrentDropout && this.recurrentDropout < 1) {
-          hTMinus1 = tfc.mul(hTMinus1, recDpMask[0]);
-        }
-        z = tfc.add(z, K.dot(hTMinus1, this.recurrentKernel.read()));
-        if (this.useBias) {
-          z = K.biasAdd(z, this.bias.read());
-        }
-
-        const z0 = K.sliceAlongLastAxis(z, 0, this.units);
-        const z1 = K.sliceAlongLastAxis(z, this.units, this.units);
-        const z2 = K.sliceAlongLastAxis(z, this.units * 2, this.units);
-        const z3 = K.sliceAlongLastAxis(z, this.units * 3, this.units);
-
-        i = this.recurrentActivation.apply(z0);
-        f = this.recurrentActivation.apply(z1);
-        c = tfc.add(
-            tfc.mul(f, cTMinus1), tfc.mul(i, this.activation.apply(z2)));
-        o = this.recurrentActivation.apply(z3);
+      if (0 < this.dropout && this.dropout < 1) {
+        inputs = tfc.mul(inputs, dpMask[0]);
       }
+      let z = K.dot(inputs, this.kernel.read());
+      if (0 < this.recurrentDropout && this.recurrentDropout < 1) {
+        hTMinus1 = tfc.mul(hTMinus1, recDpMask[0]);
+      }
+      z = tfc.add(z, K.dot(hTMinus1, this.recurrentKernel.read()));
+      if (this.useBias) {
+        z = K.biasAdd(z, this.bias.read());
+      }
+
+      const z0 = K.sliceAlongLastAxis(z, 0, this.units);
+      const z1 = K.sliceAlongLastAxis(z, this.units, this.units);
+      const z2 = K.sliceAlongLastAxis(z, this.units * 2, this.units);
+      const z3 = K.sliceAlongLastAxis(z, this.units * 3, this.units);
+
+      i = this.recurrentActivation.apply(z0);
+      f = this.recurrentActivation.apply(z1);
+      c = tfc.add(tfc.mul(f, cTMinus1), tfc.mul(i, this.activation.apply(z2)));
+      o = this.recurrentActivation.apply(z3);
 
       const h = tfc.mul(o, this.activation.apply(c));
       // TODO(cais): Add use_learning_phase flag properly.

--- a/src/layers/recurrent.ts
+++ b/src/layers/recurrent.ts
@@ -1564,24 +1564,20 @@ export class GRUCell extends RNNCell {
       if (0 < this.recurrentDropout && this.recurrentDropout < 1) {
         hTMinus1 = tfc.mul(hTMinus1, recDpMask[0]);
       }
-      const matrixInner = K.dot(
-          hTMinus1,
-          K.sliceAlongLastAxis(this.recurrentKernel.read(), 0, 2 * this.units));
 
-      const xZ = K.sliceAlongLastAxis(matrixX, 0, this.units);
-      const xR = K.sliceAlongLastAxis(matrixX, this.units, this.units);
-      const recurrentZ = K.sliceAlongLastAxis(matrixInner, 0, this.units);
-      const recurrentR =
-          K.sliceAlongLastAxis(matrixInner, this.units, this.units);
+      const recurrentKernelValue = this.recurrentKernel.read();
+      const [rk1, rk2] = tfc.split(
+          recurrentKernelValue, [2 * this.units, this.units],
+          recurrentKernelValue.rank - 1);
+      const matrixInner = K.dot(hTMinus1, rk1);
 
+      const [xZ, xR, xH] = tfc.split(matrixX, 3, matrixX.rank - 1);
+      const [recurrentZ, recurrentR] =
+          tfc.split(matrixInner, 2, matrixInner.rank - 1)
       z = this.recurrentActivation.apply(tfc.add(xZ, recurrentZ));
       r = this.recurrentActivation.apply(tfc.add(xR, recurrentR));
 
-      const xH = K.sliceAlongLastAxis(matrixX, 2 * this.units, this.units);
-      const recurrentH = K.dot(
-          tfc.mul(r, hTMinus1),
-          K.sliceAlongLastAxis(
-              this.recurrentKernel.read(), 2 * this.units, this.units));
+      const recurrentH = K.dot(tfc.mul(r, hTMinus1), rk2);
       hh = this.activation.apply(tfc.add(xH, recurrentH));
 
       const h = tfc.add(
@@ -2047,15 +2043,7 @@ export class LSTMCell extends RNNCell {
         z = K.biasAdd(z, this.bias.read());
       }
 
-      const zs = tfc.split(z, 4, z.rank - 1);
-      const z0 = zs[0];
-      const z1 = zs[1];
-      const z2 = zs[2];
-      const z3 = zs[3];
-      // const z0 = K.sliceAlongLastAxis(z, 0, this.units);
-      // const z1 = K.sliceAlongLastAxis(z, this.units, this.units);
-      // const z2 = K.sliceAlongLastAxis(z, this.units * 2, this.units);
-      // const z3 = K.sliceAlongLastAxis(z, this.units * 3, this.units);
+      const [z0, z1, z2, z3] = tfc.split(z, 4, z.rank - 1);
 
       i = this.recurrentActivation.apply(z0);
       f = this.recurrentActivation.apply(z1);

--- a/src/layers/recurrent.ts
+++ b/src/layers/recurrent.ts
@@ -1370,6 +1370,9 @@ export interface GRUCellLayerConfig extends SimpleRNNCellLayerConfig {
    * Mode 2 will batch them into fewer, larger operations. These modes will
    * have different performance profiles on different hardware and
    * for different applications.
+   *
+   * Note: For superior performance, TensorFlow.js always uses implementation
+   * 2, regardless of the actual value of this configuration field.
    */
   implementation?: number;
 }
@@ -1530,6 +1533,9 @@ export class GRUCell extends RNNCell {
       let hTMinus1 = inputs[1];  // Previous memory state.
       inputs = inputs[0];
 
+      // Note: For superior performance, TensorFlow.js always uses
+      // implementation 2, regardless of the actual value of
+      // config.implementation.
       if (0 < this.dropout && this.dropout < 1 && this.dropoutMask == null) {
         this.dropoutMask = generateDropoutMask(
                                () => tfc.onesLike(inputs as Tensor),
@@ -1633,6 +1639,9 @@ export interface GRULayerConfig extends SimpleRNNLayerConfig {
    * Mode 2 will batch them into fewer, larger operations. These modes will
    * have different performance profiles on different hardware and
    * for different applications.
+   *
+   * Note: For superior performance, TensorFlow.js always uses implementation
+   * 2, regardless of the actual value of this configuration field.
    */
   implementation?: number;
 }
@@ -1820,8 +1829,11 @@ export interface LSTMCellLayerConfig extends SimpleRNNCellLayerConfig {
    * Mode 2 will batch them into fewer, larger operations. These modes will
    * have different performance profiles on different hardware and
    * for different applications.
+   *
+   * Note: For superior performance, TensorFlow.js always uses implementation
+   * 2, regardless of the actual value of this configuration field.
    */
-  implementation?: 1|2;
+  implementation?: number;
 }
 
 /**
@@ -2016,6 +2028,9 @@ export class LSTMCell extends RNNCell {
       const recDpMask =
           this.recurrentDropoutMask as [Tensor, Tensor, Tensor, Tensor];
 
+      // Note: For superior performance, TensorFlow.js always uses
+      // implementation 2 regardless of the actual value of
+      // config.implementation.
       let i: Tensor;
       let f: Tensor;
       let c: Tensor;
@@ -2104,6 +2119,9 @@ export interface LSTMLayerConfig extends SimpleRNNLayerConfig {
    *   batch them into fewer, larger operations. These modes will
    *   have different performance profiles on different hardware and
    *   for different applications.
+   *
+   * Note: For superior performance, TensorFlow.js always uses implementation
+   * 2, regardless of the actual value of this config field.
    */
   implementation?: 1|2;
 }

--- a/src/layers/recurrent.ts
+++ b/src/layers/recurrent.ts
@@ -1555,7 +1555,7 @@ export class GRUCell extends RNNCell {
       if (this.useBias) {
         matrixX = K.biasAdd(matrixX, this.bias.read());
       }
-      if (0 < this.dropout && this.dropout < 1) {
+      if (0 < this.recurrentDropout && this.recurrentDropout < 1) {
         hTMinus1 = tfc.mul(hTMinus1, recDpMask[0]);
       }
       const matrixInner = K.dot(

--- a/src/layers/recurrent.ts
+++ b/src/layers/recurrent.ts
@@ -2123,7 +2123,7 @@ export interface LSTMLayerConfig extends SimpleRNNLayerConfig {
    * Note: For superior performance, TensorFlow.js always uses implementation
    * 2, regardless of the actual value of this config field.
    */
-  implementation?: 1|2;
+  implementation?: number;
 }
 
 /**

--- a/src/layers/recurrent.ts
+++ b/src/layers/recurrent.ts
@@ -2047,10 +2047,15 @@ export class LSTMCell extends RNNCell {
         z = K.biasAdd(z, this.bias.read());
       }
 
-      const z0 = K.sliceAlongLastAxis(z, 0, this.units);
-      const z1 = K.sliceAlongLastAxis(z, this.units, this.units);
-      const z2 = K.sliceAlongLastAxis(z, this.units * 2, this.units);
-      const z3 = K.sliceAlongLastAxis(z, this.units * 3, this.units);
+      const zs = tfc.split(z, 4, z.rank - 1);
+      const z0 = zs[0];
+      const z1 = zs[1];
+      const z2 = zs[2];
+      const z3 = zs[3];
+      // const z0 = K.sliceAlongLastAxis(z, 0, this.units);
+      // const z1 = K.sliceAlongLastAxis(z, this.units, this.units);
+      // const z2 = K.sliceAlongLastAxis(z, this.units * 2, this.units);
+      // const z3 = K.sliceAlongLastAxis(z, this.units * 3, this.units);
 
       i = this.recurrentActivation.apply(z0);
       f = this.recurrentActivation.apply(z1);

--- a/src/layers/recurrent.ts
+++ b/src/layers/recurrent.ts
@@ -1573,7 +1573,7 @@ export class GRUCell extends RNNCell {
 
       const [xZ, xR, xH] = tfc.split(matrixX, 3, matrixX.rank - 1);
       const [recurrentZ, recurrentR] =
-          tfc.split(matrixInner, 2, matrixInner.rank - 1)
+          tfc.split(matrixInner, 2, matrixInner.rank - 1);
       z = this.recurrentActivation.apply(tfc.add(xZ, recurrentZ));
       r = this.recurrentActivation.apply(tfc.add(xR, recurrentR));
 

--- a/src/layers/recurrent_test.ts
+++ b/src/layers/recurrent_test.ts
@@ -1434,14 +1434,16 @@ describeMathCPU('LSTM Symbolic', () => {
      });
 
 
-  it('Serialization round trip', () => {
-    const layer = tfl.layers.lstm({units: 4});
-    const pythonicConfig = convertTsToPythonic(layer.getConfig());
-    // tslint:disable-next-line:no-any
-    const tsConfig = convertPythonicToTs(pythonicConfig) as any;
-    const layerPrime = tfl.layers.lstm(tsConfig);
-    expect(layerPrime.getConfig().units).toEqual(4);
-  });
+  for (const implementation of [1, 2]) {
+    it('Serialization round trip', () => {
+      const layer = tfl.layers.lstm({units: 4, implementation});
+      const pythonicConfig = convertTsToPythonic(layer.getConfig());
+      // tslint:disable-next-line:no-any
+      const tsConfig = convertPythonicToTs(pythonicConfig) as any;
+      const layerPrime = tfl.layers.lstm(tsConfig);
+      expect(layerPrime.getConfig().units).toEqual(4);
+    });
+  }
 });
 
 describeMathCPUAndGPU('LSTM Tensor', () => {

--- a/src/layers/recurrent_test.ts
+++ b/src/layers/recurrent_test.ts
@@ -970,14 +970,16 @@ describeMathCPU('GRU Symbolic', () => {
      });
 
 
-  it('Serialization round trip', () => {
-    const layer = tfl.layers.gru({units: 4});
-    const pythonicConfig = convertTsToPythonic(layer.getConfig());
-    // tslint:disable-next-line:no-any
-    const tsConfig = convertPythonicToTs(pythonicConfig) as any;
-    const layerPrime = tfl.layers.gru(tsConfig);
-    expect(layerPrime.getConfig().units).toEqual(4);
-  });
+  for (const implementation of [1, 2]) {
+    it('Serialization round trip', () => {
+      const layer = tfl.layers.gru({units: 4, implementation});
+      const pythonicConfig = convertTsToPythonic(layer.getConfig());
+      // tslint:disable-next-line:no-any
+      const tsConfig = convertPythonicToTs(pythonicConfig) as any;
+      const layerPrime = tfl.layers.gru(tsConfig);
+      expect(layerPrime.getConfig().units).toEqual(4);
+    });
+  }
 });
 
 describeMathCPUAndGPU('GRU Tensor', () => {

--- a/src/layers/recurrent_test.ts
+++ b/src/layers/recurrent_test.ts
@@ -978,6 +978,7 @@ describeMathCPU('GRU Symbolic', () => {
       const tsConfig = convertPythonicToTs(pythonicConfig) as any;
       const layerPrime = tfl.layers.gru(tsConfig);
       expect(layerPrime.getConfig().units).toEqual(4);
+      expect(layerPrime.getConfig().implementation).toEqual(implementation);
     });
   }
 });
@@ -1442,6 +1443,7 @@ describeMathCPU('LSTM Symbolic', () => {
       const tsConfig = convertPythonicToTs(pythonicConfig) as any;
       const layerPrime = tfl.layers.lstm(tsConfig);
       expect(layerPrime.getConfig().units).toEqual(4);
+      expect(layerPrime.getConfig().implementation).toEqual(implementation);
     });
   }
 });


### PR DESCRIPTION
PERF

Improvement in Benchmarks (Averaging 5-6 repeated runs of the benchmark to reduce noise):

- GRU predict:
  - 92.7 ms --> 86.4 ms (1.07x)
- LSTM predict:
  - 72.1 ms --> 68.7 ms (1.05x)
- Attention predict:
  - 72.9 ms --> 69.6 ms (1.05x)

Relating to https://github.com/tensorflow/tfjs/issues/863

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/365)
<!-- Reviewable:end -->
