### PR TITLE
Make tf.Model handle 1D tensor inputs correctly; Better check for validationSplit in fitDataset

### DIFF
--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -33,7 +33,7 @@ import {Dataset} from './dataset_stub';
 import {execute, FeedDict} from './executor';
 import {SymbolicTensor} from './topology';
 import {evaluateDataset, fitDataset, ModelEvaluateDatasetConfig, ModelFitDatasetConfig} from './training_dataset';
-import {checkBatchSize, fitTensors, makeBatches, ModelFitConfig, sliceArrays, sliceArraysByIndices} from './training_tensors';
+import {checkBatchSize, disposeNewTensors, ensureTensorRank2OrHigher, fitTensors, makeBatches, ModelFitConfig, sliceArrays, sliceArraysByIndices} from './training_tensors';
 
 /**
  * Helper function for polymorphic input data: 1. singleton Tensor.
@@ -59,6 +59,8 @@ export function isDataDict(x: Tensor|Tensor[]|
   return !isDataTensor(x) && !isDataArray(x);
 }
 
+
+
 /**
  * Normalizes inputs and targets provided by users.
  * @param data User-provided input data (polymorphic).
@@ -72,8 +74,7 @@ export function isDataDict(x: Tensor|Tensor[]|
  */
 export function standardizeInputData(
     data: Tensor|Tensor[]|{[inputName: string]: Tensor}, names: string[],
-    shapes?: Shape[], checkBatchAxis = true,
-    exceptionPrefix = ''): {tensors: Tensor[], disposalNeeded: boolean[]} {
+    shapes?: Shape[], checkBatchAxis = true, exceptionPrefix = ''): Tensor[] {
   if (names == null || names.length === 0) {
     // Check for the case where the model expected no data, but some data got
     // sent.
@@ -98,29 +99,23 @@ export function standardizeInputData(
             `but got ${data}`);
       }
     }
-    return {tensors: [], disposalNeeded: []};
+    return [];
   }
   if (data == null) {
-    return {
-      tensors: names.map(name => null),
-      disposalNeeded: names.map(name => null)
-    };
+    return names.map(name => null);
   }
 
-  let tensors: Tensor[];
-  let disposalNeeded: boolean[];
+  let arrays: Tensor[];
   if (isDataDict(data)) {
     data = data as {[inputName: string]: Tensor};
-    tensors = [];
-    disposalNeeded = [];
+    arrays = [];
     for (const name of names) {
       if (data[name] == null) {
         throw new ValueError(
             `No data provided for "${name}". Need data for each key in: ` +
             `${names}`);
       }
-      tensors.push(data[name]);
-      disposalNeeded.push(false);
+      arrays.push(data[name]);
     }
   } else if (isDataArray(data)) {
     data = data as Tensor[];
@@ -131,8 +126,7 @@ export function standardizeInputData(
           `model expected. Expected to see ${names.length} Tensor(s), but ` +
           `instead got the following list of Tensor(s): ${data}`);
     }
-    tensors = data;
-    disposalNeeded = data.map(d => false);
+    arrays = data;
   } else {
     data = data as Tensor;
     if (names.length > 1) {
@@ -141,18 +135,10 @@ export function standardizeInputData(
           `but only received one Tensor. Found: Tensor with shape ${
               data.shape}`);
     }
-    tensors = [data];
-    disposalNeeded = [false];
+    arrays = [data];
   }
 
-  // Make Tensors at least 2D.
-  for (let i = 0; i < names.length; ++i) {
-    const array = tensors[i];
-    if (array.shape.length === 1) {
-      tensors[i] = K.expandDims(array, 1);
-      disposalNeeded[i] = true;
-    }
-  }
+  arrays = ensureTensorRank2OrHigher(arrays);
 
   // Check shape compatibility.
   if (shapes != null) {
@@ -160,7 +146,7 @@ export function standardizeInputData(
       if (shapes[i] == null) {
         continue;
       }
-      const array = tensors[i];
+      const array = arrays[i];
       if (array.shape.length !== shapes[i].length) {
         throw new ValueError(
             `Error when checking ${exceptionPrefix}: expected ${names[i]} ` +
@@ -183,7 +169,7 @@ export function standardizeInputData(
       }
     }
   }
-  return {tensors, disposalNeeded};
+  return arrays;
 }
 
 /**
@@ -818,14 +804,20 @@ export class Model extends Container implements tfc.InferenceModel {
     // TODO(cais): Standardize `config.sampleWeights` as well.
     // Validate user data.
     const standardizedOuts = this.standardizeUserData(x, y, true, batchSize);
-    // TODO(cais): If uses `useLearningPhase`, set the corresponding element of
-    //   the input to 0.
-    const ins = standardizedOuts[0].concat(standardizedOuts[1]);
-    this.makeTestFunction();
-    const f = this.testFunction;
-    const testOuts =
-        this.testLoop(f, ins, batchSize, config.verbose, config.steps);
-    return singletonOrArray(testOuts);
+    try {
+      // TODO(cais): If uses `useLearningPhase`, set the corresponding element
+      // of
+      //   the input to 0.
+      const ins = standardizedOuts[0].concat(standardizedOuts[1]);
+      this.makeTestFunction();
+      const f = this.testFunction;
+      const testOuts =
+          this.testLoop(f, ins, batchSize, config.verbose, config.steps);
+      return singletonOrArray(testOuts);
+    } finally {
+      disposeNewTensors(standardizedOuts[0], x);
+      disposeNewTensors(standardizedOuts[1], y);
+    }
   }
 
   // TODO(cais): Add code snippet below once real dataset objects are
@@ -1080,14 +1072,20 @@ export class Model extends Container implements tfc.InferenceModel {
    */
   predict(x: Tensor|Tensor[], config: ModelPredictConfig = {}): Tensor
       |Tensor[] {
-    checkInputData(x, this.inputNames, this.feedInputShapes, false);
-    // TODO(cais): Take care of stateful models.
-    //   if (this.stateful) ...
-    // TODO(cais): Take care of the learning_phase boolean flag.
-    //   if (this.useLearningPhase) ...
-    const batchSize = config.batchSize == null ? 32 : config.batchSize;
-    checkBatchSize(batchSize);
-    return this.predictLoop(x, batchSize);
+    const xsRank2OrHigher = ensureTensorRank2OrHigher(x);
+    checkInputData(
+        xsRank2OrHigher, this.inputNames, this.feedInputShapes, false);
+    try {
+      // TODO(cais): Take care of stateful models.
+      //   if (this.stateful) ...
+      // TODO(cais): Take care of the learning_phase boolean flag.
+      //   if (this.useLearningPhase) ...
+      const batchSize = config.batchSize == null ? 32 : config.batchSize;
+      checkBatchSize(batchSize);
+      return this.predictLoop(xsRank2OrHigher, batchSize);
+    } finally {
+      disposeNewTensors(xsRank2OrHigher, x);
+    }
   }
 
   /**
@@ -1113,8 +1111,7 @@ export class Model extends Container implements tfc.InferenceModel {
   protected standardizeUserData(
       x: Tensor|Tensor[]|{[inputName: string]: Tensor},
       y: Tensor|Tensor[]|{[inputName: string]: Tensor}, checkBatchAxis = true,
-      batchSize?: number):
-      [Tensor[], Tensor[], Tensor[], boolean[], boolean[], boolean[]] {
+      batchSize?: number): [Tensor[], Tensor[], Tensor[]] {
     // TODO(cais): Add sampleWeight, classWeight
     if (this.optimizer == null) {
       throw new RuntimeError(
@@ -1133,14 +1130,11 @@ export class Model extends Container implements tfc.InferenceModel {
         outputShapes.push(outputShape);
       }
     }
-    const xStandard = standardizeInputData(
-        x, this.feedInputNames, this.feedInputShapes, false, 'input');
-    x = xStandard.tensors;
-    const xDisposalNeeded = xStandard.disposalNeeded;
-    const yStandard = standardizeInputData(
-        y, this.feedOutputNames, outputShapes, false, 'target');
-    y = yStandard.tensors;
-    const yDisposalNeeded = yStandard.disposalNeeded;
+    x = standardizeInputData(
+            x, this.feedInputNames, this.feedInputShapes, false, 'input') as
+        Tensor[];
+    y = standardizeInputData(
+            y, this.feedOutputNames, outputShapes, false, 'target') as Tensor[];
     // TODO(cais): Standardize sampleWeights & classWeights.
     checkArrayLengths(x, y, null);
     // TODO(cais): Check sampleWeights as well.
@@ -1154,7 +1148,7 @@ export class Model extends Container implements tfc.InferenceModel {
       }
     }
     // TODO(cais): Deal with the case of model.stateful == true.
-    return [x, y, null, xDisposalNeeded, yDisposalNeeded, null];
+    return [x, y, null];
   }
 
   /**

--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -806,8 +806,7 @@ export class Model extends Container implements tfc.InferenceModel {
     const standardizedOuts = this.standardizeUserData(x, y, true, batchSize);
     try {
       // TODO(cais): If uses `useLearningPhase`, set the corresponding element
-      // of
-      //   the input to 0.
+      // of the input to 0.
       const ins = standardizedOuts[0].concat(standardizedOuts[1]);
       this.makeTestFunction();
       const f = this.testFunction;

--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -33,7 +33,7 @@ import {Dataset} from './dataset_stub';
 import {execute, FeedDict} from './executor';
 import {SymbolicTensor} from './topology';
 import {evaluateDataset, fitDataset, ModelEvaluateDatasetConfig, ModelFitDatasetConfig} from './training_dataset';
-import {checkBatchSize, disposeNewTensors, ensureTensorRank2OrHigher, fitTensors, makeBatches, ModelFitConfig, sliceArrays, sliceArraysByIndices} from './training_tensors';
+import {checkBatchSize, disposeNewTensors, ensureTensorsRank2OrHigher, fitTensors, makeBatches, ModelFitConfig, sliceArrays, sliceArraysByIndices} from './training_tensors';
 
 /**
  * Helper function for polymorphic input data: 1. singleton Tensor.
@@ -138,7 +138,7 @@ export function standardizeInputData(
     arrays = [data];
   }
 
-  arrays = ensureTensorRank2OrHigher(arrays);
+  arrays = ensureTensorsRank2OrHigher(arrays);
 
   // Check shape compatibility.
   if (shapes != null) {
@@ -1071,7 +1071,7 @@ export class Model extends Container implements tfc.InferenceModel {
    */
   predict(x: Tensor|Tensor[], config: ModelPredictConfig = {}): Tensor
       |Tensor[] {
-    const xsRank2OrHigher = ensureTensorRank2OrHigher(x);
+    const xsRank2OrHigher = ensureTensorsRank2OrHigher(x);
     checkInputData(
         xsRank2OrHigher, this.inputNames, this.feedInputShapes, false);
     try {

--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -59,8 +59,6 @@ export function isDataDict(x: Tensor|Tensor[]|
   return !isDataTensor(x) && !isDataArray(x);
 }
 
-
-
 /**
  * Normalizes inputs and targets provided by users.
  * @param data User-provided input data (polymorphic).

--- a/src/engine/training_dataset.ts
+++ b/src/engine/training_dataset.ts
@@ -260,6 +260,11 @@ export async function fitDataset<T extends TensorContainer>(
           Number.isInteger(config.batchesPerEpoch),
       `For fitDataset(), config.batchesPerEpoch is expected to be a ` +
           `positive integer, but got ${config.batchesPerEpoch}`);
+  tfc.util.assert(
+      // tslint:disable-next-line:no-any
+      (config as any)['validationSplit'] == null,
+      '`validationSplit` is not supported by `fitDataset()`. ' +
+          'Use validationData instead.');
 
   if (model.isTraining) {
     throw new Error(

--- a/src/engine/training_dataset_test.ts
+++ b/src/engine/training_dataset_test.ts
@@ -1138,7 +1138,39 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
     expect(errorCaught.message)
         .toMatch(/fitDataset.*dataset-based validation.*integer.*undefined/);
   });
+
+  it('Calling fitDataset with validationSplit leads to Error', async () => {
+    const model = createDenseModel();
+    model.compile(
+        {loss: 'meanSquaredError', optimizer: 'sgd', metrics: ['accuracy']});
+
+    const batchSize = 8;
+    const epochs = 2;
+    const batchesPerEpoch = 3;
+
+    // Training dataset.
+    const dataset = new FakeNumericDataset({
+      xShape: [1],
+      yShape: [1],
+      batchSize,
+      numBatches: batchesPerEpoch * epochs
+    });
+
+    let errorCaught: Error;
+    try {
+      await model.fitDataset(
+          dataset,
+          // tslint:disable-next-line:no-any
+          {epochs: 1, batchesPerEpoch: 2, validationSplit: 0.25} as any);
+    } catch (err) {
+      errorCaught = err;
+    }
+    expect(errorCaught.message)
+        .toMatch(/.*validationSplit.*not supported.*validationData/);
+  });
 });
+
+// TODO(cais): The corresponding test for predict() and evaluate().
 
 describeMathCPUAndGPU('Model.evaluateDataset', () => {
   // Reference Python tf.keras code:

--- a/src/engine/training_dataset_test.ts
+++ b/src/engine/training_dataset_test.ts
@@ -821,6 +821,7 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
     });
     model.setWeights([tfc.zeros([2, 1]), tfc.zeros([1])]);
 
+    
     const numTensors0 = tfc.memory().numTensors;
     const history = await model.fitDataset(dataset, {
       batchesPerEpoch,
@@ -897,7 +898,7 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
   // print(model.get_weights()[0])
   // print(model.get_weights()[1])
   // ```
-  it('2 input, 1 output, 1 metric, tensor array validation', async () => {
+  it('2 input, 1 output, 1 metric, tensor array validation', async () => {    
     // Create a functional model with 2 inputs.
     const input1 = tfl.layers.input({shape: [1]});
     const input2 = tfl.layers.input({shape: [1]});

--- a/src/engine/training_dataset_test.ts
+++ b/src/engine/training_dataset_test.ts
@@ -820,7 +820,7 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
       validationBatchSize: batchSize
     });
     model.setWeights([tfc.zeros([2, 1]), tfc.zeros([1])]);
-    
+
     const numTensors0 = tfc.memory().numTensors;
     const history = await model.fitDataset(dataset, {
       batchesPerEpoch,
@@ -897,7 +897,7 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
   // print(model.get_weights()[0])
   // print(model.get_weights()[1])
   // ```
-  it('2 input, 1 output, 1 metric, tensor array validation', async () => {    
+  it('2 input, 1 output, 1 metric, tensor array validation', async () => {
     // Create a functional model with 2 inputs.
     const input1 = tfl.layers.input({shape: [1]});
     const input2 = tfl.layers.input({shape: [1]});

--- a/src/engine/training_dataset_test.ts
+++ b/src/engine/training_dataset_test.ts
@@ -820,7 +820,6 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
       validationBatchSize: batchSize
     });
     model.setWeights([tfc.zeros([2, 1]), tfc.zeros([1])]);
-
     
     const numTensors0 = tfc.memory().numTensors;
     const history = await model.fitDataset(dataset, {

--- a/src/engine/training_tensors.ts
+++ b/src/engine/training_tensors.ts
@@ -575,7 +575,7 @@ export function disposeNewTensors(
     }
   } else if (Array.isArray(tensors)) {
     tensors.forEach(t => {
-      if (oldTensorIds.indexOf(t.id)) {
+      if (oldTensorIds.indexOf(t.id) === -1) {
         tensorsToDispose.push(t);
       }
     });
@@ -583,7 +583,7 @@ export function disposeNewTensors(
     // `oldTensors` is a map from string name to Tensor.
     for (const name in tensors) {
       const tensor = tensors[name];
-      if (oldTensorIds.indexOf(tensor.id)) {
+      if (oldTensorIds.indexOf(tensor.id) === -1) {
         tensorsToDispose.push(tensor);
       }
     }

--- a/src/engine/training_tensors.ts
+++ b/src/engine/training_tensors.ts
@@ -521,7 +521,13 @@ export async function fitTensors(
   // TODO(cais): Add value to outLabels.
 }
 
-export function ensureTensorRank2OrHigher(tensors: Tensor|Tensor[]): Tensor[] {
+/**
+ * Ensure tensors all have a rank of at least 2.
+ * 
+ * If a tensor has a rank of 1, it is dimension-expanded to rank 2.
+ * If any tensor has a rank of 0 (i.e., is a scalar), an error will be thrown.
+ */
+export function ensureTensorsRank2OrHigher(tensors: Tensor|Tensor[]): Tensor[] {
   const outs: Tensor[] = [];
   if (tensors instanceof Tensor) {
     tensors = [tensors];
@@ -530,8 +536,12 @@ export function ensureTensorRank2OrHigher(tensors: Tensor|Tensor[]): Tensor[] {
   // Make Tensors at least 2D.
   for (let i = 0; i < tensors.length; ++i) {
     const tensor = tensors[i];
-    if (tensor.shape.length === 1) {
+    if (tensor.rank === 1) {
       outs.push(expandDims(tensor, 1));
+    } else if (tensor.rank === 0) {
+      throw new Error(
+          'Expected tensor to be at least 1D, but received a 0D tensor ' +
+          '(scalar).');
     } else {
       outs.push(tensor);
     }

--- a/src/engine/training_tensors.ts
+++ b/src/engine/training_tensors.ts
@@ -523,7 +523,7 @@ export async function fitTensors(
 
 /**
  * Ensure tensors all have a rank of at least 2.
- * 
+ *
  * If a tensor has a rank of 1, it is dimension-expanded to rank 2.
  * If any tensor has a rank of 0 (i.e., is a scalar), an error will be thrown.
  */
@@ -559,6 +559,7 @@ export function ensureTensorsRank2OrHigher(tensors: Tensor|Tensor[]): Tensor[] {
  *   `refTensors`.
  * @param refTensors Reference Tensor set.
  */
+// TODO(cais, kangyizhang): Deduplicate with tfjs-data.
 export function disposeNewTensors(
     tensors: Tensor|Tensor[]|{[inputName: string]: Tensor},
     refTensors: Tensor|Tensor[]|{[inputName: string]: Tensor}): void {

--- a/src/engine/training_test.ts
+++ b/src/engine/training_test.ts
@@ -31,87 +31,95 @@ import {makeBatches, sliceArraysByIndices} from './training_tensors';
 
 
 describeMathCPU('isDataTensor', () => {
+  const x = tfc.tensor2d([[3.14]]);
+
   it('Positive case', () => {
-    expect(isDataTensor(scalar(3.14))).toEqual(true);
+    expect(isDataTensor(x)).toEqual(true);
   });
   it('Negative cases', () => {
-    expect(isDataTensor([scalar(3.14), scalar(-3.14)])).toEqual(false);
-    expect(isDataTensor({'Pie': scalar(3.14)})).toEqual(false);
+    expect(isDataTensor([x, x])).toEqual(false);
+    expect(isDataTensor({'Pie': x})).toEqual(false);
     expect(isDataTensor({})).toEqual(false);
   });
 });
 
 describeMathCPU('isDataArray', () => {
+  const x = tfc.tensor2d([[3.14]]);
+
   it('Positive case', () => {
-    expect(isDataArray([scalar(3.14), scalar(-3.14)])).toEqual(true);
+    expect(isDataArray([x, x])).toEqual(true);
     expect(isDataArray([])).toEqual(true);
   });
   it('Negative cases', () => {
-    expect(isDataArray(scalar(3.14))).toEqual(false);
-    expect(isDataArray({'Pie': scalar(3.14)})).toEqual(false);
+    expect(isDataArray(x)).toEqual(false);
+    expect(isDataArray({'Pie': x})).toEqual(false);
     expect(isDataArray({})).toEqual(false);
   });
 });
 
 describeMathCPU('isDataDict', () => {
+  const x = tfc.tensor2d([[3.14]]);
   it('Positive case', () => {
-    expect(isDataDict({'Pie': scalar(3.14)})).toEqual(true);
+    expect(isDataDict({'Pie': x})).toEqual(true);
     expect(isDataDict({})).toEqual(true);
   });
   it('Negative cases', () => {
-    expect(isDataDict(scalar(3.14))).toEqual(false);
-    expect(isDataDict([scalar(3.14), scalar(-3.14)])).toEqual(false);
+    expect(isDataDict(x)).toEqual(false);
+    expect(isDataDict([x, x])).toEqual(false);
     expect(isDataDict([])).toEqual(false);
   });
 });
 
 describeMathCPU('standardizeInputData', () => {
+  const getX = () => tfc.tensor2d([[42]]);
+  const getY = () => tfc.tensor2d([[21]]);
+
   it('Singleton Tensor, Array of one name', () => {
-    const outputs = standardizeInputData(scalar(42), ['Foo']);
+    const outputs = standardizeInputData(getX(), ['Foo']);
     expect(outputs.length).toEqual(1);
-    expectTensorsClose(outputs[0], scalar(42));
+    expectTensorsClose(outputs[0], getX());
   });
   it('Array of one Tensor, Array of one name', () => {
-    const outputs = standardizeInputData([scalar(42)], ['Foo']);
+    const outputs = standardizeInputData([getX()], ['Foo']);
     expect(outputs.length).toEqual(1);
-    expectTensorsClose(outputs[0], scalar(42));
+    expectTensorsClose(outputs[0], getX());
   });
   it('Array of two Tensors, Array of two names', () => {
     const outputs =
-        standardizeInputData([scalar(42), scalar(21)], ['Foo', 'Bar']);
+        standardizeInputData([getX(), getY()], ['Foo', 'Bar']);
     expect(outputs.length).toEqual(2);
-    expectTensorsClose(outputs[0], scalar(42));
-    expectTensorsClose(outputs[1], scalar(21));
+    expectTensorsClose(outputs[0], getX());
+    expectTensorsClose(outputs[1], getY());
   });
   it('Dict of two Tensors, Array of two names', () => {
     const outputs = standardizeInputData(
-        {'Foo': scalar(42), 'Bar': scalar(21)}, ['Foo', 'Bar']);
+        {'Foo': getX(), 'Bar': getY()}, ['Foo', 'Bar']);
     expect(outputs.length).toEqual(2);
-    expectTensorsClose(outputs[0], scalar(42));
-    expectTensorsClose(outputs[1], scalar(21));
+    expectTensorsClose(outputs[0], getX());
+    expectTensorsClose(outputs[1], getY());
   });
   it('Unexpected data leads to exception: singleton Tensor', () => {
-    expect(() => standardizeInputData(scalar(42), []))
+    expect(() => standardizeInputData(getX(), []))
         .toThrowError(/expected no data/);
   });
   it('Unexpected data leads to exception: Array of two Tensors', () => {
-    expect(() => standardizeInputData([scalar(42), scalar(21)], []))
+    expect(() => standardizeInputData([getX(), getY()], []))
         .toThrowError(/expected no data/);
   });
   it('Unexpected data leads to exception: Dict', () => {
-    expect(() => standardizeInputData({'Pie': scalar(42)}, []))
+    expect(() => standardizeInputData({'Pie': getX()}, []))
         .toThrowError(/expected no data/);
   });
   it('Length mismatch: 1 singleton Scalar vs two names', () => {
-    expect(() => standardizeInputData(scalar(42), ['Foo', 'Bar']))
+    expect(() => standardizeInputData(getX(), ['Foo', 'Bar']))
         .toThrowError(/expects 2 Tensor.* but only received one/);
   });
   it('Length mismatch: Array of 2 Scalars vs one name', () => {
-    expect(() => standardizeInputData([scalar(42), scalar(-42)], ['Foo']))
+    expect(() => standardizeInputData([getX(), scalar(-42)], ['Foo']))
         .toThrowError(/Expected to see 1 Tensor/);
   });
   it('Length mismatch: Dict of 1 Scalar vs 2 names', () => {
-    expect(() => standardizeInputData({'Foo': scalar(42)}, ['Foo', 'Bar']))
+    expect(() => standardizeInputData({'Foo': getX()}, ['Foo', 'Bar']))
         .toThrowError(/No data provided for \"Bar\"/);
   });
 });


### PR DESCRIPTION
BUG

- Fix the problem in which `tf.Model.predict()` doesn't take 1D inputs.
- Fix memory leaks in `tf.Model.fit()` and `tf.Model.evaluate()` that happens when the inputs are 1D tensors.
- Let `tf.Model.fitDataset()` throw an error on receiving the unsupported `validationSplit`.

Fixes https://github.com/tensorflow/tfjs/issues/880

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/366)
<!-- Reviewable:end -->
