### PR TITLE
Fix doc for tf.layers.dot()

### DIFF
--- a/src/layers/merge.ts
+++ b/src/layers/merge.ts
@@ -1076,12 +1076,13 @@ function batchDot(x: Tensor, y: Tensor, axes: number|[number, number]): Tensor {
  * Example:
  *
  * ```js
- * const dotLayer = tf.layers.dot({axis: -1});
+ * const dotLayer = tf.layers.dot({axes: -1});
  * const x1 = tf.tensor2d([[10, 20], [30, 40]]);
  * const x2 = tf.tensor2d([[-1, -2], [-3, -4]]);
  *
  * // Invoke the layer's apply() method in eager (imperative) mode.
  * const y = dotLayer.apply([x1, x2]);
+ * y.print();
  * ```
  */
 export class Dot extends Merge {


### PR DESCRIPTION
The javascript example uses {axis : -1} as option for tf.layer.dot, which is useless. the correct option would be {axes : -1}.
I have also added a y.print(); line to show the result.

#### Description
<!--
Please describe the pull request here.
Also, if this is an issue/bug fix, please add the issue link for reference here.
-->
A simple fir for the tf.layers.dot() documentation
---
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/395)
<!-- Reviewable:end -->
