### PR TITLE
Set model for fitDataset callback list

### DIFF
--- a/src/engine/training_dataset.ts
+++ b/src/engine/training_dataset.ts
@@ -324,6 +324,7 @@ export async function fitDataset<T extends TensorContainer>(
         config.batchesPerEpoch,
         null,  // Batch size determined by the dataset itself.
         doValidation, callbackMetrics);
+    callbackList.setModel(model);
     model.history = history;
 
     await callbackList.onTrainBegin();


### PR DESCRIPTION
#### Description
<!--
Please describe the pull request here.
Also, if this is an issue/bug fix, please add the issue link for reference here.
-->
This ensures callbacks that work for `fit` also work for `fitDataset`, as without the `setModel` call, `this.model` isn't available in callbacks for `fitDataset`.


---
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/378)
<!-- Reviewable:end -->
