### PR TITLE
Fix a bug in which kwarg is not passed properly to internally nested containers

### DIFF
--- a/src/engine/container.ts
+++ b/src/engine/container.ts
@@ -818,7 +818,7 @@ export abstract class Container extends Layer {
       for (let i = 0; i < this.inputs.length; ++i) {
         feedDict.add(this.inputs[i], inputs[i]);
       }
-      return execute(this.outputs, feedDict, kwargs) as Tensor | Tensor[];  
+      return execute(this.outputs, feedDict, kwargs) as Tensor | Tensor[];
     });
   }
 

--- a/src/engine/container.ts
+++ b/src/engine/container.ts
@@ -816,12 +816,8 @@ export abstract class Container extends Layer {
       inputs = generic_utils.toList(inputs);
       const feedDict = new FeedDict();
       for (let i = 0; i < this.inputs.length; ++i) {
-        // console.log('symbolic name:', this.inputs[i].name);
-        // console.log('symbolic shape:', this.inputs[i].shape);
-        // console.log('concrete shape:', inputs[i].shape);
         feedDict.add(this.inputs[i], inputs[i]);
       }
-      // console.log('Calling execute() from Container.call()');  // DEBUG
       return execute(this.outputs, feedDict, kwargs) as Tensor | Tensor[];  
     });
   }
@@ -1002,8 +998,6 @@ export abstract class Container extends Layer {
             if (kwargs.mask == null) {
               kwargs['mask'] = computedMask;
             }
-            console.log(`Length =1 call, layer.name = ${layer.name}`);  // DEBUG
-            console.log((layer.input as SymbolicTensor).shape);  // DEBUG
             outputTensors =
                 generic_utils.toList(layer.call(computedTensor, kwargs));
             outputMasks = generic_utils.toList(
@@ -1016,7 +1010,6 @@ export abstract class Container extends Layer {
             if (kwargs.mask == null) {
               kwargs['mask'] = computedMasks;
             }
-            console.log('Length >1 call');  // DEBUG
             outputTensors =
                 generic_utils.toList(layer.call(computedTensors, kwargs));
             outputMasks = generic_utils.toList(

--- a/src/engine/container.ts
+++ b/src/engine/container.ts
@@ -812,19 +812,6 @@ export abstract class Container extends Layer {
    *   are more than one outputs.
    */
   call(inputs: Tensor|Tensor[], kwargs: Kwargs): Tensor|Tensor[] {
-    // return tidy(() => {
-    //   inputs = generic_utils.toList(inputs);
-    //   let masks: Tensor[];
-
-    //   if ('mask' in kwargs) {
-    //     masks = generic_utils.toList(kwargs['mask']);
-    //   } else {
-    //     masks = generic_utils.pyListRepeat(null, inputs.length);
-    //   }
-    //   // TODO(michaelterry): Add support for caching.
-    //   return this.runInternalGraph(inputs, masks)[0];
-    // });
-    // console.log(`In Container.call(), this.name = ${this.name}`);  // DEBUG
     return tidy(() => {
       inputs = generic_utils.toList(inputs);
       const feedDict = new FeedDict();

--- a/src/engine/container_test.ts
+++ b/src/engine/container_test.ts
@@ -15,7 +15,8 @@ import {describeMathCPUAndGPU, expectTensorsClose} from '../utils/test_utils';
 
 import {Container, ContainerConfig} from './container';
 import {execute, FeedDict} from './executor';
-import {getSourceInputs, Layer, LayerConfig} from './topology';
+import {getSourceInputs, Layer, LayerConfig, SymbolicTensor, CallHook} from './topology';
+import {Kwargs} from '../types';
 
 class LayerForTest extends tfl.layers.Layer {
   static className = 'LayerForTest';
@@ -645,5 +646,28 @@ describeMathCPUAndGPU('Model-dispose', () => {
 
     // At this point, the inner model should have become unusable.
     expect(() => innerModel.predict(xsInner)).toThrowError(/already disposed/);
+  });
+
+  fit('Nested model gets the correct kwargs', async () => {
+    const innerModel = tfl.sequential();
+    const layer = tfl.layers.dense({
+      units: 1,inputShape: [5], activation: 'sigmoid'});
+    innerModel.add(layer);
+
+    const input = tfl.input({shape: [5]});
+    const output = innerModel.apply(input) as SymbolicTensor;
+    const model = tfl.model({inputs: input, outputs: output});
+    model.compile({loss: 'meanSquaredError', optimizer: 'sgd'});
+
+    const kwargsArray: Kwargs[] = [];
+    const recordKwargsHook: CallHook =
+        (inputs: Tensor|Tensor[], kwargs: {}) => kwargsArray.push(kwargs);
+    layer.setCallHook(recordKwargsHook);
+
+    const xs = ones([3, 5]);
+    const ys = ones([3, 1]);
+    await model.trainOnBatch(xs, ys);
+    expect(kwargsArray.length).toEqual(1);
+    expect(kwargsArray[0]['training']).toEqual(true);
   });
 });

--- a/src/engine/container_test.ts
+++ b/src/engine/container_test.ts
@@ -648,7 +648,7 @@ describeMathCPUAndGPU('Model-dispose', () => {
     expect(() => innerModel.predict(xsInner)).toThrowError(/already disposed/);
   });
 
-  fit('Nested model gets the correct kwargs', async () => {
+  it('Nested model gets the correct kwargs', async () => {
     const innerModel = tfl.sequential();
     const layer = tfl.layers.dense({
       units: 1,inputShape: [5], activation: 'sigmoid'});

--- a/src/engine/executor.ts
+++ b/src/engine/executor.ts
@@ -25,32 +25,16 @@ import {SymbolicTensor} from './topology';
  * Helper function to check the dtype and shape compatibility of a feed value.
  */
 function assertFeedCompatibility(key: SymbolicTensor, val: Tensor): Tensor {
-  // 1. Check shape compatibility.  If shapes are not compatible, error.
-  if (key.shape != null) {
-    if (key.shape.length !== val.shape.length) {
-      throw new ValueError(
-          `The rank of feed (${val.shape.length}) does not match the rank of ` +
-          `the key (${key.shape.length}).`);
-    }
-
-    for (let i = 0; i < key.shape.length; ++i) {
-      if (key.shape[i] != null && key.shape[i] !== val.shape[i]) {
-        throw new ValueError(
-            `The ${i}-th dimension of the feed (${val.shape[i]}) is ` +
-            `incompatible with that of the key (${key.shape[i]}).`);
-      }
-    }
-  }
-  // 2. Check dtype compatibility.
+  // Check dtype compatibility.
   if (key.dtype == null || key.dtype === val.dtype) {
-    //  2a.  If types match, return val tensor as is.
+    //  a.  If types match, return val tensor as is.
     return val;
   }
   try {
-    //  2b. Attempt to convert to expected type.
+    //  b. Attempt to convert to expected type.
     return cast(val, key.dtype);
   } catch (err) {
-    //  2c. If conversion fails, return helpful error.
+    //  c. If conversion fails, return helpful error.
     throw new ValueError(
         `The dtype of the feed (${val.dtype}) can not be cast to the dtype ` +
         `of the key '${key.name}' (${key.dtype}).`);

--- a/src/engine/executor_test.ts
+++ b/src/engine/executor_test.ts
@@ -86,18 +86,6 @@ describeMathCPU('FeedDict', () => {
     const feedDict = new FeedDict([{key: s, value: sValue}]);
     expect(feedDict.getValue(s)).toEqual(sValue);
   });
-  it('Feeding incompatible rank leads to error', () => {
-    const s = tfl.input({shape: [null, 4], name: 's', dtype: 'float32'});
-    const sValue = tensor2d([1, 3, 3, 7], [1, 4]);
-    expect(() => new FeedDict([{key: s, value: sValue}]))
-        .toThrowError(/rank of feed .* does not match/);
-  });
-  it('Feeding incompatible dimension leads to error', () => {
-    const s = tfl.input({shape: [null, 4], name: 's', dtype: 'float32'});
-    const sValue = tensor3d([0, 0, 8], [1, 1, 3]);
-    expect(() => new FeedDict([{key: s, value: sValue}]))
-        .toThrowError(/The 2-th dimension of the feed .* is incompatible/);
-  });
 });
 
 describeMathCPUAndGPU('Executor', () => {

--- a/src/layers/wrappers.ts
+++ b/src/layers/wrappers.ts
@@ -218,7 +218,6 @@ export class TimeDistributed extends Wrapper {
   }
 
   call(inputs: Tensor|Tensor[], kwargs: Kwargs): Tensor|Tensor[] {
-    console.log('In TimeDistributed.call()');  // DEBUG
     return tidy(() => {
       // TODO(cais): Add 'training' and 'useLearningPhase' to kwargs.
       inputs = getExactlyOneTensor(inputs);
@@ -226,13 +225,10 @@ export class TimeDistributed extends Wrapper {
       // values. Hence the inputs can't have an undetermined first (batch)
       // dimension, which is why we always use the K.rnn approach here.
       const step: RnnStepFunction = (inputs: Tensor, states: Tensor[]) => {
-        console.log(`In step()`);  // DEBUG
         // TODO(cais): Add useLearningPhase.
         // NOTE(cais): `layer.call` may return a length-1 array of Tensor in
         //   some cases (e.g., `layer` is a `Sequential` instance), which is
         //   why `getExactlyOneTensor` is used below.
-        console.log(`Calling this.layers.call(): kwargs = ${kwargs}`);  // DEBUG
-        console.log(`  inputs.shape = ${inputs.shape}`);  // DEBUG
         const output = getExactlyOneTensor(this.layer.call(inputs, kwargs));
         return [output, []];
       };

--- a/src/layers/wrappers.ts
+++ b/src/layers/wrappers.ts
@@ -218,6 +218,7 @@ export class TimeDistributed extends Wrapper {
   }
 
   call(inputs: Tensor|Tensor[], kwargs: Kwargs): Tensor|Tensor[] {
+    console.log('In TimeDistributed.call()');  // DEBUG
     return tidy(() => {
       // TODO(cais): Add 'training' and 'useLearningPhase' to kwargs.
       inputs = getExactlyOneTensor(inputs);
@@ -225,10 +226,13 @@ export class TimeDistributed extends Wrapper {
       // values. Hence the inputs can't have an undetermined first (batch)
       // dimension, which is why we always use the K.rnn approach here.
       const step: RnnStepFunction = (inputs: Tensor, states: Tensor[]) => {
+        console.log(`In step()`);  // DEBUG
         // TODO(cais): Add useLearningPhase.
         // NOTE(cais): `layer.call` may return a length-1 array of Tensor in
         //   some cases (e.g., `layer` is a `Sequential` instance), which is
         //   why `getExactlyOneTensor` is used below.
+        console.log(`Calling this.layers.call(): kwargs = ${kwargs}`);  // DEBUG
+        console.log(`  inputs.shape = ${inputs.shape}`);  // DEBUG
         const output = getExactlyOneTensor(this.layer.call(inputs, kwargs));
         return [output, []];
       };

--- a/src/layers/wrappers_test.ts
+++ b/src/layers/wrappers_test.ts
@@ -80,16 +80,44 @@ describeMathCPUAndGPU('TimeDistributed Layer: Tensor', () => {
             [[[3], [7], [11], [15]], [[-3], [-7], [-11], [-15]]], [2, 4, 1]));
   });
 
+  // Reference Python Keras code:
+  // ```py
+  // import keras
+  // import numpy as np
+  //
+  // model_as_layer = keras.Sequential(
+  //     layers=[keras.layers.Dense(
+  //         units=3,
+  //         input_shape=[2, 5],
+  //         kernel_initializer='ones',
+  //         activation='softmax')])
+  //
+  // td = keras.layers.TimeDistributed(
+  //     layer=model_as_layer, input_shape=[2, 5])
+  // model = keras.Sequential(layers=[td])
+  // model.summary()
+  //
+  // xs = np.ones([1, 2, 5])
+  // ys = model.predict(xs)
+  // print(ys)
+  // ```
   it('Model as constituent layer', () => {
+    console.log('---------- Test begins --------------');  // DEBUG
     const modelAsLayer = tfl.sequential({
-      layers: [tfl.layers.dense(
-          {activation: 'softmax', units: 3, inputShape: [2, 5]})]
+      layers: [tfl.layers.dense({
+        activation: 'softmax',
+        units: 3,
+        inputShape: [2, 5],
+        kernelInitializer: 'ones'})],
     });
     const td =
         tfl.layers.timeDistributed({layer: modelAsLayer, inputShape: [2, 5]});
     const model = tfl.sequential({layers: [td]});
     const ys = model.predict(ones([1, 2, 5])) as Tensor;
     expect(ys.shape).toEqual([1, 2, 3]);
+    expectTensorsClose(ys, tensor3d(
+        [[[0.33333334, 0.33333334, 0.33333334],
+          [0.33333334, 0.33333334, 0.33333334]]]));
   });
 });
 

--- a/src/layers/wrappers_test.ts
+++ b/src/layers/wrappers_test.ts
@@ -102,7 +102,6 @@ describeMathCPUAndGPU('TimeDistributed Layer: Tensor', () => {
   // print(ys)
   // ```
   it('Model as constituent layer', () => {
-    console.log('---------- Test begins --------------');  // DEBUG
     const modelAsLayer = tfl.sequential({
       layers: [tfl.layers.dense({
         activation: 'softmax',


### PR DESCRIPTION
- Discovered this problem when working on the MNIST-ACGAN example. The generator model was a functional model that contained a nested sequential model. During `trainOnBatch()` calls, the kwarg `training: true` was not passed down properly. This PR fixes that.
- This PR also unifies execution with `executor.execute()`. The `runInternalGraph()` method will eventually be completely removed.
- The rank and shape check in the `FeedDict` class is removed. It turns out that in some special cases, it is fine to pass mismatched ranks. If such cases do cause problems, the underlying `Layer` or sub-Container will throw an error by itself.

BUG

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/384)
<!-- Reviewable:end -->
