### PR TITLE
Make batchesPerEpoch optional, use iterator.next().done to stop when batchesPerEpoch not specified 

### DIFF
--- a/src/engine/dataset_fakes.ts
+++ b/src/engine/dataset_fakes.ts
@@ -11,7 +11,8 @@
 import * as tfc from '@tensorflow/tfjs-core';
 
 import {Shape} from '../types';
-import {LazyIterator, TensorOrTensorMap, Dataset,} from './dataset_stub';
+
+import {Dataset, LazyIterator, TensorOrTensorMap,} from './dataset_stub';
 
 export interface FakeDatasetConfig {
   /**
@@ -113,6 +114,9 @@ class FakeNumericIterator extends
   async next():
       Promise<IteratorResult<[TensorOrTensorMap, TensorOrTensorMap]>> {
     const done = ++this.batchCount > this.numBatches;
+    if (done) {
+      return {done, value: null};
+    }
     if (this.xTensorsFunc == null) {
       // Generate data randomly.
       return {
@@ -152,8 +156,7 @@ class FakeNumericIterator extends
       }
 
       // TODO(cais): Take care of the case of multiple outputs.
-      const ys =
-          (this.yTensorValues as tfc.Tensor[])[index] as tfc.Tensor;
+      const ys = (this.yTensorValues as tfc.Tensor[])[index] as tfc.Tensor;
       tfc.util.assert(
           tfc.util.arraysEqual(ys.shape, this.yBatchShape as Shape),
           `Shape mismatch: expected: ${JSON.stringify(this.yBatchShape)}; ` +

--- a/src/engine/dataset_fakes.ts
+++ b/src/engine/dataset_fakes.ts
@@ -161,7 +161,7 @@ class FakeNumericIterator extends
           tfc.util.arraysEqual(ys.shape, this.yBatchShape as Shape),
           `Shape mismatch: expected: ${JSON.stringify(this.yBatchShape)}; ` +
               `actual: ${JSON.stringify(ys.shape)}`);
-      return {done, value: done ? null : [xs, ys]};
+      return {done, value: [xs, ys]};
     }
   }
 }

--- a/src/engine/training_dataset.ts
+++ b/src/engine/training_dataset.ts
@@ -110,7 +110,7 @@ export interface ModelFitDatasetConfig<T extends TensorContainer> {
    * Total number of batches of samples to draw from `validationData` for
    * validation purpose before stopping at the end of every epoch. If not
    * specified, `evaluateDataset` will use `iterator.next().done` as signal to
-   * stop evaluation.
+   * stop validation.
    */
   validationBatches?: number;
 

--- a/src/engine/training_dataset.ts
+++ b/src/engine/training_dataset.ts
@@ -311,28 +311,6 @@ export async function fitDataset<T extends TensorContainer>(
       while (true) {
         const iteratorOut = await dataIterator.next();
 
-        if (iteratorOut.done) {
-          // Epoch finished. Perform validation.
-          if (doValidation) {
-            let valOuts: tfc.Scalar[];
-            if (isDatasetObject(config.validationData)) {
-              valOuts = toList(await model.evaluateDataset(
-                  validationDataIterator, {batches: config.validationBatches}));
-            } else {
-              valOuts = toList(model.evaluate(valXs, valYs, {
-                batchSize: config.validationBatchSize == null ?
-                    DEFAULT_VALIDATION_BATCH_SIZE :
-                    config.validationBatchSize,
-                verbose: 0
-              }));
-            }
-            for (let i = 0; i < model.metricsNames.length; ++i) {
-              epochLogs[`val_${model.metricsNames[i]}`] = valOuts[i];
-            }
-          }
-          break;
-        }
-
         const xsAndYs = standardizeDataIteratorOutput(model, iteratorOut.value);
         const batchLogs: UnresolvedLogs = {};
         batchLogs['batch'] = batchIndex;
@@ -355,6 +333,28 @@ export async function fitDataset<T extends TensorContainer>(
         disposeTensorsInLogs(batchLogs);
 
         batchIndex++;
+
+        if (iteratorOut.done) {
+          // Epoch finished. Perform validation.
+          if (doValidation) {
+            let valOuts: tfc.Scalar[];
+            if (isDatasetObject(config.validationData)) {
+              valOuts = toList(await model.evaluateDataset(
+                  validationDataIterator, {batches: config.validationBatches}));
+            } else {
+              valOuts = toList(model.evaluate(valXs, valYs, {
+                batchSize: config.validationBatchSize == null ?
+                    DEFAULT_VALIDATION_BATCH_SIZE :
+                    config.validationBatchSize,
+                verbose: 0
+              }));
+            }
+            for (let i = 0; i < model.metricsNames.length; ++i) {
+              epochLogs[`val_${model.metricsNames[i]}`] = valOuts[i];
+            }
+          }
+          break;
+        }
 
         if (model.stopTraining_) {
           break;

--- a/src/engine/training_dataset.ts
+++ b/src/engine/training_dataset.ts
@@ -311,6 +311,28 @@ export async function fitDataset<T extends TensorContainer>(
       while (true) {
         const iteratorOut = await dataIterator.next();
 
+        if (iteratorOut.done) {
+          // Epoch finished. Perform validation.
+          if (doValidation) {
+            let valOuts: tfc.Scalar[];
+            if (isDatasetObject(config.validationData)) {
+              valOuts = toList(await model.evaluateDataset(
+                  validationDataIterator, {batches: config.validationBatches}));
+            } else {
+              valOuts = toList(model.evaluate(valXs, valYs, {
+                batchSize: config.validationBatchSize == null ?
+                    DEFAULT_VALIDATION_BATCH_SIZE :
+                    config.validationBatchSize,
+                verbose: 0
+              }));
+            }
+            for (let i = 0; i < model.metricsNames.length; ++i) {
+              epochLogs[`val_${model.metricsNames[i]}`] = valOuts[i];
+            }
+          }
+          break;
+        }
+
         const xsAndYs = standardizeDataIteratorOutput(model, iteratorOut.value);
         const batchLogs: UnresolvedLogs = {};
         batchLogs['batch'] = batchIndex;
@@ -333,28 +355,6 @@ export async function fitDataset<T extends TensorContainer>(
         disposeTensorsInLogs(batchLogs);
 
         batchIndex++;
-
-        if (iteratorOut.done) {
-          // Epoch finished. Perform validation.
-          if (doValidation) {
-            let valOuts: tfc.Scalar[];
-            if (isDatasetObject(config.validationData)) {
-              valOuts = toList(await model.evaluateDataset(
-                  validationDataIterator, {batches: config.validationBatches}));
-            } else {
-              valOuts = toList(model.evaluate(valXs, valYs, {
-                batchSize: config.validationBatchSize == null ?
-                    DEFAULT_VALIDATION_BATCH_SIZE :
-                    config.validationBatchSize,
-                verbose: 0
-              }));
-            }
-            for (let i = 0; i < model.metricsNames.length; ++i) {
-              epochLogs[`val_${model.metricsNames[i]}`] = valOuts[i];
-            }
-          }
-          break;
-        }
 
         if (model.stopTraining_) {
           break;

--- a/src/engine/training_dataset.ts
+++ b/src/engine/training_dataset.ts
@@ -401,6 +401,11 @@ export async function fitDataset<T extends TensorContainer>(
               epochLogs[`val_${model.metricsNames[i]}`] = valOuts[i];
             }
           }
+          // Call `break` to exit one epoch lopp after validation is done. If
+          // config.batchesPerEpoch is specified, an epoch while loop will stop
+          // when `stepsDone >= config.batchesPerEpoch`. When
+          // config.batchesPerEpoch is not provided, the following `break` is
+          // required to exit the while lopp after dataset is exhausted.
           break;
         }
 

--- a/src/engine/training_dataset_test.ts
+++ b/src/engine/training_dataset_test.ts
@@ -63,46 +63,90 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
   // print(model.get_weights()[0])
   // print(model.get_weights()[1])
   // ```
-  it('1 input, 1 output, no metric, no validation', async () => {
-    const model = createDenseModel();
-    model.compile({loss: 'meanSquaredError', optimizer: 'sgd'});
+  it('1 input, 1 output, no metric, no validation, with batchesPerEpoch',
+     async () => {
+       const model = createDenseModel();
+       model.compile({loss: 'meanSquaredError', optimizer: 'sgd'});
 
-    const batchSize = 8;
-    const epochs = 2;
-    const batchesPerEpoch = 3;
-    const xTensorsFunc =
-        () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
-          batchSize, 1
-        ])];
-    const yTensorsFunc =
-        () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
-          batchSize, 1
-        ])];
-    const dataset = new FakeNumericDataset({
-      xShape: [1],
-      yShape: [1],
-      batchSize,
-      numBatches: batchesPerEpoch,
-      xTensorsFunc,
-      yTensorsFunc
-    });
+       const batchSize = 8;
+       const epochs = 2;
+       const batchesPerEpoch = 3;
+       const xTensorsFunc = () =>
+           [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
+            tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
+            tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])];
+       const yTensorsFunc = () =>
+           [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
+            tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
+            tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])];
+       const dataset = new FakeNumericDataset({
+         xShape: [1],
+         yShape: [1],
+         batchSize,
+         numBatches: batchesPerEpoch * epochs,
+         xTensorsFunc,
+         yTensorsFunc
+       });
 
-    // Do a burn-in call to account for initialization of cached tensors (for
-    // the memory-leak check below).
-    await model.fitDataset(dataset, {epochs: 1});
-    model.setWeights([tfc.zeros([1, 1]), tfc.zeros([1])]);
+       // Do a burn-in call to account for initialization of cached tensors (for
+       // the memory-leak check below).
+       await model.fitDataset(dataset, {batchesPerEpoch, epochs: 1});
+       model.setWeights([tfc.zeros([1, 1]), tfc.zeros([1])]);
 
-    const numTensors0 = tfc.memory().numTensors;
-    const history = await model.fitDataset(dataset, {epochs});
-    const numTensors1 = tfc.memory().numTensors;
-    expect(numTensors1).toEqual(numTensors0);
-    expect(Object.keys(history.history)).toEqual(['loss']);
-    expect(history.history.loss.length).toEqual(2);
-    expect(history.history.loss[0]).toBeCloseTo(0.923649);
-    expect(history.history.loss[1]).toBeCloseTo(0.722993);
-    expectArraysClose(model.getWeights()[0], tfc.tensor2d([[0.108621]]));
-    expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.108621]));
-  });
+       const numTensors0 = tfc.memory().numTensors;
+       const history =
+           await model.fitDataset(dataset, {batchesPerEpoch, epochs});
+       const numTensors1 = tfc.memory().numTensors;
+       expect(numTensors1).toEqual(numTensors0);
+       expect(Object.keys(history.history)).toEqual(['loss']);
+       expect(history.history.loss.length).toEqual(2);
+       expect(history.history.loss[0]).toBeCloseTo(0.923649);
+       expect(history.history.loss[1]).toBeCloseTo(0.722993);
+       expectArraysClose(model.getWeights()[0], tfc.tensor2d([[0.108621]]));
+       expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.108621]));
+     });
+
+  it('1 input, 1 output, no metric, no validation, no batchesPerEpoch',
+     async () => {
+       const model = createDenseModel();
+       model.compile({loss: 'meanSquaredError', optimizer: 'sgd'});
+
+       const batchSize = 8;
+       const epochs = 2;
+       const batchesPerEpoch = 3;
+       const xTensorsFunc =
+           () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
+             batchSize, 1
+           ])];
+       const yTensorsFunc =
+           () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
+             batchSize, 1
+           ])];
+       const dataset = new FakeNumericDataset({
+         xShape: [1],
+         yShape: [1],
+         batchSize,
+         numBatches: batchesPerEpoch,
+         xTensorsFunc,
+         yTensorsFunc
+       });
+
+       // Do a burn-in call to account for initialization of cached tensors (for
+       // the memory-leak check below).
+       await model.fitDataset(dataset, {epochs: 1});
+       model.setWeights([tfc.zeros([1, 1]), tfc.zeros([1])]);
+
+       const numTensors0 = tfc.memory().numTensors;
+       const history = await model.fitDataset(dataset, {epochs});
+       const numTensors1 = tfc.memory().numTensors;
+       expect(numTensors1).toEqual(numTensors0);
+       expect(Object.keys(history.history)).toEqual(['loss']);
+       expect(history.history.loss.length).toEqual(2);
+       expect(history.history.loss[0]).toBeCloseTo(0.923649);
+       expect(history.history.loss[1]).toBeCloseTo(0.722993);
+       expectArraysClose(model.getWeights()[0], tfc.tensor2d([[0.108621]]));
+       expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.108621]));
+     });
 
   // Reference Python tf.keras code:
   //
@@ -135,50 +179,98 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
   // print(model.get_weights()[0])
   // print(model.get_weights()[1])
   // ```
-  it('1 input, 1 output, 1 metric, no validation', async () => {
-    const model = createDenseModel();
-    model.compile(
-        {loss: 'meanSquaredError', optimizer: 'sgd', metrics: ['accuracy']});
+  it('1 input, 1 output, 1 metric, no validation, with batchesPerEpoch',
+     async () => {
+       const model = createDenseModel();
+       model.compile(
+           {loss: 'meanSquaredError', optimizer: 'sgd', metrics: ['accuracy']});
 
-    const batchSize = 8;
-    const epochs = 2;
-    const batchesPerEpoch = 3;
-    const xTensorsFunc =
-        () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
-          batchSize, 1
-        ])];
-    const yTensorsFunc =
-        () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
-          batchSize, 1
-        ])];
-    const dataset = new FakeNumericDataset({
-      xShape: [1],
-      yShape: [1],
-      batchSize,
-      numBatches: batchesPerEpoch,
-      xTensorsFunc,
-      yTensorsFunc
-    });
+       const batchSize = 8;
+       const epochs = 2;
+       const batchesPerEpoch = 3;
+       const xTensorsFunc = () =>
+           [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
+            tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
+            tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])];
+       const yTensorsFunc = () =>
+           [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
+            tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
+            tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])];
+       const dataset = new FakeNumericDataset({
+         xShape: [1],
+         yShape: [1],
+         batchSize,
+         numBatches: batchesPerEpoch * epochs,
+         xTensorsFunc,
+         yTensorsFunc
+       });
 
-    // Do a burn-in call to account for initialization of cached tensors (for
-    // the memory-leak check below).
-    await model.fitDataset(dataset, {epochs: 1});
-    model.setWeights([tfc.zeros([1, 1]), tfc.zeros([1])]);
+       // Do a burn-in call to account for initialization of cached tensors (for
+       // the memory-leak check below).
+       await model.fitDataset(dataset, {batchesPerEpoch, epochs: 1});
+       model.setWeights([tfc.zeros([1, 1]), tfc.zeros([1])]);
 
-    const numTensors0 = tfc.memory().numTensors;
-    const history = await model.fitDataset(dataset, {epochs});
-    const numTensors1 = tfc.memory().numTensors;
-    expect(numTensors1).toEqual(numTensors0);
-    expect(Object.keys(history.history)).toEqual(['loss', 'acc']);
-    expect(history.history.loss.length).toEqual(2);
-    expect(history.history.loss[0]).toBeCloseTo(0.923649);
-    expect(history.history.loss[1]).toBeCloseTo(0.722993);
-    expect(history.history.acc.length).toEqual(2);
-    expect(history.history.acc[0]).toBeCloseTo(0);
-    expect(history.history.acc[1]).toBeCloseTo(0);
-    expectArraysClose(model.getWeights()[0], tfc.tensor2d([[0.108621]]));
-    expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.108621]));
-  });
+       const numTensors0 = tfc.memory().numTensors;
+       const history =
+           await model.fitDataset(dataset, {batchesPerEpoch, epochs});
+       const numTensors1 = tfc.memory().numTensors;
+       expect(numTensors1).toEqual(numTensors0);
+       expect(Object.keys(history.history)).toEqual(['loss', 'acc']);
+       expect(history.history.loss.length).toEqual(2);
+       expect(history.history.loss[0]).toBeCloseTo(0.923649);
+       expect(history.history.loss[1]).toBeCloseTo(0.722993);
+       expect(history.history.acc.length).toEqual(2);
+       expect(history.history.acc[0]).toBeCloseTo(0);
+       expect(history.history.acc[1]).toBeCloseTo(0);
+       expectArraysClose(model.getWeights()[0], tfc.tensor2d([[0.108621]]));
+       expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.108621]));
+     });
+
+  it('1 input, 1 output, 1 metric, no validation, no batchesPerEpoch',
+     async () => {
+       const model = createDenseModel();
+       model.compile(
+           {loss: 'meanSquaredError', optimizer: 'sgd', metrics: ['accuracy']});
+
+       const batchSize = 8;
+       const epochs = 2;
+       const batchesPerEpoch = 3;
+       const xTensorsFunc =
+           () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
+             batchSize, 1
+           ])];
+       const yTensorsFunc =
+           () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
+             batchSize, 1
+           ])];
+       const dataset = new FakeNumericDataset({
+         xShape: [1],
+         yShape: [1],
+         batchSize,
+         numBatches: batchesPerEpoch,
+         xTensorsFunc,
+         yTensorsFunc
+       });
+
+       // Do a burn-in call to account for initialization of cached tensors (for
+       // the memory-leak check below).
+       await model.fitDataset(dataset, {epochs: 1});
+       model.setWeights([tfc.zeros([1, 1]), tfc.zeros([1])]);
+
+       const numTensors0 = tfc.memory().numTensors;
+       const history = await model.fitDataset(dataset, {epochs});
+       const numTensors1 = tfc.memory().numTensors;
+       expect(numTensors1).toEqual(numTensors0);
+       expect(Object.keys(history.history)).toEqual(['loss', 'acc']);
+       expect(history.history.loss.length).toEqual(2);
+       expect(history.history.loss[0]).toBeCloseTo(0.923649);
+       expect(history.history.loss[1]).toBeCloseTo(0.722993);
+       expect(history.history.acc.length).toEqual(2);
+       expect(history.history.acc[0]).toBeCloseTo(0);
+       expect(history.history.acc[1]).toBeCloseTo(0);
+       expectArraysClose(model.getWeights()[0], tfc.tensor2d([[0.108621]]));
+       expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.108621]));
+     });
 
   // Reference Python tf.keras code.
   //
@@ -221,79 +313,159 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
   // print(model.get_weights()[0])
   // print(model.get_weights()[1])
   // ```
-  it('1 input, 1 output, 1 metric, tensor validation, callback', async () => {
-    const model = createDenseModel();
-    model.compile(
-        {loss: 'meanSquaredError', optimizer: 'sgd', metrics: ['accuracy']});
+  it('1 input, 1 output, 1 metric, tensor validation, callback, ' +
+         'with batchesPerEpoch',
+     async () => {
+       const model = createDenseModel();
+       model.compile(
+           {loss: 'meanSquaredError', optimizer: 'sgd', metrics: ['accuracy']});
 
-    const batchSize = 8;
-    const epochs = 2;
-    const batchesPerEpoch = 3;
-    const xTensorsFunc =
-        () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
-          batchSize, 1
-        ])];
-    const yTensorsFunc =
-        () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
-          batchSize, 1
-        ])];
-    const dataset = new FakeNumericDataset({
-      xShape: [1],
-      yShape: [1],
-      batchSize,
-      numBatches: batchesPerEpoch,
-      xTensorsFunc,
-      yTensorsFunc
-    });
-    const valXs = tfc.zeros([batchSize * 2, 1]);
-    const valYs = tfc.zeros([batchSize * 2, 1]);
+       const batchSize = 8;
+       const epochs = 2;
+       const batchesPerEpoch = 3;
+       const xTensorsFunc = () =>
+           [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
+            tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
+            tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])];
+       const yTensorsFunc = () =>
+           [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
+            tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
+            tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])];
+       const dataset = new FakeNumericDataset({
+         xShape: [1],
+         yShape: [1],
+         batchSize,
+         numBatches: batchesPerEpoch * epochs,
+         xTensorsFunc,
+         yTensorsFunc
+       });
+       const valXs = tfc.zeros([batchSize * 2, 1]);
+       const valYs = tfc.zeros([batchSize * 2, 1]);
 
-    // Do a burn-in call to account for initialization of cached
-    // tensors (for the memory-leak check below).
-    await model.fitDataset(
-        dataset, {epochs: 1, validationData: [valXs, valYs]});
-    model.setWeights([tfc.zeros([1, 1]), tfc.zeros([1])]);
+       // Do a burn-in call to account for initialization of cached
+       // tensors (for the memory-leak check below).
+       await model.fitDataset(
+           dataset,
+           {batchesPerEpoch, epochs: 1, validationData: [valXs, valYs]});
+       model.setWeights([tfc.zeros([1, 1]), tfc.zeros([1])]);
 
-    const numTensors0 = tfc.memory().numTensors;
-    const epochEndValLosses: number[] = [];
-    const epochEndValAccs: number[] = [];
-    const history = await model.fitDataset(dataset, {
-      epochs,
-      validationData: [valXs, valYs],
-      callbacks: {
-        onEpochEnd: async (epoch, logs) => {
-          epochEndValLosses.push(logs.val_loss);
-          epochEndValAccs.push(logs.val_acc);
-        }
-      }
-    });
-    const numTensors1 = tfc.memory().numTensors;
-    expect(numTensors1).toEqual(numTensors0);
-    expect(Object.keys(history.history).sort()).toEqual([
-      'loss', 'acc', 'val_loss', 'val_acc'
-    ].sort());
-    expect(history.history.loss.length).toEqual(2);
-    expect(history.history.loss[0]).toBeCloseTo(0.923649);
-    expect(history.history.loss[1]).toBeCloseTo(0.722993);
-    expect(history.history.acc.length).toEqual(2);
-    expect(history.history.acc[0]).toBeCloseTo(0);
-    expect(history.history.acc[1]).toBeCloseTo(0);
-    expect(history.history.val_loss.length).toEqual(2);
-    expect(history.history.val_loss[0]).toBeCloseTo(0.003321);
-    expect(history.history.val_loss[1]).toBeCloseTo(0.011799);
-    expect(history.history.val_acc.length).toEqual(2);
-    expect(history.history.val_acc[0]).toBeCloseTo(1);
-    expect(history.history.val_acc[1]).toBeCloseTo(1);
-    expectArraysClose(model.getWeights()[0], tfc.tensor2d([[0.108621]]));
-    expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.108621]));
+       const numTensors0 = tfc.memory().numTensors;
+       const epochEndValLosses: number[] = [];
+       const epochEndValAccs: number[] = [];
+       const history = await model.fitDataset(dataset, {
+         batchesPerEpoch,
+         epochs,
+         validationData: [valXs, valYs],
+         callbacks: {
+           onEpochEnd: async (epoch, logs) => {
+             epochEndValLosses.push(logs.val_loss);
+             epochEndValAccs.push(logs.val_acc);
+           }
+         }
+       });
+       const numTensors1 = tfc.memory().numTensors;
+       expect(numTensors1).toEqual(numTensors0);
+       expect(Object.keys(history.history).sort()).toEqual([
+         'loss', 'acc', 'val_loss', 'val_acc'
+       ].sort());
+       expect(history.history.loss.length).toEqual(2);
+       expect(history.history.loss[0]).toBeCloseTo(0.923649);
+       expect(history.history.loss[1]).toBeCloseTo(0.722993);
+       expect(history.history.acc.length).toEqual(2);
+       expect(history.history.acc[0]).toBeCloseTo(0);
+       expect(history.history.acc[1]).toBeCloseTo(0);
+       expect(history.history.val_loss.length).toEqual(2);
+       expect(history.history.val_loss[0]).toBeCloseTo(0.003321);
+       expect(history.history.val_loss[1]).toBeCloseTo(0.011799);
+       expect(history.history.val_acc.length).toEqual(2);
+       expect(history.history.val_acc[0]).toBeCloseTo(1);
+       expect(history.history.val_acc[1]).toBeCloseTo(1);
+       expectArraysClose(model.getWeights()[0], tfc.tensor2d([[0.108621]]));
+       expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.108621]));
 
-    expect(epochEndValLosses.length).toEqual(2);
-    expect(epochEndValLosses[0]).toBeCloseTo(0.003321);
-    expect(epochEndValLosses[1]).toBeCloseTo(0.011799);
-    expect(epochEndValAccs.length).toEqual(2);
-    expect(epochEndValAccs[0]).toBeCloseTo(1);
-    expect(epochEndValAccs[1]).toBeCloseTo(1);
-  });
+       expect(epochEndValLosses.length).toEqual(2);
+       expect(epochEndValLosses[0]).toBeCloseTo(0.003321);
+       expect(epochEndValLosses[1]).toBeCloseTo(0.011799);
+       expect(epochEndValAccs.length).toEqual(2);
+       expect(epochEndValAccs[0]).toBeCloseTo(1);
+       expect(epochEndValAccs[1]).toBeCloseTo(1);
+     });
+
+  it('1 input, 1 output, 1 metric, tensor validation, callback, ' +
+         'no batchesPerEpoch',
+     async () => {
+       const model = createDenseModel();
+       model.compile(
+           {loss: 'meanSquaredError', optimizer: 'sgd', metrics: ['accuracy']});
+
+       const batchSize = 8;
+       const epochs = 2;
+       const batchesPerEpoch = 3;
+       const xTensorsFunc =
+           () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
+             batchSize, 1
+           ])];
+       const yTensorsFunc =
+           () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
+             batchSize, 1
+           ])];
+       const dataset = new FakeNumericDataset({
+         xShape: [1],
+         yShape: [1],
+         batchSize,
+         numBatches: batchesPerEpoch,
+         xTensorsFunc,
+         yTensorsFunc
+       });
+       const valXs = tfc.zeros([batchSize * 2, 1]);
+       const valYs = tfc.zeros([batchSize * 2, 1]);
+
+       // Do a burn-in call to account for initialization of cached
+       // tensors (for the memory-leak check below).
+       await model.fitDataset(
+           dataset, {epochs: 1, validationData: [valXs, valYs]});
+       model.setWeights([tfc.zeros([1, 1]), tfc.zeros([1])]);
+
+       const numTensors0 = tfc.memory().numTensors;
+       const epochEndValLosses: number[] = [];
+       const epochEndValAccs: number[] = [];
+       const history = await model.fitDataset(dataset, {
+         epochs,
+         validationData: [valXs, valYs],
+         callbacks: {
+           onEpochEnd: async (epoch, logs) => {
+             epochEndValLosses.push(logs.val_loss);
+             epochEndValAccs.push(logs.val_acc);
+           }
+         }
+       });
+       const numTensors1 = tfc.memory().numTensors;
+       expect(numTensors1).toEqual(numTensors0);
+       expect(Object.keys(history.history).sort()).toEqual([
+         'loss', 'acc', 'val_loss', 'val_acc'
+       ].sort());
+       expect(history.history.loss.length).toEqual(2);
+       expect(history.history.loss[0]).toBeCloseTo(0.923649);
+       expect(history.history.loss[1]).toBeCloseTo(0.722993);
+       expect(history.history.acc.length).toEqual(2);
+       expect(history.history.acc[0]).toBeCloseTo(0);
+       expect(history.history.acc[1]).toBeCloseTo(0);
+       expect(history.history.val_loss.length).toEqual(2);
+       expect(history.history.val_loss[0]).toBeCloseTo(0.003321);
+       expect(history.history.val_loss[1]).toBeCloseTo(0.011799);
+       expect(history.history.val_acc.length).toEqual(2);
+       expect(history.history.val_acc[0]).toBeCloseTo(1);
+       expect(history.history.val_acc[1]).toBeCloseTo(1);
+       expectArraysClose(model.getWeights()[0], tfc.tensor2d([[0.108621]]));
+       expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.108621]));
+
+       expect(epochEndValLosses.length).toEqual(2);
+       expect(epochEndValLosses[0]).toBeCloseTo(0.003321);
+       expect(epochEndValLosses[1]).toBeCloseTo(0.011799);
+       expect(epochEndValAccs.length).toEqual(2);
+       expect(epochEndValAccs[0]).toBeCloseTo(1);
+       expect(epochEndValAccs[1]).toBeCloseTo(1);
+     });
 
   // Reference Python tf.keras code:
   //
@@ -343,96 +515,196 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
   // print(model.get_weights()[0])
   // print(model.get_weights()[1])
   // ```
-  it('1 input, 1 output, 1 metric, dataset validation, callback', async () => {
-    const model = createDenseModel();
-    model.compile(
-        {loss: 'meanSquaredError', optimizer: 'sgd', metrics: ['accuracy']});
+  it('1 input, 1 output, 1 metric, dataset validation, callback, ' +
+         'with batchesPerEpoch',
+     async () => {
+       const model = createDenseModel();
+       model.compile(
+           {loss: 'meanSquaredError', optimizer: 'sgd', metrics: ['accuracy']});
 
-    const batchSize = 8;
-    const epochs = 2;
-    const batchesPerEpoch = 3;
+       const batchSize = 8;
+       const epochs = 2;
+       const batchesPerEpoch = 3;
 
-    // Training dataset.
-    const xTensorsFunc =
-        () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
-          batchSize, 1
-        ])];
-    const yTensorsFunc =
-        () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
-          batchSize, 1
-        ])];
-    const dataset = new FakeNumericDataset({
-      xShape: [1],
-      yShape: [1],
-      batchSize,
-      numBatches: batchesPerEpoch,
-      xTensorsFunc,
-      yTensorsFunc
-    });
+       // Training dataset.
+       const xTensorsFunc = () =>
+           [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
+            tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
+            tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])];
+       const yTensorsFunc = () =>
+           [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
+            tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
+            tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])];
+       const dataset = new FakeNumericDataset({
+         xShape: [1],
+         yShape: [1],
+         batchSize,
+         numBatches: batchesPerEpoch * epochs,
+         xTensorsFunc,
+         yTensorsFunc
+       });
 
-    // Validation dataset.
-    const valXTensorsFunc =
-        () => [tfc.zeros([batchSize, 1]), tfc.zeros([batchSize, 1]), tfc.zeros([
-          batchSize, 1
-        ])];
-    const valYTensorsFunc =
-        () => [tfc.zeros([batchSize, 1]), tfc.zeros([batchSize, 1]), tfc.zeros([
-          batchSize, 1
-        ])];
-    const valDataset = new FakeNumericDataset({
-      xShape: [1],
-      yShape: [1],
-      batchSize,
-      numBatches: batchesPerEpoch,
-      xTensorsFunc: valXTensorsFunc,
-      yTensorsFunc: valYTensorsFunc
-    });
+       // Validation dataset.
+       const valXTensorsFunc = () =>
+           [tfc.zeros([batchSize, 1]), tfc.zeros([batchSize, 1]),
+            tfc.zeros([batchSize, 1]), tfc.zeros([batchSize, 1]),
+            tfc.zeros([batchSize, 1]), tfc.zeros([batchSize, 1])];
+       const valYTensorsFunc = () =>
+           [tfc.zeros([batchSize, 1]), tfc.zeros([batchSize, 1]),
+            tfc.zeros([batchSize, 1]), tfc.zeros([batchSize, 1]),
+            tfc.zeros([batchSize, 1]), tfc.zeros([batchSize, 1])];
+       const valDataset = new FakeNumericDataset({
+         xShape: [1],
+         yShape: [1],
+         batchSize,
+         numBatches: batchesPerEpoch * epochs,
+         xTensorsFunc: valXTensorsFunc,
+         yTensorsFunc: valYTensorsFunc
+       });
 
-    // Do a burn-in call to account for initialization of cached
-    // tensors (for the memory-leak check below).
-    await model.fitDataset(dataset, {epochs, validationData: valDataset});
-    model.setWeights([tfc.zeros([1, 1]), tfc.zeros([1])]);
+       // Do a burn-in call to account for initialization of cached
+       // tensors (for the memory-leak check below).
+       await model.fitDataset(dataset, {
+         batchesPerEpoch,
+         epochs,
+         validationData: valDataset,
+         validationBatches: batchesPerEpoch * epochs
+       });
+       model.setWeights([tfc.zeros([1, 1]), tfc.zeros([1])]);
 
-    const numTensors0 = tfc.memory().numTensors;
-    const epochEndValLosses: number[] = [];
-    const epochEndValAccs: number[] = [];
-    const history = await model.fitDataset(dataset, {
-      epochs,
-      validationData: valDataset,
-      callbacks: {
-        onEpochEnd: async (epoch, logs) => {
-          epochEndValLosses.push(logs.val_loss);
-          epochEndValAccs.push(logs.val_acc);
-        }
-      }
-    });
-    const numTensors1 = tfc.memory().numTensors;
-    expect(numTensors1).toEqual(numTensors0);
-    expect(Object.keys(history.history).sort()).toEqual([
-      'loss', 'acc', 'val_loss', 'val_acc'
-    ].sort());
-    expect(history.history.loss.length).toEqual(2);
-    expect(history.history.loss[0]).toBeCloseTo(0.923649);
-    expect(history.history.loss[1]).toBeCloseTo(0.722993);
-    expect(history.history.acc.length).toEqual(2);
-    expect(history.history.acc[0]).toBeCloseTo(0);
-    expect(history.history.acc[1]).toBeCloseTo(0);
-    expect(history.history.val_loss.length).toEqual(2);
-    expect(history.history.val_loss[0]).toBeCloseTo(0.003321);
-    expect(history.history.val_loss[1]).toBeCloseTo(0.011799);
-    expect(history.history.val_acc.length).toEqual(2);
-    expect(history.history.val_acc[0]).toBeCloseTo(1);
-    expect(history.history.val_acc[1]).toBeCloseTo(1);
-    expectArraysClose(model.getWeights()[0], tfc.tensor2d([[0.108621]]));
-    expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.108621]));
+       const numTensors0 = tfc.memory().numTensors;
+       const epochEndValLosses: number[] = [];
+       const epochEndValAccs: number[] = [];
+       const history = await model.fitDataset(dataset, {
+         batchesPerEpoch,
+         epochs,
+         validationData: valDataset,
+         validationBatches: batchesPerEpoch * epochs,
+         callbacks: {
+           onEpochEnd: async (epoch, logs) => {
+             epochEndValLosses.push(logs.val_loss);
+             epochEndValAccs.push(logs.val_acc);
+           }
+         }
+       });
+       const numTensors1 = tfc.memory().numTensors;
+       expect(numTensors1).toEqual(numTensors0);
+       expect(Object.keys(history.history).sort()).toEqual([
+         'loss', 'acc', 'val_loss', 'val_acc'
+       ].sort());
+       expect(history.history.loss.length).toEqual(2);
+       expect(history.history.loss[0]).toBeCloseTo(0.923649);
+       expect(history.history.loss[1]).toBeCloseTo(0.722993);
+       expect(history.history.acc.length).toEqual(2);
+       expect(history.history.acc[0]).toBeCloseTo(0);
+       expect(history.history.acc[1]).toBeCloseTo(0);
+       expect(history.history.val_loss.length).toEqual(2);
+       expect(history.history.val_loss[0]).toBeCloseTo(0.003321);
+       expect(history.history.val_loss[1]).toBeCloseTo(0.011799);
+       expect(history.history.val_acc.length).toEqual(2);
+       expect(history.history.val_acc[0]).toBeCloseTo(1);
+       expect(history.history.val_acc[1]).toBeCloseTo(1);
+       expectArraysClose(model.getWeights()[0], tfc.tensor2d([[0.108621]]));
+       expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.108621]));
 
-    expect(epochEndValLosses.length).toEqual(2);
-    expect(epochEndValLosses[0]).toBeCloseTo(0.003321);
-    expect(epochEndValLosses[1]).toBeCloseTo(0.011799);
-    expect(epochEndValAccs.length).toEqual(2);
-    expect(epochEndValAccs[0]).toBeCloseTo(1);
-    expect(epochEndValAccs[1]).toBeCloseTo(1);
-  });
+       expect(epochEndValLosses.length).toEqual(2);
+       expect(epochEndValLosses[0]).toBeCloseTo(0.003321);
+       expect(epochEndValLosses[1]).toBeCloseTo(0.011799);
+       expect(epochEndValAccs.length).toEqual(2);
+       expect(epochEndValAccs[0]).toBeCloseTo(1);
+       expect(epochEndValAccs[1]).toBeCloseTo(1);
+     });
+
+  it('1 input, 1 output, 1 metric, dataset validation, callback, ' +
+         'no batchesPerEpoch',
+     async () => {
+       const model = createDenseModel();
+       model.compile(
+           {loss: 'meanSquaredError', optimizer: 'sgd', metrics: ['accuracy']});
+
+       const batchSize = 8;
+       const epochs = 2;
+       const batchesPerEpoch = 3;
+
+       // Training dataset.
+       const xTensorsFunc =
+           () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
+             batchSize, 1
+           ])];
+       const yTensorsFunc =
+           () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
+             batchSize, 1
+           ])];
+       const dataset = new FakeNumericDataset({
+         xShape: [1],
+         yShape: [1],
+         batchSize,
+         numBatches: batchesPerEpoch,
+         xTensorsFunc,
+         yTensorsFunc
+       });
+
+       // Validation dataset.
+       const valXTensorsFunc = () =>
+           [tfc.zeros([batchSize, 1]), tfc.zeros([batchSize, 1]),
+            tfc.zeros([batchSize, 1])];
+       const valYTensorsFunc = () =>
+           [tfc.zeros([batchSize, 1]), tfc.zeros([batchSize, 1]),
+            tfc.zeros([batchSize, 1])];
+       const valDataset = new FakeNumericDataset({
+         xShape: [1],
+         yShape: [1],
+         batchSize,
+         numBatches: batchesPerEpoch,
+         xTensorsFunc: valXTensorsFunc,
+         yTensorsFunc: valYTensorsFunc
+       });
+
+       // Do a burn-in call to account for initialization of cached
+       // tensors (for the memory-leak check below).
+       await model.fitDataset(dataset, {epochs, validationData: valDataset});
+       model.setWeights([tfc.zeros([1, 1]), tfc.zeros([1])]);
+
+       const numTensors0 = tfc.memory().numTensors;
+       const epochEndValLosses: number[] = [];
+       const epochEndValAccs: number[] = [];
+       const history = await model.fitDataset(dataset, {
+         epochs,
+         validationData: valDataset,
+         callbacks: {
+           onEpochEnd: async (epoch, logs) => {
+             epochEndValLosses.push(logs.val_loss);
+             epochEndValAccs.push(logs.val_acc);
+           }
+         }
+       });
+       const numTensors1 = tfc.memory().numTensors;
+       expect(numTensors1).toEqual(numTensors0);
+       expect(Object.keys(history.history).sort()).toEqual([
+         'loss', 'acc', 'val_loss', 'val_acc'
+       ].sort());
+       expect(history.history.loss.length).toEqual(2);
+       expect(history.history.loss[0]).toBeCloseTo(0.923649);
+       expect(history.history.loss[1]).toBeCloseTo(0.722993);
+       expect(history.history.acc.length).toEqual(2);
+       expect(history.history.acc[0]).toBeCloseTo(0);
+       expect(history.history.acc[1]).toBeCloseTo(0);
+       expect(history.history.val_loss.length).toEqual(2);
+       expect(history.history.val_loss[0]).toBeCloseTo(0.003321);
+       expect(history.history.val_loss[1]).toBeCloseTo(0.011799);
+       expect(history.history.val_acc.length).toEqual(2);
+       expect(history.history.val_acc[0]).toBeCloseTo(1);
+       expect(history.history.val_acc[1]).toBeCloseTo(1);
+       expectArraysClose(model.getWeights()[0], tfc.tensor2d([[0.108621]]));
+       expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.108621]));
+
+       expect(epochEndValLosses.length).toEqual(2);
+       expect(epochEndValLosses[0]).toBeCloseTo(0.003321);
+       expect(epochEndValLosses[1]).toBeCloseTo(0.011799);
+       expect(epochEndValAccs.length).toEqual(2);
+       expect(epochEndValAccs[0]).toBeCloseTo(1);
+       expect(epochEndValAccs[1]).toBeCloseTo(1);
+     });
 
   it('Memory leak check with metric and validation', async () => {
     const model = createDenseModel();

--- a/src/engine/training_dataset_test.ts
+++ b/src/engine/training_dataset_test.ts
@@ -63,37 +63,37 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
   // print(model.get_weights()[0])
   // print(model.get_weights()[1])
   // ```
-  it('1 input, 1 output, no metric, no validation', async () => {
+  fit('1 input, 1 output, no metric, no validation', async () => {
     const model = createDenseModel();
     model.compile({loss: 'meanSquaredError', optimizer: 'sgd'});
 
     const batchSize = 8;
     const epochs = 2;
     const batchesPerEpoch = 3;
-    const xTensorsFunc = () =>
-        [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])];
-    const yTensorsFunc = () =>
-        [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])];
+    const xTensorsFunc =
+        () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
+          batchSize, 1
+        ])];
+    const yTensorsFunc =
+        () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
+          batchSize, 1
+        ])];
     const dataset = new FakeNumericDataset({
       xShape: [1],
       yShape: [1],
       batchSize,
-      numBatches: batchesPerEpoch * epochs,
+      numBatches: batchesPerEpoch,
       xTensorsFunc,
       yTensorsFunc
     });
 
     // Do a burn-in call to account for initialization of cached tensors (for
     // the memory-leak check below).
-    await model.fitDataset(dataset, {batchesPerEpoch, epochs: 1});
+    await model.fitDataset(dataset, {epochs: 1});
     model.setWeights([tfc.zeros([1, 1]), tfc.zeros([1])]);
 
     const numTensors0 = tfc.memory().numTensors;
-    const history = await model.fitDataset(dataset, {batchesPerEpoch, epochs});
+    const history = await model.fitDataset(dataset, {epochs});
     const numTensors1 = tfc.memory().numTensors;
     expect(numTensors1).toEqual(numTensors0);
     expect(Object.keys(history.history)).toEqual(['loss']);
@@ -162,11 +162,11 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
 
     // Do a burn-in call to account for initialization of cached tensors (for
     // the memory-leak check below).
-    await model.fitDataset(dataset, {batchesPerEpoch, epochs: 1});
+    await model.fitDataset(dataset, {epochs: 1});
     model.setWeights([tfc.zeros([1, 1]), tfc.zeros([1])]);
 
     const numTensors0 = tfc.memory().numTensors;
-    const history = await model.fitDataset(dataset, {batchesPerEpoch, epochs});
+    const history = await model.fitDataset(dataset, {epochs});
     const numTensors1 = tfc.memory().numTensors;
     expect(numTensors1).toEqual(numTensors0);
     expect(Object.keys(history.history)).toEqual(['loss', 'acc']);
@@ -251,14 +251,13 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
     // Do a burn-in call to account for initialization of cached
     // tensors (for the memory-leak check below).
     await model.fitDataset(
-        dataset, {batchesPerEpoch, epochs: 1, validationData: [valXs, valYs]});
+        dataset, {epochs: 1, validationData: [valXs, valYs]});
     model.setWeights([tfc.zeros([1, 1]), tfc.zeros([1])]);
 
     const numTensors0 = tfc.memory().numTensors;
     const epochEndValLosses: number[] = [];
     const epochEndValAccs: number[] = [];
     const history = await model.fitDataset(dataset, {
-      batchesPerEpoch,
       epochs,
       validationData: [valXs, valYs],
       callbacks: {
@@ -389,19 +388,14 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
 
     // Do a burn-in call to account for initialization of cached
     // tensors (for the memory-leak check below).
-    await model.fitDataset(dataset, {
-      batchesPerEpoch,
-      epochs,
-      validationData: valDataset,
-      validationBatches: 2
-    });
+    await model.fitDataset(
+        dataset, {epochs, validationData: valDataset, validationBatches: 2});
     model.setWeights([tfc.zeros([1, 1]), tfc.zeros([1])]);
 
     const numTensors0 = tfc.memory().numTensors;
     const epochEndValLosses: number[] = [];
     const epochEndValAccs: number[] = [];
     const history = await model.fitDataset(dataset, {
-      batchesPerEpoch,
       epochs,
       validationData: valDataset,
       validationBatches: 2,
@@ -460,12 +454,11 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
     // Do a burn-in call to account for initialization of cached
     // tensors (for the memory-leak check below).
     await model.fitDataset(
-        dataset, {batchesPerEpoch, epochs: 1, validationData: [valXs, valYs]});
+        dataset, {epochs: 1, validationData: [valXs, valYs]});
     model.setWeights([tfc.zeros([1, 1]), tfc.zeros([1])]);
 
     const numTensors0 = tfc.memory().numTensors;
     await model.fitDataset(dataset, {
-      batchesPerEpoch,
       epochs,
       validationData: [valXs, valYs],
       callbacks: {
@@ -540,7 +533,7 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
 
     // Do a burn-in call to account for initialization of cached tensors (for
     // the memory-leak check below).
-    await model.fitDataset(dataset, {batchesPerEpoch, epochs: 1});
+    await model.fitDataset(dataset, {epochs: 1});
     model.setWeights([tfc.zeros([1, 1]), tfc.zeros([1])]);
 
     const numTensors0 = tfc.memory().numTensors;
@@ -555,7 +548,6 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
     const batchEndLosses: number[] = [];
     const batchEndAccs: number[] = [];
     const history = await model.fitDataset(dataset, {
-      batchesPerEpoch,
       epochs,
       callbacks: {
         onTrainBegin: async () => {
@@ -694,11 +686,11 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
 
     // Do a burn-in call to account for initialization of cached tensors (for
     // the memory-leak check below).
-    await model.fitDataset(dataset, {batchesPerEpoch, epochs: 1});
+    await model.fitDataset(dataset, {epochs: 1});
     model.setWeights([tfc.zeros([2, 1]), tfc.zeros([1])]);
 
     const numTensors0 = tfc.memory().numTensors;
-    const history = await model.fitDataset(dataset, {batchesPerEpoch, epochs});
+    const history = await model.fitDataset(dataset, {epochs});
     const numTensors1 = tfc.memory().numTensors;
     expect(numTensors1).toEqual(numTensors0);
     expect(Object.keys(history.history)).toEqual(['loss', 'acc']);
@@ -814,7 +806,6 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
     // Do a burn-in call to account for initialization of cached tensors (for
     // the memory-leak check below).
     await model.fitDataset(dataset, {
-      batchesPerEpoch,
       epochs: 1,
       validationData: [valXs, valYs],
       validationBatchSize: batchSize
@@ -823,7 +814,6 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
 
     const numTensors0 = tfc.memory().numTensors;
     const history = await model.fitDataset(dataset, {
-      batchesPerEpoch,
       epochs,
       validationData: [valXs, valYs],
       validationBatchSize: batchSize
@@ -954,7 +944,6 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
     // Do a burn-in call to account for initialization of cached tensors (for
     // the memory-leak check below).
     await model.fitDataset(dataset, {
-      batchesPerEpoch,
       epochs: 1,
       validationData: [valXs, valYs],
       validationBatchSize: batchSize
@@ -963,7 +952,6 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
 
     const numTensors0 = tfc.memory().numTensors;
     const history = await model.fitDataset(dataset, {
-      batchesPerEpoch,
       epochs,
       validationData: [valXs, valYs],
       validationBatchSize: batchSize
@@ -1033,7 +1021,7 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
 
     let errorCaught: Error;
     try {
-      await model.fitDataset(dataset, {batchesPerEpoch, epochs});
+      await model.fitDataset(dataset, {epochs});
     } catch (err) {
       errorCaught = err;
     }
@@ -1054,7 +1042,7 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
 
     // Do a burn-in call to account for initialization of cached tensors (for
     // the memory-leak check below).
-    await model.fitDataset(dataset, {batchesPerEpoch, epochs: 1});
+    await model.fitDataset(dataset, {epochs: 1});
     model.setWeights([tfc.zeros([1, 1]), tfc.zeros([1])]);
 
     const warningMessages: string[] = [];
@@ -1063,7 +1051,7 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
 
     const numTensors0 = tfc.memory().numTensors;
     const epochs = 3;
-    const history = await model.fitDataset(dataset, {batchesPerEpoch, epochs});
+    const history = await model.fitDataset(dataset, {epochs});
     const numTensors1 = tfc.memory().numTensors;
     expect(numTensors1).toEqual(numTensors0);
     expect(Object.keys(history.history)).toEqual(['loss']);
@@ -1090,7 +1078,7 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
 
     let errorCaught: Error;
     try {
-      await model.fitDataset(dataset, {batchesPerEpoch: numBatches, epochs});
+      await model.fitDataset(dataset, {epochs});
     } catch (err) {
       errorCaught = err;
     }
@@ -1128,7 +1116,6 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
     let errorCaught: Error;
     try {
       await model.fitDataset(dataset, {
-        batchesPerEpoch,
         epochs,
         validationData: valDataset,
       });

--- a/src/engine/training_dataset_test.ts
+++ b/src/engine/training_dataset_test.ts
@@ -1282,8 +1282,8 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
            [tfc.zeros([batchSize, 1]), tfc.zeros([batchSize, 1])];
        const valYs = tfc.zeros([batchSize, 1]);
 
-       // Do a burn-in call to account for initialization of cached tensors (for
-       // the memory-leak check below).
+       // Do a burn-in call to account for initialization of cached tensors
+       // (for the memory-leak check below).
        await model.fitDataset(dataset, {
          batchesPerEpoch,
          epochs: 1,
@@ -1772,9 +1772,9 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
     expect(history.history.loss.length).toEqual(3);
     expect(warningMessages.length).toEqual(2);
     expect(warningMessages[0])
-        .toMatch(/You provided `batchesPerEpoch` but .* 9 batches/);
+        .toMatch(/You provided `batchesPerEpoch` as .* 9 batches/);
     expect(warningMessages[1])
-        .toMatch(/You provided `batchesPerEpoch` but .* 9 batches/);
+        .toMatch(/You provided `batchesPerEpoch` as .* 9 batches/);
   });
 
   it('Calling fitDataset() without calling compile() errors', async () => {

--- a/src/engine/training_dataset_test.ts
+++ b/src/engine/training_dataset_test.ts
@@ -63,7 +63,7 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
   // print(model.get_weights()[0])
   // print(model.get_weights()[1])
   // ```
-  fit('1 input, 1 output, no metric, no validation', async () => {
+  it('1 input, 1 output, no metric, no validation', async () => {
     const model = createDenseModel();
     model.compile({loss: 'meanSquaredError', optimizer: 'sgd'});
 
@@ -143,19 +143,19 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
     const batchSize = 8;
     const epochs = 2;
     const batchesPerEpoch = 3;
-    const xTensorsFunc = () =>
-        [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])];
-    const yTensorsFunc = () =>
-        [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])];
+    const xTensorsFunc =
+        () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
+          batchSize, 1
+        ])];
+    const yTensorsFunc =
+        () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
+          batchSize, 1
+        ])];
     const dataset = new FakeNumericDataset({
       xShape: [1],
       yShape: [1],
       batchSize,
-      numBatches: batchesPerEpoch * epochs,
+      numBatches: batchesPerEpoch,
       xTensorsFunc,
       yTensorsFunc
     });
@@ -229,19 +229,19 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
     const batchSize = 8;
     const epochs = 2;
     const batchesPerEpoch = 3;
-    const xTensorsFunc = () =>
-        [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])];
-    const yTensorsFunc = () =>
-        [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])];
+    const xTensorsFunc =
+        () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
+          batchSize, 1
+        ])];
+    const yTensorsFunc =
+        () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
+          batchSize, 1
+        ])];
     const dataset = new FakeNumericDataset({
       xShape: [1],
       yShape: [1],
       batchSize,
-      numBatches: batchesPerEpoch * epochs,
+      numBatches: batchesPerEpoch,
       xTensorsFunc,
       yTensorsFunc
     });
@@ -343,7 +343,7 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
   // print(model.get_weights()[0])
   // print(model.get_weights()[1])
   // ```
-  it('1 input, 1 output, 1 metric, dataset validation, callback', async () => {
+  fit('1 input, 1 output, 1 metric, dataset validation, callback', async () => {
     const model = createDenseModel();
     model.compile(
         {loss: 'meanSquaredError', optimizer: 'sgd', metrics: ['accuracy']});
@@ -353,19 +353,19 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
     const batchesPerEpoch = 3;
 
     // Training dataset.
-    const xTensorsFunc = () =>
-        [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])];
-    const yTensorsFunc = () =>
-        [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])];
+    const xTensorsFunc =
+        () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
+          batchSize, 1
+        ])];
+    const yTensorsFunc =
+        () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
+          batchSize, 1
+        ])];
     const dataset = new FakeNumericDataset({
       xShape: [1],
       yShape: [1],
       batchSize,
-      numBatches: batchesPerEpoch * epochs,
+      numBatches: batchesPerEpoch,
       xTensorsFunc,
       yTensorsFunc
     });
@@ -388,8 +388,7 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
 
     // Do a burn-in call to account for initialization of cached
     // tensors (for the memory-leak check below).
-    await model.fitDataset(
-        dataset, {epochs, validationData: valDataset, validationBatches: 2});
+    await model.fitDataset(dataset, {epochs, validationData: valDataset});
     model.setWeights([tfc.zeros([1, 1]), tfc.zeros([1])]);
 
     const numTensors0 = tfc.memory().numTensors;
@@ -398,7 +397,6 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
     const history = await model.fitDataset(dataset, {
       epochs,
       validationData: valDataset,
-      validationBatches: 2,
       callbacks: {
         onEpochEnd: async (epoch, logs) => {
           epochEndValLosses.push(logs.val_loss);
@@ -442,12 +440,8 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
     const batchSize = 8;
     const epochs = 3;
     const batchesPerEpoch = 3;
-    const dataset = new FakeNumericDataset({
-      xShape: [1],
-      yShape: [1],
-      batchSize,
-      numBatches: batchesPerEpoch * epochs
-    });
+    const dataset = new FakeNumericDataset(
+        {xShape: [1], yShape: [1], batchSize, numBatches: batchesPerEpoch});
     const valXs = tfc.zeros([batchSize * 2, 1]);
     const valYs = tfc.zeros([batchSize * 2, 1]);
 
@@ -514,19 +508,19 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
     const batchSize = 8;
     const epochs = 2;
     const batchesPerEpoch = 3;
-    const xTensorsFunc = () =>
-        [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])];
-    const yTensorsFunc = () =>
-        [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])];
+    const xTensorsFunc =
+        () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
+          batchSize, 1
+        ])];
+    const yTensorsFunc =
+        () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
+          batchSize, 1
+        ])];
     const dataset = new FakeNumericDataset({
       xShape: [1],
       yShape: [1],
       batchSize,
-      numBatches: batchesPerEpoch * epochs,
+      numBatches: batchesPerEpoch,
       xTensorsFunc,
       yTensorsFunc
     });
@@ -661,25 +655,23 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
       const output: {[name: string]: tfc.Tensor[]} = {};
       output[input1.name] = [
         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-        tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-        tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])
+        tfc.ones([batchSize, 1])
       ];
       output[input2.name] = [
         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-        tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-        tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])
+        tfc.ones([batchSize, 1])
       ];
       return output;
     };
-    const yTensorsFunc = () =>
-        [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])];
+    const yTensorsFunc =
+        () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
+          batchSize, 1
+        ])];
     const dataset = new FakeNumericDataset({
       xShape: [1],
       yShape: [1],
       batchSize,
-      numBatches: batchesPerEpoch * epochs,
+      numBatches: batchesPerEpoch,
       xTensorsFunc,
       yTensorsFunc
     });
@@ -775,25 +767,23 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
       const output: {[name: string]: tfc.Tensor[]} = {};
       output[input1.name] = [
         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-        tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-        tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])
+        tfc.ones([batchSize, 1])
       ];
       output[input2.name] = [
         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-        tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-        tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])
+        tfc.ones([batchSize, 1])
       ];
       return output;
     };
-    const yTensorsFunc = () =>
-        [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])];
+    const yTensorsFunc =
+        () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
+          batchSize, 1
+        ])];
     const dataset = new FakeNumericDataset({
       xShape: [1],
       yShape: [1],
       batchSize,
-      numBatches: batchesPerEpoch * epochs,
+      numBatches: batchesPerEpoch,
       xTensorsFunc,
       yTensorsFunc
     });
@@ -912,25 +902,23 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
       const output: {[name: string]: tfc.Tensor[]} = {};
       output[input1.name] = [
         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-        tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-        tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])
+        tfc.ones([batchSize, 1])
       ];
       output[input2.name] = [
         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-        tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-        tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])
+        tfc.ones([batchSize, 1])
       ];
       return output;
     };
-    const yTensorsFunc = () =>
-        [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])];
+    const yTensorsFunc =
+        () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
+          batchSize, 1
+        ])];
     const dataset = new FakeNumericDataset({
       xShape: [1],
       yShape: [1],
       batchSize,
-      numBatches: batchesPerEpoch * epochs,
+      numBatches: batchesPerEpoch,
       xTensorsFunc,
       yTensorsFunc
     });
@@ -1000,21 +988,20 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
       const output: {[name: string]: tfc.Tensor[]} = {};
       output[input1.name] = [
         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-        tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-        tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])
+        tfc.ones([batchSize, 1])
       ];
       // Note: input2 is missing from the data, by intention.
       return output;
     };
-    const yTensorsFunc = () =>
-        [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
-         tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])];
+    const yTensorsFunc =
+        () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
+          batchSize, 1
+        ])];
     const dataset = new FakeNumericDataset({
       xShape: [1],
       yShape: [1],
       batchSize,
-      numBatches: batchesPerEpoch * epochs,
+      numBatches: batchesPerEpoch,
       xTensorsFunc,
       yTensorsFunc
     });
@@ -1096,20 +1083,12 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
     const batchesPerEpoch = 3;
 
     // Training dataset.
-    const dataset = new FakeNumericDataset({
-      xShape: [1],
-      yShape: [1],
-      batchSize,
-      numBatches: batchesPerEpoch * epochs
-    });
+    const dataset = new FakeNumericDataset(
+        {xShape: [1], yShape: [1], batchSize, numBatches: batchesPerEpoch});
 
     // Validation dataset.
-    const valDataset = new FakeNumericDataset({
-      xShape: [1],
-      yShape: [1],
-      batchSize,
-      numBatches: batchesPerEpoch * epochs
-    });
+    const valDataset = new FakeNumericDataset(
+        {xShape: [1], yShape: [1], batchSize, numBatches: batchesPerEpoch});
 
     // Do a burn-in call to account for initialization of cached
     // tensors (for the memory-leak check below).
@@ -1180,12 +1159,10 @@ describeMathCPUAndGPU('Model.evaluateDataset', () => {
 
     // Do a burn-in call to account for initialization of cached tensors (for
     // the memory-leak check below).
-    tfc.dispose(
-        await model.evaluateDataset(dataset, {batches}) as tfc.Scalar[]);
+    tfc.dispose(await model.evaluateDataset(dataset, {}) as tfc.Scalar[]);
 
     const numTensors0 = tfc.memory().numTensors;
-    const evalOut =
-        await model.evaluateDataset(dataset, {batches}) as tfc.Scalar;
+    const evalOut = await model.evaluateDataset(dataset, {}) as tfc.Scalar;
     const expectedLoss = tfc.scalar(1.0);
     expectTensorsClose(evalOut, expectedLoss);
     tfc.dispose(evalOut);
@@ -1248,12 +1225,10 @@ describeMathCPUAndGPU('Model.evaluateDataset', () => {
 
     // Do a burn-in call to account for initialization of cached tensors (for
     // the memory-leak check below).
-    tfc.dispose(
-        await model.evaluateDataset(dataset, {batches}) as tfc.Scalar[]);
+    tfc.dispose(await model.evaluateDataset(dataset, {}) as tfc.Scalar[]);
 
     const numTensors0 = tfc.memory().numTensors;
-    const evalOut =
-        await model.evaluateDataset(dataset, {batches}) as tfc.Scalar[];
+    const evalOut = await model.evaluateDataset(dataset, {}) as tfc.Scalar[];
     expect(evalOut.length).toEqual(2);
     const expectedLoss = tfc.scalar(1.0);
     const expectedAcc = tfc.scalar(0.0);
@@ -1276,15 +1251,14 @@ describeMathCPUAndGPU('Model.evaluateDataset', () => {
 
     // Do a burn-in call to account for initialization of cached tensors (for
     // the memory-leak check below).
-    tfc.dispose(
-        await model.evaluateDataset(dataset, {batches}) as tfc.Scalar[]);
+    tfc.dispose(await model.evaluateDataset(dataset, {}) as tfc.Scalar[]);
 
     const warningMessages: string[] = [];
     spyOn(console, 'warn')
         .and.callFake((msg: string) => warningMessages.push(msg));
 
     const numTensors0 = tfc.memory().numTensors;
-    tfc.dispose(await model.evaluateDataset(dataset, {batches: batches + 2}));
+    tfc.dispose(await model.evaluateDataset(dataset, {}));
     const numTensors1 = tfc.memory().numTensors;
     expect(numTensors1).toEqual(numTensors0);
 
@@ -1372,12 +1346,11 @@ describeMathCPUAndGPU('Model.evaluateDataset', () => {
 
     // Do a burn-in call to account for initialization of cached tensors (for
     // the memory-leak check below).
-    await model.evaluateDataset(dataset, {batches});
+    await model.evaluateDataset(dataset, {});
     model.setWeights([tfc.zeros([2, 1]), tfc.zeros([1])]);
 
     const numTensors0 = tfc.memory().numTensors;
-    const evalOut =
-        await model.evaluateDataset(dataset, {batches}) as tfc.Scalar[];
+    const evalOut = await model.evaluateDataset(dataset, {}) as tfc.Scalar[];
     const expectedLoss = tfc.scalar(1.0);
     const expectedAcc = tfc.scalar(0.0);
     expectTensorsClose(evalOut[0], expectedLoss);


### PR DESCRIPTION
Make 

batchesPerEpoch in ModelFitDatasetConfig,
validationBatches in ModelFitDatasetConfig,
batches in ModelEvaluateDatasetConfig,

optional. In each place, if corresponded batches count is not specified, use iterator.next().done as signal to stop an epoch.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/368)
<!-- Reviewable:end -->
