### PR TITLE
Move ActivationIdentifier into src/keras_format (3/n)

### DIFF
--- a/src/activations.ts
+++ b/src/activations.ts
@@ -12,8 +12,9 @@
 import * as tfc from '@tensorflow/tfjs-core';
 import {serialization, Tensor, tidy} from '@tensorflow/tfjs-core';
 
-import * as K from './backend/tfjs_backend';
 import {getScalar} from './backend/state';
+import * as K from './backend/tfjs_backend';
+import {ActivationIdentifier} from './keras_format/activation_config';
 import {deserializeKerasObject} from './utils/generic_utils';
 
 /**
@@ -29,10 +30,6 @@ export abstract class Activation extends serialization.Serializable {
     return {};
   }
 }
-
-/** @docinline */
-export type ActivationIdentifier = 'elu'|'hardSigmoid'|'linear'|'relu'|'relu6'|
-    'selu'|'sigmoid'|'softmax'|'softplus'|'softsign'|'tanh'|string;
 
 /**
  * Exponential linear unit (ELU).

--- a/src/keras_format/activation_config.ts
+++ b/src/keras_format/activation_config.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ * =============================================================================
+ */
+
+/** @docinline */
+export type ActivationIdentifier = 'elu'|'hardSigmoid'|'linear'|'relu'|'relu6'|
+    'selu'|'sigmoid'|'softmax'|'softplus'|'softsign'|'tanh'|string;

--- a/src/keras_format/initializer_config.ts
+++ b/src/keras_format/initializer_config.ts
@@ -64,32 +64,32 @@ export interface IdentitySerialization {
 }
 
 export interface LeCunNormalSerialization {
-  class_name: 'lecun_normal';
+  class_name: 'LeCunNormal';
   config: {seed?: number;};
 }
 
 export interface LeCunUniformSerialization {
-  class_name: 'lecun_uniform';
+  class_name: 'LeCunUniform';
   config: {seed?: number;};
 }
 
 export interface GlorotNormalSerialization {
-  class_name: 'glorot_normal';
+  class_name: 'GlorotNormal';
   config: {seed?: number;};
 }
 
 export interface GlorotUniformSerialization {
-  class_name: 'glorot_uniform';
+  class_name: 'GlorotUniform';
   config: {seed?: number;};
 }
 
 export interface HeNormalSerialization {
-  class_name: 'he_normal';
+  class_name: 'HeNormal';
   config: {seed?: number;};
 }
 
 export interface HeUniformSerialization {
-  class_name: 'he_uniform';
+  class_name: 'HeUniform';
   config: {seed?: number;};
 }
 

--- a/src/keras_format/initializer_config.ts
+++ b/src/keras_format/initializer_config.ts
@@ -27,76 +27,72 @@ export interface OnesSerialization {
 
 export interface ConstantSerialization {
   class_name: 'Constant';
-  config: {value: number;};
+  config: {
+
+    value: number;
+  };
 }
 
 export interface RandomNormalSerialization {
   class_name: 'RandomNormal';
-  config: {mean?: number; stddev?: number; seed?: number;};
+  config: {
+
+    mean?: number;
+    stddev?: number;
+    seed?: number;
+  };
 }
 
 export interface RandomUniformSerialization {
   class_name: 'RandomUniform';
-  config: {minval?: number; maxval?: number; seed?: number;};
+  config: {
+
+    minval?: number;
+    maxval?: number;
+    seed?: number;
+  };
 }
 
 export interface TruncatedNormalSerialization {
   class_name: 'TruncatedNormal';
-  config: {mean?: number; stddev?: number; seed?: number;};
+  config: {
+
+    mean?: number;
+    stddev?: number;
+    seed?: number;
+  };
 }
 
 export interface VarianceScalingSerialization {
   class_name: 'VarianceScaling';
   config: {
-    scale: number; mode: FanMode; distribution: Distribution;
+
+    scale: number;
+
+    mode: FanMode;
+    distribution: Distribution;
     seed?: number;
   };
 }
 
 export interface OrthogonalSerialization {
   class_name: 'Orthogonal';
-  config: {seed?: number; gain?: number;};
+  config: {
+
+    seed?: number;
+    gain?: number;
+  };
 }
 
 export interface IdentitySerialization {
   class_name: 'Identity';
-  config: {gain?: number;};
-}
+  config: {
 
-export interface LeCunNormalSerialization {
-  class_name: 'LeCunNormal';
-  config: {seed?: number;};
-}
-
-export interface LeCunUniformSerialization {
-  class_name: 'LeCunUniform';
-  config: {seed?: number;};
-}
-
-export interface GlorotNormalSerialization {
-  class_name: 'GlorotNormal';
-  config: {seed?: number;};
-}
-
-export interface GlorotUniformSerialization {
-  class_name: 'GlorotUniform';
-  config: {seed?: number;};
-}
-
-export interface HeNormalSerialization {
-  class_name: 'HeNormal';
-  config: {seed?: number;};
-}
-
-export interface HeUniformSerialization {
-  class_name: 'HeUniform';
-  config: {seed?: number;};
+    gain?: number;
+  };
 }
 
 export type InitializerSerialization =
     ConstantSerialization|RandomUniformSerialization|RandomNormalSerialization|
     TruncatedNormalSerialization|IdentitySerialization|
-    VarianceScalingSerialization|OrthogonalSerialization|
-    LeCunNormalSerialization|LeCunUniformSerialization|
-    GlorotNormalSerialization|GlorotUniformSerialization|HeNormalSerialization|
-    HeUniformSerialization;
+    VarianceScalingSerialization|OrthogonalSerialization;

--- a/src/layers/core.ts
+++ b/src/layers/core.ts
@@ -14,13 +14,14 @@
 
 import {Scalar, serialization, Tensor, tidy, transpose, util} from '@tensorflow/tfjs-core';
 
-import {Activation as ActivationFn, ActivationIdentifier, getActivation, serializeActivation} from '../activations';
+import {Activation as ActivationFn, getActivation, serializeActivation} from '../activations';
 import {getScalar} from '../backend/state';
 import * as K from '../backend/tfjs_backend';
 import {Constraint, ConstraintIdentifier, getConstraint, serializeConstraint} from '../constraints';
 import {InputSpec, Layer, LayerArgs} from '../engine/topology';
 import {NotImplementedError, ValueError} from '../errors';
 import {getInitializer, Initializer, InitializerIdentifier, serializeInitializer} from '../initializers';
+import {ActivationIdentifier} from '../keras_format/activation_config';
 import {Shape} from '../keras_format/types';
 import {getRegularizer, Regularizer, RegularizerIdentifier, serializeRegularizer} from '../regularizers';
 import {Kwargs} from '../types';

--- a/src/layers/core_test.ts
+++ b/src/layers/core_test.ts
@@ -14,7 +14,6 @@
 
 import {mul, ones, scalar, Tensor, tensor2d, tensor3d, tensor4d, zeros} from '@tensorflow/tfjs-core';
 
-import {ActivationIdentifier} from '../activations';
 import * as K from '../backend/tfjs_backend';
 import * as tfl from '../index';
 import {InitializerIdentifier} from '../initializers';
@@ -22,6 +21,7 @@ import {pyListRepeat} from '../utils/generic_utils';
 import {arrayProd} from '../utils/math_utils';
 import {convertPythonicToTs, convertTsToPythonic} from '../utils/serialization_utils';
 import {describeMathCPU, describeMathCPUAndGPU, expectTensorsClose} from '../utils/test_utils';
+import {ActivationIdentifier} from '../keras_format/activation_config';
 
 describe('Dropout Layer: Symbolic', () => {
   const dropoutRates = [0, 0.5];

--- a/src/layers/recurrent.ts
+++ b/src/layers/recurrent.ts
@@ -15,7 +15,7 @@
 import * as tfc from '@tensorflow/tfjs-core';
 import {DataType, serialization, Tensor, tidy, util} from '@tensorflow/tfjs-core';
 
-import {Activation, ActivationIdentifier, getActivation, serializeActivation} from '../activations';
+import {Activation, getActivation, serializeActivation} from '../activations';
 import {getScalar} from '../backend/state';
 import * as K from '../backend/tfjs_backend';
 import {Constraint, ConstraintIdentifier, getConstraint, serializeConstraint} from '../constraints';
@@ -23,6 +23,7 @@ import {InputSpec, SymbolicTensor} from '../engine/topology';
 import {Layer, LayerArgs} from '../engine/topology';
 import {AttributeError, NotImplementedError, ValueError} from '../errors';
 import {getInitializer, Initializer, InitializerIdentifier, Ones, serializeInitializer} from '../initializers';
+import {ActivationIdentifier} from '../keras_format/activation_config';
 import {Shape} from '../keras_format/types';
 import {getRegularizer, Regularizer, RegularizerIdentifier, serializeRegularizer} from '../regularizers';
 import {Kwargs, RnnStepFunction} from '../types';


### PR DESCRIPTION
This is very confusing!  Activation functions are serialized only as a string identifier, not as a `*Serializable` type.  The string identifier is given by a `static readonly className` field in each class, which may differ from the actual class name (in capitalization, at least).  The identifiers are lowerCamelCase.  The `ActivationIdentifier` type recapitulates exactly the strings given in the `className` fields.  Hence, the `ActivationIdentifier` type is needed as part of the serialization format spec.

That is all in contrast to Constraints, Initializers, and Regularizers.  In those cases, serialization is done via a full `*Serializable` type, where the `class_name` field is populated from the actual class name (always UpperCamelCase).  In those cases, the values of `ConstraintIdentifier`, `InitializerIdentifier`, and `RegularizerIdentifier` are in lowerCamelCase, and they are used only in the course of accepting constructor arguments during programmatic use of the API.  Thus, those `*Identifier` types *do not* form part of the serialization spec.

FEATURE Provide types describing the Keras JSON format (3/n)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/416)
<!-- Reviewable:end -->
