### PR TITLE
Reset stopTraining at start of model training

### DIFF
--- a/src/engine/training_dataset.ts
+++ b/src/engine/training_dataset.ts
@@ -328,6 +328,7 @@ export async function fitDataset<T extends TensorContainer>(
     model.history = history;
 
     await callbackList.onTrainBegin();
+    model.stopTraining_ = false;
     let epoch = config.initialEpoch == null ? 0 : config.initialEpoch;
     const epochLogs: UnresolvedLogs = {};
 


### PR DESCRIPTION
#### Description
<!--
Please describe the pull request here.
Also, if this is an issue/bug fix, please add the issue link for reference here.
-->
It's a bit unexpected that `stopTraining` stays set even when calling `fit` again. Running `fit` on a model that had `stopTraining` set currently leads to it running for a moment then exiting.

PR resets `stopTraining` at the start of each training run, I can't think of any reason why you'd want it to persist and stop new calls to `fit` immediately.

---
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/376)
<!-- Reviewable:end -->
