### PR TITLE
rnn(): Replace repeated slice() and concat() with unstack() and stack()

### DIFF
--- a/src/layers/recurrent.ts
+++ b/src/layers/recurrent.ts
@@ -228,10 +228,6 @@ export function rnn(
     if (needPerStepOutputs) {
       outputs = tfc.stack(perStepOutputs, 1);
     }
-    // The last element is `lastOutput` and shouldn't be disposed.
-    // perStepOutputs.pop();
-    // tfc.dispose([perStepInputs]);
-    // tfc.dispose([perStepInputs, perStepOutputs]);
     return [lastOutput, outputs, states] as [Tensor, Tensor, Tensor[]];
   });
 }

--- a/src/layers/recurrent.ts
+++ b/src/layers/recurrent.ts
@@ -230,7 +230,8 @@ export function rnn(
     }
     let outputs: Tensor;
     if (needPerStepOutputs) {
-      outputs = tfc.stack(perStepOutputs, 1);
+      const axis = 1;
+      outputs = tfc.stack(perStepOutputs, axis);
     }
     return [lastOutput, outputs, states] as [Tensor, Tensor, Tensor[]];
   });


### PR DESCRIPTION
PERF

Benchmark numbers: 

Each individual number below is an average from 20 predict() calls. Only the numbers from relevant number types are shown. CNNs and dense-only models are not shown. So as you can see, there is a consistent small speed up (on the order of 3-3.5%) across the four RNN model types in the benchmark.

BEFORE (master)
SimpleRNN 32.9, 30.1, 32.7, 34.4, 33.2, 32.6
GRU 122.6, 116.9, 112.1, 118.6, 112.1, 113.6
LSTM 92.4, 96.1, 90.2, 89.4, 92.7, 88.8
Attention 120.9, 113.9, 114.8, 110.6, 113.8, 114.4

AFTER (rnn-concat-perf)
SimpleRNN 31.5, 31.6, 31.3, 30.6, 33.4, 31.2
GRU 113.1, 112.8, 111.6, 115.7, 109.1, 109.1
LSTM 90.5, 86.7, 87.8, 89.4, 88.2, 88.0
Attention 112.2, 114.3, 110.8, 108.2, 110.9, 112.2

Changes:
p-values are from `scipy.stats.ttest_ind()`.

SimpleRNN: 32.65 --> 31.6, -3.22%, p = 0.16
GRU: 116 --> 111.9, -3.52%, p = 0.068
LSTM: 91.6 --> 88.44, -3.56%, p = 0.028
Attention: 114.73 --> 111.44, -2.88%, p = 0.067

Regarding https://github.com/tensorflow/tfjs/issues/863

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/389)
<!-- Reviewable:end -->
