### PR TITLE
Enforce *Serialization is JSON-like. Add top level, training_config etc. (7/n)

### DIFF
--- a/src/engine/topology.ts
+++ b/src/engine/topology.ts
@@ -359,7 +359,7 @@ export interface LayerArgs {
    */
   batchInputShape?: Shape;
   /**
-   * If `inputShape` is specified and `batchInputShape` is *not* specifiedd,
+   * If `inputShape` is specified and `batchInputShape` is *not* specified,
    * `batchSize` is used to construct the `batchInputShape`: `[batchSize,
    * ...inputShape]`
    */

--- a/src/keras_format/common.ts
+++ b/src/keras_format/common.ts
@@ -29,3 +29,7 @@ export const VALID_POOL_MODE_VALUES = ['max', 'avg'];
 /** @docinline */
 export type BidirectionalMergeMode = 'sum'|'mul'|'concat'|'ave';
 export const VALID_BIDIRECTIONAL_MERGE_MODES = ['sum', 'mul', 'concat', 'ave'];
+
+/** @docinline */
+export type SampleWeightMode = 'temporal';
+export const VALID_SAMPLE_WEIGHT_MODES = ['temporal'];

--- a/src/keras_format/constraint_config.ts
+++ b/src/keras_format/constraint_config.ts
@@ -11,7 +11,7 @@
 import {BaseSerialization} from './types';
 
 export type MaxNormConfig = {
-  maxValue?: number;
+  max_value?: number;
   axis?: number;
 };
 
@@ -27,8 +27,8 @@ export type UnitNormSerialization =
 export type NonNegSerialization = BaseSerialization<'NonNeg', null>;
 
 export type MinMaxNormConfig = {
-  minValue?: number;
-  maxValue?: number;
+  min_value?: number;
+  max_value?: number;
   axis?: number;
   rate?: number;
 };

--- a/src/keras_format/constraint_config.ts
+++ b/src/keras_format/constraint_config.ts
@@ -8,24 +8,33 @@
  * =============================================================================
  */
 
-export interface MaxNormSerialization {
-  class_name: 'MaxNorm';
-  config: {maxValue?: number; axis?: number;};
-}
+import {BaseSerialization} from './types';
 
-export interface UnitNormSerialization {
-  class_name: 'UnitNorm';
-  config: {axis?: number;};
-}
+export type MaxNormConfig = {
+  maxValue?: number;
+  axis?: number;
+};
 
-export interface NonNegSerialization {
-  class_name: 'NonNeg';
-}
+export type MaxNormSerialization = BaseSerialization<'MaxNorm', MaxNormConfig>;
 
-export interface MinMaxNormSerialization {
-  class_name: 'MinMaxNorm';
-  config: {minValue?: number; maxValue?: number; axis?: number; rate?: number;};
-}
+export type UnitNormConfig = {
+  axis?: number;
+};
+
+export type UnitNormSerialization =
+    BaseSerialization<'UnitNorm', UnitNormConfig>;
+
+export type NonNegSerialization = BaseSerialization<'NonNeg', null>;
+
+export type MinMaxNormConfig = {
+  minValue?: number;
+  maxValue?: number;
+  axis?: number;
+  rate?: number;
+};
+
+export type MinMaxNormSerialization =
+    BaseSerialization<'MinMaxNorm', MinMaxNormConfig>;
 
 export type ConstraintSerialization = MaxNormSerialization|NonNegSerialization|
     UnitNormSerialization|MinMaxNormSerialization;

--- a/src/keras_format/initializer_config.ts
+++ b/src/keras_format/initializer_config.ts
@@ -8,6 +8,7 @@
  * =============================================================================
  */
 
+import {BaseSerialization} from './types';
 
 /** @docinline */
 export type FanMode = 'fanIn'|'fanOut'|'fanAvg';
@@ -17,80 +18,69 @@ export const VALID_FAN_MODE_VALUES = ['fanIn', 'fanOut', 'fanAvg'];
 export type Distribution = 'normal'|'uniform';
 export const VALID_DISTRIBUTION_VALUES = ['normal', 'uniform'];
 
-export interface ZerosSerialization {
-  class_name: 'Zeros';
-}
+export type ZerosSerialization = BaseSerialization<'Zeros', null>;
 
-export interface OnesSerialization {
-  class_name: 'Ones';
-}
+export type OnesSerialization = BaseSerialization<'Ones', null>;
 
-export interface ConstantSerialization {
-  class_name: 'Constant';
-  config: {
+export type ConstantConfig = {
+  value: number;
+};
 
-    value: number;
-  };
-}
+export type ConstantSerialization =
+    BaseSerialization<'Constant', ConstantConfig>;
 
-export interface RandomNormalSerialization {
-  class_name: 'RandomNormal';
-  config: {
+export type RandomNormalConfig = {
+  mean?: number;
+  stddev?: number;
+  seed?: number;
+};
 
-    mean?: number;
-    stddev?: number;
-    seed?: number;
-  };
-}
+export type RandomNormalSerialization =
+    BaseSerialization<'RandomNormal', RandomNormalConfig>;
 
-export interface RandomUniformSerialization {
-  class_name: 'RandomUniform';
-  config: {
+export type RandomUniformConfig = {
+  minval?: number;
+  maxval?: number;
+  seed?: number;
+};
 
-    minval?: number;
-    maxval?: number;
-    seed?: number;
-  };
-}
+export type RandomUniformSerialization =
+    BaseSerialization<'RandomUniform', RandomUniformConfig>;
 
-export interface TruncatedNormalSerialization {
-  class_name: 'TruncatedNormal';
-  config: {
+export type TruncatedNormalConfig = {
+  mean?: number;
+  stddev?: number;
+  seed?: number;
+};
 
-    mean?: number;
-    stddev?: number;
-    seed?: number;
-  };
-}
+export type TruncatedNormalSerialization =
+    BaseSerialization<'TruncatedNormal', TruncatedNormalConfig>;
 
-export interface VarianceScalingSerialization {
-  class_name: 'VarianceScaling';
-  config: {
+export type VarianceScalingConfig = {
+  scale: number;
 
-    scale: number;
+  mode: FanMode;
+  distribution: Distribution;
+  seed?: number;
+};
 
-    mode: FanMode;
-    distribution: Distribution;
-    seed?: number;
-  };
-}
+export type VarianceScalingSerialization =
+    BaseSerialization<'VarianceScaling', VarianceScalingConfig>;
 
-export interface OrthogonalSerialization {
-  class_name: 'Orthogonal';
-  config: {
+export type OrthogonalConfig = {
+  seed?: number;
+  gain?: number;
+};
 
-    seed?: number;
-    gain?: number;
-  };
-}
+export type OrthogonalSerialization =
+    BaseSerialization<'Orthogonal', OrthogonalConfig>;
 
-export interface IdentitySerialization {
-  class_name: 'Identity';
-  config: {
+export type IdentityConfig = {
+  gain?: number;
+};
 
-    gain?: number;
-  };
-}
+export type IdentitySerialization =
+    BaseSerialization<'Identity', IdentityConfig>;
 
 export type InitializerSerialization =
     ConstantSerialization|RandomUniformSerialization|RandomNormalSerialization|

--- a/src/keras_format/input_config.ts
+++ b/src/keras_format/input_config.ts
@@ -14,9 +14,9 @@ import {Shape} from './common';
 import {BaseSerialization} from './types';
 
 export type InputLayerConfig = {
-  inputShape?: Shape;
-  batchSize?: number;
-  batchInputShape?: Shape;
+  input_shape?: Shape;
+  batch_size?: number;
+  batch_input_shape?: Shape;
   dtype?: DataType;
   sparse?: boolean;
   name?: string;

--- a/src/keras_format/input_config.ts
+++ b/src/keras_format/input_config.ts
@@ -11,15 +11,16 @@
 import {DataType} from '@tensorflow/tfjs-core';
 
 import {Shape} from './common';
+import {BaseSerialization} from './types';
 
-export interface InputLayerSerialization {
-  class_name: 'Input';
-  config: {
-    inputShape?: Shape;
-    batchSize?: number;
-    batchInputShape?: Shape;
-    dtype?: DataType;
-    sparse?: boolean;
-    name?: string;
-  };
-}
+export type InputLayerConfig = {
+  inputShape?: Shape;
+  batchSize?: number;
+  batchInputShape?: Shape;
+  dtype?: DataType;
+  sparse?: boolean;
+  name?: string;
+};
+
+export type InputLayerSerialization =
+    BaseSerialization<'Input', InputLayerConfig>;

--- a/src/keras_format/layers/advanced_activation_serialization.ts
+++ b/src/keras_format/layers/advanced_activation_serialization.ts
@@ -11,25 +11,21 @@
 import {ConstraintSerialization} from '../constraint_config';
 import {InitializerSerialization} from '../initializer_config';
 import {RegularizerSerialization} from '../regularizer_config';
-import {LayerConfig} from '../topology_config';
+import {BaseLayerSerialization, LayerConfig} from '../topology_config';
 
 export interface ReLULayerConfig extends LayerConfig {
   maxValue?: number;
 }
 
-export interface ReLULayerSerialization {
-  class_name: 'ReLU';
-  config: ReLULayerConfig;
-}
+export type ReLULayerSerialization =
+    BaseLayerSerialization<'ReLU', ReLULayerConfig>;
 
 export interface LeakyReLULayerConfig extends LayerConfig {
   alpha?: number;
 }
 
-export interface LeakyReLULayerSerialization {
-  class_name: 'LeakyReLU';
-  config: LeakyReLULayerConfig;
-}
+export type LeakyReLULayerSerialization =
+    BaseLayerSerialization<'LeakyReLU', LeakyReLULayerConfig>;
 
 export interface PReLULayerConfig extends LayerConfig {
   alphaInitializer?: InitializerSerialization;
@@ -38,37 +34,29 @@ export interface PReLULayerConfig extends LayerConfig {
   sharedAxes?: number|number[];
 }
 
-export interface PReLULayerSerialization {
-  class_name: 'PReLU';
-  config: PReLULayerConfig;
-}
+export type PReLULayerSerialization =
+    BaseLayerSerialization<'PReLU', PReLULayerConfig>;
 
 export interface ELULayerConfig extends LayerConfig {
   alpha?: number;
 }
 
-export interface ELULayerSerialization {
-  class_name: 'ELU';
-  config: ELULayerConfig;
-}
+export type ELULayerSerialization =
+    BaseLayerSerialization<'ELU', ELULayerConfig>;
 
 export interface ThresholdedReLULayerConfig extends LayerConfig {
   theta?: number;
 }
 
-export interface ThresholdedReLULayerSerialization {
-  class_name: 'ThresholdedReLU';
-  config: ThresholdedReLULayerConfig;
-}
+export type ThresholdedReLULayerSerialization =
+    BaseLayerSerialization<'ThresholdedReLU', ThresholdedReLULayerConfig>;
 
 export interface SoftmaxLayerConfig extends LayerConfig {
   axis?: number;
 }
 
-export interface SoftmaxLayerSerialization {
-  class_name: 'Softmax';
-  config: SoftmaxLayerConfig;
-}
+export type SoftmaxLayerSerialization =
+    BaseLayerSerialization<'Softmax', SoftmaxLayerConfig>;
 
 export type AdvancedActivationLayerSerialization = ReLULayerSerialization|
     LeakyReLULayerSerialization|PReLULayerSerialization|ELULayerSerialization|

--- a/src/keras_format/layers/advanced_activation_serialization.ts
+++ b/src/keras_format/layers/advanced_activation_serialization.ts
@@ -14,7 +14,7 @@ import {RegularizerSerialization} from '../regularizer_config';
 import {BaseLayerSerialization, LayerConfig} from '../topology_config';
 
 export interface ReLULayerConfig extends LayerConfig {
-  maxValue?: number;
+  max_value?: number;
 }
 
 export type ReLULayerSerialization =
@@ -28,10 +28,10 @@ export type LeakyReLULayerSerialization =
     BaseLayerSerialization<'LeakyReLU', LeakyReLULayerConfig>;
 
 export interface PReLULayerConfig extends LayerConfig {
-  alphaInitializer?: InitializerSerialization;
-  alphaRegularizer?: RegularizerSerialization;
-  alphaConstraint?: ConstraintSerialization;
-  sharedAxes?: number|number[];
+  alpha_initializer?: InitializerSerialization;
+  alpha_regularizer?: RegularizerSerialization;
+  alpha_constraint?: ConstraintSerialization;
+  shared_axes?: number|number[];
 }
 
 export type PReLULayerSerialization =

--- a/src/keras_format/layers/convolutional_depthwise_serialization.ts
+++ b/src/keras_format/layers/convolutional_depthwise_serialization.ts
@@ -11,6 +11,8 @@
 import {ConstraintSerialization} from '../constraint_config';
 import {InitializerSerialization} from '../initializer_config';
 import {RegularizerSerialization} from '../regularizer_config';
+import {BaseLayerSerialization} from '../topology_config';
+
 import {BaseConvLayerConfig} from './convolutional_serialization';
 
 export interface DepthwiseConv2DLayerConfig extends BaseConvLayerConfig {
@@ -21,7 +23,5 @@ export interface DepthwiseConv2DLayerConfig extends BaseConvLayerConfig {
   depthwiseRegularizer?: RegularizerSerialization;
 }
 
-export interface DepthwiseConv2DLayerSerialization {
-  class_name: 'DepthwiseConv2D';
-  config: DepthwiseConv2DLayerConfig;
-}
+export type DepthwiseConv2DLayerSerialization =
+    BaseLayerSerialization<'DepthwiseConv2D', DepthwiseConv2DLayerConfig>;

--- a/src/keras_format/layers/convolutional_depthwise_serialization.ts
+++ b/src/keras_format/layers/convolutional_depthwise_serialization.ts
@@ -16,11 +16,11 @@ import {BaseLayerSerialization} from '../topology_config';
 import {BaseConvLayerConfig} from './convolutional_serialization';
 
 export interface DepthwiseConv2DLayerConfig extends BaseConvLayerConfig {
-  kernelSize: number|[number, number];
-  depthMultiplier?: number;
-  depthwiseInitializer?: InitializerSerialization;
-  depthwiseConstraint?: ConstraintSerialization;
-  depthwiseRegularizer?: RegularizerSerialization;
+  kernel_size: number|[number, number];
+  depth_multiplier?: number;
+  depthwise_initializer?: InitializerSerialization;
+  depthwise_constraint?: ConstraintSerialization;
+  depthwise_regularizer?: RegularizerSerialization;
 }
 
 export type DepthwiseConv2DLayerSerialization =

--- a/src/keras_format/layers/convolutional_serialization.ts
+++ b/src/keras_format/layers/convolutional_serialization.ts
@@ -15,20 +15,20 @@ import {RegularizerSerialization} from '../regularizer_config';
 import {BaseLayerSerialization, LayerConfig} from '../topology_config';
 
 export interface BaseConvLayerConfig extends LayerConfig {
-  kernelSize: number|number[];
+  kernel_size: number|number[];
   strides?: number|number[];
   padding?: PaddingMode;
-  dataFormat?: DataFormat;
-  dilationRate?: number|[number]|[number, number];
+  data_format?: DataFormat;
+  dilation_rate?: number|[number]|[number, number];
   activation?: string;
-  useBias?: boolean;
-  kernelInitializer?: InitializerSerialization;
-  biasInitializer?: InitializerSerialization;
-  kernelConstraint?: ConstraintSerialization;
-  biasConstraint?: ConstraintSerialization;
-  kernelRegularizer?: RegularizerSerialization;
-  biasRegularizer?: RegularizerSerialization;
-  activityRegularizer?: RegularizerSerialization;
+  use_bias?: boolean;
+  kernel_initializer?: InitializerSerialization;
+  bias_initializer?: InitializerSerialization;
+  kernel_constraint?: ConstraintSerialization;
+  bias_constraint?: ConstraintSerialization;
+  kernel_regularizer?: RegularizerSerialization;
+  bias_regularizer?: RegularizerSerialization;
+  activity_regularizer?: RegularizerSerialization;
 }
 
 export interface ConvLayerConfig extends BaseConvLayerConfig {

--- a/src/keras_format/layers/convolutional_serialization.ts
+++ b/src/keras_format/layers/convolutional_serialization.ts
@@ -12,7 +12,7 @@ import {DataFormat, PaddingMode} from '../common';
 import {ConstraintSerialization} from '../constraint_config';
 import {InitializerSerialization} from '../initializer_config';
 import {RegularizerSerialization} from '../regularizer_config';
-import {LayerConfig} from '../topology_config';
+import {BaseLayerSerialization, LayerConfig} from '../topology_config';
 
 export interface BaseConvLayerConfig extends LayerConfig {
   kernelSize: number|number[];
@@ -35,7 +35,5 @@ export interface ConvLayerConfig extends BaseConvLayerConfig {
   filters: number;
 }
 
-export interface ConvLayerSerialization {
-  class_name: 'Conv';
-  config: ConvLayerConfig;
-}
+export type ConvLayerSerialization =
+    BaseLayerSerialization<'Conv', ConvLayerConfig>;

--- a/src/keras_format/layers/core_serialization.ts
+++ b/src/keras_format/layers/core_serialization.ts
@@ -17,7 +17,7 @@ import {BaseLayerSerialization, LayerConfig} from '../topology_config';
 
 export interface DropoutLayerConfig extends LayerConfig {
   rate: number;
-  noiseShape?: number[];
+  noise_shape?: number[];
   seed?: number;
 }
 
@@ -27,15 +27,15 @@ export type DropoutLayerSerialization =
 export interface DenseLayerConfig extends LayerConfig {
   units: number;
   activation?: ActivationIdentifier;
-  useBias?: boolean;
-  inputDim?: number;
-  kernelInitializer?: InitializerSerialization;
-  biasInitializer?: InitializerSerialization;
-  kernelConstraint?: ConstraintSerialization;
-  biasConstraint?: ConstraintSerialization;
-  kernelRegularizer?: RegularizerSerialization;
-  biasRegularizer?: RegularizerSerialization;
-  activityRegularizer?: RegularizerSerialization;
+  use_bias?: boolean;
+  input_dim?: number;
+  kernel_initializer?: InitializerSerialization;
+  bias_initializer?: InitializerSerialization;
+  kernel_constraint?: ConstraintSerialization;
+  bias_constraint?: ConstraintSerialization;
+  kernel_regularizer?: RegularizerSerialization;
+  bias_regularizer?: RegularizerSerialization;
+  activity_regularizer?: RegularizerSerialization;
 }
 
 export type DenseLayerSerialization =

--- a/src/keras_format/layers/core_serialization.ts
+++ b/src/keras_format/layers/core_serialization.ts
@@ -13,7 +13,7 @@ import {Shape} from '../common';
 import {ConstraintSerialization} from '../constraint_config';
 import {InitializerSerialization} from '../initializer_config';
 import {RegularizerSerialization} from '../regularizer_config';
-import {LayerConfig} from '../topology_config';
+import {BaseLayerSerialization, LayerConfig} from '../topology_config';
 
 export interface DropoutLayerConfig extends LayerConfig {
   rate: number;
@@ -21,10 +21,8 @@ export interface DropoutLayerConfig extends LayerConfig {
   seed?: number;
 }
 
-export interface DropoutLayerSerialization {
-  class_name: 'Dropout';
-  config: DropoutLayerConfig;
-}
+export type DropoutLayerSerialization =
+    BaseLayerSerialization<'Dropout', DropoutLayerConfig>;
 
 export interface DenseLayerConfig extends LayerConfig {
   units: number;
@@ -40,46 +38,36 @@ export interface DenseLayerConfig extends LayerConfig {
   activityRegularizer?: RegularizerSerialization;
 }
 
-export interface DenseLayerSerialization {
-  class_name: 'Dense';
-  config: DenseLayerConfig;
-}
+export type DenseLayerSerialization =
+    BaseLayerSerialization<'Dense', DenseLayerConfig>;
 
 export interface ActivationLayerConfig extends LayerConfig {
   activation: ActivationIdentifier;
 }
 
-export interface ActivationLayerSerialization {
-  class_name: 'Activation';
-  config: ActivationLayerConfig;
-}
+export type ActivationLayerSerialization =
+    BaseLayerSerialization<'Activation', ActivationLayerConfig>;
 
 export interface RepeatVectorLayerConfig extends LayerConfig {
   n: number;
 }
 
-export interface RepeatVectorLayerSerialization {
-  class_name: 'RepeatVector';
-  config: RepeatVectorLayerConfig;
-}
+export type RepeatVectorLayerSerialization =
+    BaseLayerSerialization<'RepeatVector', RepeatVectorLayerConfig>;
 
 export interface ReshapeLayerConfig extends LayerConfig {
   targetShape: Shape;
 }
 
-export interface ReshapeLayerSerialization {
-  class_name: 'Reshape';
-  config: ReshapeLayerConfig;
-}
+export type ReshapeLayerSerialization =
+    BaseLayerSerialization<'Reshape', ReshapeLayerConfig>;
 
 export interface PermuteLayerConfig extends LayerConfig {
   dims: number[];
 }
 
-export interface PermuteLayerSerialization {
-  class_name: 'Permute';
-  config: PermuteLayerConfig;
-}
+export type PermuteLayerSerialization =
+    BaseLayerSerialization<'Permute', PermuteLayerConfig>;
 
 export type CoreLayerSerialization =
     DropoutLayerSerialization|DenseLayerSerialization|

--- a/src/keras_format/layers/embeddings_serialization.ts
+++ b/src/keras_format/layers/embeddings_serialization.ts
@@ -11,7 +11,7 @@
 import {ConstraintSerialization} from '../constraint_config';
 import {InitializerSerialization} from '../initializer_config';
 import {RegularizerSerialization} from '../regularizer_config';
-import {LayerConfig} from '../topology_config';
+import {BaseLayerSerialization, LayerConfig} from '../topology_config';
 
 export interface EmbeddingLayerConfig extends LayerConfig {
   inputDim: number;
@@ -24,7 +24,5 @@ export interface EmbeddingLayerConfig extends LayerConfig {
   inputLength?: number|number[];
 }
 
-export interface EmbeddingLayerSerialization {
-  class_name: 'Embedding';
-  config: EmbeddingLayerConfig;
-}
+export type EmbeddingLayerSerialization =
+    BaseLayerSerialization<'Embedding', EmbeddingLayerConfig>;

--- a/src/keras_format/layers/embeddings_serialization.ts
+++ b/src/keras_format/layers/embeddings_serialization.ts
@@ -14,14 +14,14 @@ import {RegularizerSerialization} from '../regularizer_config';
 import {BaseLayerSerialization, LayerConfig} from '../topology_config';
 
 export interface EmbeddingLayerConfig extends LayerConfig {
-  inputDim: number;
-  outputDim: number;
-  embeddingsInitializer?: InitializerSerialization;
-  embeddingsRegularizer?: RegularizerSerialization;
-  activityRegularizer?: RegularizerSerialization;
-  embeddingsConstraint?: ConstraintSerialization;
-  maskZero?: boolean;
-  inputLength?: number|number[];
+  input_dim: number;
+  output_dim: number;
+  embeddings_initializer?: InitializerSerialization;
+  embeddings_regularizer?: RegularizerSerialization;
+  activity_regularizer?: RegularizerSerialization;
+  embeddings_constraint?: ConstraintSerialization;
+  mask_zero?: boolean;
+  input_length?: number|number[];
 }
 
 export type EmbeddingLayerSerialization =

--- a/src/keras_format/layers/layer_serialization.ts
+++ b/src/keras_format/layers/layer_serialization.ts
@@ -23,3 +23,5 @@ export type LayerSerialization =
     ConvLayerSerialization|CoreLayerSerialization|MergeLayerSerialization|
     BatchNormalizationLayerSerialization|ZeroPadding2DLayerSerialization|
     PoolingLayerSerialization|RecurrentLayerSerialization;
+
+export type LayerClassName = LayerSerialization['class_name'];

--- a/src/keras_format/layers/merge_serialization.ts
+++ b/src/keras_format/layers/merge_serialization.ts
@@ -8,26 +8,22 @@
  * =============================================================================
  */
 
-import {LayerConfig} from '../topology_config';
+import {BaseLayerSerialization, LayerConfig} from '../topology_config';
 
 export interface ConcatenateLayerConfig extends LayerConfig {
   axis?: number;
 }
 
-export interface ConcatenateLayerSerialization {
-  class_name: 'Concatenate';
-  config: ConcatenateLayerConfig;
-}
+export type ConcatenateLayerSerialization =
+    BaseLayerSerialization<'Concatenate', ConcatenateLayerConfig>;
 
 export interface DotLayerConfig extends LayerConfig {
   axes: number|[number, number];
   normalize?: boolean;
 }
 
-export interface DotLayerSerialization {
-  class_name: 'Dot';
-  config: DotLayerConfig;
-}
+export type DotLayerSerialization =
+    BaseLayerSerialization<'Dot', DotLayerConfig>;
 
 export type MergeLayerSerialization =
     ConcatenateLayerSerialization|DotLayerSerialization;

--- a/src/keras_format/layers/normalization_serialization.ts
+++ b/src/keras_format/layers/normalization_serialization.ts
@@ -11,7 +11,7 @@
 import {ConstraintSerialization} from '../constraint_config';
 import {InitializerSerialization} from '../initializer_config';
 import {RegularizerSerialization} from '../regularizer_config';
-import {LayerConfig} from '../topology_config';
+import {BaseLayerSerialization, LayerConfig} from '../topology_config';
 
 export interface BatchNormalizationLayerConfig extends LayerConfig {
   axis?: number;
@@ -29,7 +29,5 @@ export interface BatchNormalizationLayerConfig extends LayerConfig {
   gammaRegularizer?: RegularizerSerialization;
 }
 
-export interface BatchNormalizationLayerSerialization {
-  class_name: 'BatchNormalization';
-  config: BatchNormalizationLayerConfig;
-}
+export type BatchNormalizationLayerSerialization =
+    BaseLayerSerialization<'BatchNormalization', BatchNormalizationLayerConfig>;

--- a/src/keras_format/layers/normalization_serialization.ts
+++ b/src/keras_format/layers/normalization_serialization.ts
@@ -19,14 +19,14 @@ export interface BatchNormalizationLayerConfig extends LayerConfig {
   epsilon?: number;
   center?: boolean;
   scale?: boolean;
-  betaInitializer?: InitializerSerialization;
-  gammaInitializer?: InitializerSerialization;
-  movingMeanInitializer?: InitializerSerialization;
-  movingVarianceInitializer?: InitializerSerialization;
-  betaConstraint?: ConstraintSerialization;
-  gammaConstraint?: ConstraintSerialization;
-  betaRegularizer?: RegularizerSerialization;
-  gammaRegularizer?: RegularizerSerialization;
+  beta_initializer?: InitializerSerialization;
+  gamma_initializer?: InitializerSerialization;
+  moving_mean_initializer?: InitializerSerialization;
+  moving_variance_initializer?: InitializerSerialization;
+  beta_constraint?: ConstraintSerialization;
+  gamma_constraint?: ConstraintSerialization;
+  beta_regularizer?: RegularizerSerialization;
+  gamma_regularizer?: RegularizerSerialization;
 }
 
 export type BatchNormalizationLayerSerialization =

--- a/src/keras_format/layers/padding_serialization.ts
+++ b/src/keras_format/layers/padding_serialization.ts
@@ -9,14 +9,12 @@
  */
 
 import {DataFormat} from '../common';
-import {LayerConfig} from '../topology_config';
+import {BaseLayerSerialization, LayerConfig} from '../topology_config';
 
 export interface ZeroPadding2DLayerConfig extends LayerConfig {
   padding?: number|[number, number]|[[number, number], [number, number]];
   dataFormat?: DataFormat;
 }
 
-export interface ZeroPadding2DLayerSerialization {
-  class_name: 'ZeroPadding2D';
-  config: ZeroPadding2DLayerConfig;
-}
+export type ZeroPadding2DLayerSerialization =
+    BaseLayerSerialization<'ZeroPadding2D', ZeroPadding2DLayerConfig>;

--- a/src/keras_format/layers/padding_serialization.ts
+++ b/src/keras_format/layers/padding_serialization.ts
@@ -13,7 +13,7 @@ import {BaseLayerSerialization, LayerConfig} from '../topology_config';
 
 export interface ZeroPadding2DLayerConfig extends LayerConfig {
   padding?: number|[number, number]|[[number, number], [number, number]];
-  dataFormat?: DataFormat;
+  data_format?: DataFormat;
 }
 
 export type ZeroPadding2DLayerSerialization =

--- a/src/keras_format/layers/pooling_serialization.ts
+++ b/src/keras_format/layers/pooling_serialization.ts
@@ -9,7 +9,7 @@
  */
 
 import {DataFormat, PaddingMode} from '../common';
-import {LayerConfig} from '../topology_config';
+import {BaseLayerSerialization, LayerConfig} from '../topology_config';
 
 
 export interface Pooling1DLayerConfig extends LayerConfig {
@@ -17,10 +17,8 @@ export interface Pooling1DLayerConfig extends LayerConfig {
   strides?: number;
   padding?: PaddingMode;
 }
-export interface Pooling1DLayerSerialization {
-  class_name: 'Pooling1D';
-  config: Pooling1DLayerConfig;
-}
+export type Pooling1DLayerSerialization =
+    BaseLayerSerialization<'Pooling1D', Pooling1DLayerConfig>;
 
 export interface Pooling2DLayerConfig extends LayerConfig {
   poolSize?: number|[number, number];
@@ -29,19 +27,15 @@ export interface Pooling2DLayerConfig extends LayerConfig {
   dataFormat?: DataFormat;
 }
 
-export interface Pooling2DLayerSerialization {
-  class_name: 'Pooling2D';
-  config: Pooling2DLayerConfig;
-}
+export type Pooling2DLayerSerialization =
+    BaseLayerSerialization<'Pooling2D', Pooling2DLayerConfig>;
 
 export interface GlobalPooling2DLayerConfig extends LayerConfig {
   dataFormat?: DataFormat;
 }
 
-export interface GlobalPooling2DLayerSerialization {
-  class_name: 'GlobalPooling2D';
-  config: GlobalPooling2DLayerConfig;
-}
+export type GlobalPooling2DLayerSerialization =
+    BaseLayerSerialization<'GlobalPooling2D', GlobalPooling2DLayerConfig>;
 
 export type PoolingLayerSerialization = Pooling1DLayerSerialization|
     Pooling2DLayerSerialization|GlobalPooling2DLayerSerialization;

--- a/src/keras_format/layers/pooling_serialization.ts
+++ b/src/keras_format/layers/pooling_serialization.ts
@@ -13,7 +13,7 @@ import {BaseLayerSerialization, LayerConfig} from '../topology_config';
 
 
 export interface Pooling1DLayerConfig extends LayerConfig {
-  poolSize?: number;
+  pool_size?: number;
   strides?: number;
   padding?: PaddingMode;
 }
@@ -21,17 +21,17 @@ export type Pooling1DLayerSerialization =
     BaseLayerSerialization<'Pooling1D', Pooling1DLayerConfig>;
 
 export interface Pooling2DLayerConfig extends LayerConfig {
-  poolSize?: number|[number, number];
+  pool_size?: number|[number, number];
   strides?: number|[number, number];
   padding?: PaddingMode;
-  dataFormat?: DataFormat;
+  data_format?: DataFormat;
 }
 
 export type Pooling2DLayerSerialization =
     BaseLayerSerialization<'Pooling2D', Pooling2DLayerConfig>;
 
 export interface GlobalPooling2DLayerConfig extends LayerConfig {
-  dataFormat?: DataFormat;
+  data_format?: DataFormat;
 }
 
 export type GlobalPooling2DLayerSerialization =

--- a/src/keras_format/layers/recurrent_serialization.ts
+++ b/src/keras_format/layers/recurrent_serialization.ts
@@ -17,30 +17,30 @@ import {BaseSerialization} from '../types';
 
 export interface BaseRNNLayerConfig extends LayerConfig {
   cell?: RNNCellSerialization|RNNCellSerialization[];
-  returnSequences?: boolean;
-  returnState?: boolean;
-  goBackwards?: boolean;
+  return_sequences?: boolean;
+  return_state?: boolean;
+  go_backwards?: boolean;
   stateful?: boolean;
   unroll?: boolean;
-  inputDim?: number;
-  inputLength?: number;
+  input_dim?: number;
+  input_length?: number;
 }
 
 export interface SimpleRNNCellConfig extends LayerConfig {
   units: number;
   activation?: ActivationIdentifier;
-  useBias?: boolean;
-  kernelInitializer?: InitializerSerialization;
-  recurrentInitializer?: InitializerSerialization;
-  biasInitializer?: InitializerSerialization;
-  kernelRegularizer?: RegularizerSerialization;
-  recurrentRegularizer?: RegularizerSerialization;
-  biasRegularizer?: RegularizerSerialization;
-  kernelConstraint?: ConstraintSerialization;
-  recurrentConstraint?: ConstraintSerialization;
-  biasConstraint?: ConstraintSerialization;
+  use_bias?: boolean;
+  kernel_initializer?: InitializerSerialization;
+  recurrent_initializer?: InitializerSerialization;
+  bias_initializer?: InitializerSerialization;
+  kernel_regularizer?: RegularizerSerialization;
+  recurrent_regularizer?: RegularizerSerialization;
+  bias_regularizer?: RegularizerSerialization;
+  kernel_constraint?: ConstraintSerialization;
+  recurrent_constraint?: ConstraintSerialization;
+  bias_constraint?: ConstraintSerialization;
   dropout?: number;
-  recurrentDropout?: number;
+  recurrent_dropout?: number;
 }
 
 export type SimpleRNNCellSerialization =
@@ -49,32 +49,32 @@ export type SimpleRNNCellSerialization =
 export interface SimpleRNNLayerConfig extends BaseRNNLayerConfig {
   units: number;
   activation?: ActivationIdentifier;
-  useBias?: boolean;
-  kernelInitializer?: InitializerSerialization;
-  recurrentInitializer?: InitializerSerialization;
-  biasInitializer?: InitializerSerialization;
-  kernelRegularizer?: RegularizerSerialization;
-  recurrentRegularizer?: RegularizerSerialization;
-  biasRegularizer?: RegularizerSerialization;
-  kernelConstraint?: ConstraintSerialization;
-  recurrentConstraint?: ConstraintSerialization;
-  biasConstraint?: ConstraintSerialization;
+  use_bias?: boolean;
+  kernel_initializer?: InitializerSerialization;
+  recurrent_initializer?: InitializerSerialization;
+  bias_initializer?: InitializerSerialization;
+  kernel_regularizer?: RegularizerSerialization;
+  recurrent_regularizer?: RegularizerSerialization;
+  bias_regularizer?: RegularizerSerialization;
+  kernel_constraint?: ConstraintSerialization;
+  recurrent_constraint?: ConstraintSerialization;
+  bias_constraint?: ConstraintSerialization;
   dropout?: number;
-  recurrentDropout?: number;
+  recurrent_dropout?: number;
 }
 
 export type SimpleRNNLayerSerialization =
     BaseLayerSerialization<'SimpleRNN', SimpleRNNLayerConfig>;
 
 export interface GRUCellConfig extends SimpleRNNCellConfig {
-  recurrentActivation?: string;
+  recurrent_activation?: string;
   implementation?: number;
 }
 
 export type GRUCellSerialization = BaseSerialization<'GRUCell', GRUCellConfig>;
 
 export interface GRULayerConfig extends SimpleRNNLayerConfig {
-  recurrentActivation?: string;
+  recurrent_activation?: ActivationIdentifier;
   implementation?: number;
 }
 
@@ -82,8 +82,8 @@ export type GRULayerSerialization =
     BaseLayerSerialization<'GRU', GRULayerConfig>;
 
 export interface LSTMCellConfig extends SimpleRNNCellConfig {
-  recurrentActivation?: ActivationIdentifier;
-  unitForgetBias?: boolean;
+  recurrent_activation?: ActivationIdentifier;
+  unit_forget_bias?: boolean;
   implementation?: number;
 }
 
@@ -91,8 +91,8 @@ export type LSTMCellSerialization =
     BaseSerialization<'LSTMCell', LSTMCellConfig>;
 
 export interface LSTMLayerConfig extends SimpleRNNLayerConfig {
-  recurrentActivation?: string;
-  unitForgetBias?: boolean;
+  recurrent_activation?: ActivationIdentifier;
+  unit_forget_bias?: boolean;
   implementation?: number;
 }
 export type LSTMLayerSerialization =

--- a/src/keras_format/layers/recurrent_serialization.ts
+++ b/src/keras_format/layers/recurrent_serialization.ts
@@ -12,7 +12,8 @@ import {ActivationIdentifier} from '../activation_config';
 import {ConstraintSerialization} from '../constraint_config';
 import {InitializerSerialization} from '../initializer_config';
 import {RegularizerSerialization} from '../regularizer_config';
-import {LayerConfig} from '../topology_config';
+import {BaseLayerSerialization, LayerConfig} from '../topology_config';
+import {BaseSerialization} from '../types';
 
 export interface BaseRNNLayerConfig extends LayerConfig {
   cell?: RNNCellSerialization|RNNCellSerialization[];
@@ -42,10 +43,8 @@ export interface SimpleRNNCellConfig extends LayerConfig {
   recurrentDropout?: number;
 }
 
-export interface SimpleRNNCellSerialization {
-  class_name: 'SimpleRNNCell';
-  config: SimpleRNNCellConfig;
-}
+export type SimpleRNNCellSerialization =
+    BaseSerialization<'SimpleRNNCell', SimpleRNNCellConfig>;
 
 export interface SimpleRNNLayerConfig extends BaseRNNLayerConfig {
   units: number;
@@ -64,30 +63,23 @@ export interface SimpleRNNLayerConfig extends BaseRNNLayerConfig {
   recurrentDropout?: number;
 }
 
-export interface SimpleRNNLayerSerialization {
-  class_name: 'SimpleRNN';
-  config: SimpleRNNLayerConfig;
-}
+export type SimpleRNNLayerSerialization =
+    BaseLayerSerialization<'SimpleRNN', SimpleRNNLayerConfig>;
 
 export interface GRUCellConfig extends SimpleRNNCellConfig {
   recurrentActivation?: string;
   implementation?: number;
 }
 
-export interface GRUCellSerialization {
-  class_name: 'GRUCell';
-  config: GRUCellConfig;
-}
+export type GRUCellSerialization = BaseSerialization<'GRUCell', GRUCellConfig>;
 
 export interface GRULayerConfig extends SimpleRNNLayerConfig {
   recurrentActivation?: string;
   implementation?: number;
 }
 
-export interface GRULayerSerialization {
-  class_name: 'GRU';
-  config: GRULayerConfig;
-}
+export type GRULayerSerialization =
+    BaseLayerSerialization<'GRU', GRULayerConfig>;
 
 export interface LSTMCellConfig extends SimpleRNNCellConfig {
   recurrentActivation?: ActivationIdentifier;
@@ -95,20 +87,16 @@ export interface LSTMCellConfig extends SimpleRNNCellConfig {
   implementation?: number;
 }
 
-export interface LSTMCellSerialization {
-  class_name: 'LSTMCell';
-  config: LSTMCellConfig;
-}
+export type LSTMCellSerialization =
+    BaseSerialization<'LSTMCell', LSTMCellConfig>;
 
 export interface LSTMLayerConfig extends SimpleRNNLayerConfig {
   recurrentActivation?: string;
   unitForgetBias?: boolean;
   implementation?: number;
 }
-export interface LSTMLayerSerialization {
-  class_name: 'LSTM';
-  config: LSTMLayerConfig;
-}
+export type LSTMLayerSerialization =
+    BaseLayerSerialization<'LSTM', LSTMLayerConfig>;
 
 export interface StackedRNNCellsConfig extends LayerConfig {
   // TODO(soergel): consider whether we can avoid improperly mixing
@@ -116,10 +104,8 @@ export interface StackedRNNCellsConfig extends LayerConfig {
   cells: RNNCellSerialization[];
 }
 
-export interface StackedRNNCellsSerialization {
-  class_name: 'StackedRNNCells';
-  config: StackedRNNCellsConfig;
-}
+export type StackedRNNCellsSerialization =
+    BaseSerialization<'StackedRNNCells', StackedRNNCellsConfig>;
 
 export type RNNCellSerialization = SimpleRNNCellSerialization|
     GRUCellSerialization|LSTMCellSerialization|StackedRNNCellsSerialization;

--- a/src/keras_format/layers/wrappers_serialization.ts
+++ b/src/keras_format/layers/wrappers_serialization.ts
@@ -26,5 +26,5 @@ export type BidirectionalLayerSerialization =
 
 export interface BidirectionalLayerConfig extends LayerConfig {
   layer: RecurrentLayerSerialization;
-  mergeMode?: BidirectionalMergeMode;
+  merge_mode?: BidirectionalMergeMode;
 }

--- a/src/keras_format/layers/wrappers_serialization.ts
+++ b/src/keras_format/layers/wrappers_serialization.ts
@@ -9,24 +9,20 @@
  */
 
 import {BidirectionalMergeMode} from '../common';
-import {LayerConfig} from '../topology_config';
+import {BaseLayerSerialization, LayerConfig} from '../topology_config';
 
 import {LayerSerialization} from './layer_serialization';
 import {RecurrentLayerSerialization} from './recurrent_serialization';
 
-export interface TimeDistributedLayerSerialization {
-  class_name: 'TimeDistributed';
-  config: TimeDistributedLayerConfig;
-}
+export type TimeDistributedLayerSerialization =
+    BaseLayerSerialization<'TimeDistributed', TimeDistributedLayerConfig>;
 
 export interface TimeDistributedLayerConfig extends LayerConfig {
   layer: LayerSerialization;
 }
 
-export interface BidirectionalLayerSerialization {
-  class_name: 'Bidirectional';
-  config: BidirectionalLayerConfig;
-}
+export type BidirectionalLayerSerialization =
+    BaseLayerSerialization<'Bidirectional', BidirectionalLayerConfig>;
 
 export interface BidirectionalLayerConfig extends LayerConfig {
   layer: RecurrentLayerSerialization;

--- a/src/keras_format/model_serialization.ts
+++ b/src/keras_format/model_serialization.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ * =============================================================================
+ */
+
+import {LayerSerialization} from './layers/layer_serialization';
+import {TensorKeyArray} from './node_config';
+import {TrainingConfig} from './training_config';
+import {BaseSerialization, PyJsonDict} from './types';
+
+export type ModelConfig = {
+  name: string,
+  layers: LayerSerialization[],
+  inputLayers: TensorKeyArray[],
+  outputLayers: TensorKeyArray[],
+}&PyJsonDict;
+
+/**
+ * A standard Keras JSON 'Model' configuration.
+ */
+export interface ModelSerialization extends
+    BaseSerialization<'Model', ModelConfig> {
+  backend?: string;
+  kerasVersion?: string;
+}
+
+export type SequentialConfig = {
+  layers: LayerSerialization[]
+}&PyJsonDict;
+
+/**
+ * A standard Keras JSON 'Sequential' configuration.
+ */
+export interface SequentialSerialization extends
+    BaseSerialization<'Sequential', SequentialConfig> {
+  backend?: string;
+  kerasVersion?: string;
+}
+
+/**
+ * A legacy Keras JSON 'Sequential' configuration.
+ *
+ * It was a bug that Keras Sequential models were recorded with
+ * model_config.config as an array of layers, instead of a dict containing a
+ * 'layers' entry.  While the bug has been fixed, we still need to be able to
+ * read this legacy format.
+ */
+export type LegacySequentialSerialization = {
+  // Note this cannot extend `BaseSerialization` because of the bug.
+  className: 'Sequential';
+
+  config: LayerSerialization[];
+  backend?: string;
+  kerasVersion?: string;
+}&PyJsonDict;
+
+/**
+ * Contains the description of a KerasModel, as well as the configuration
+ * necessary to train that model.
+ */
+export type KerasFileSerialization = {
+  // aka ModelTopology?
+  model_config: ModelSerialization|SequentialSerialization|
+  LegacySequentialSerialization;
+  training_config: TrainingConfig;
+}&PyJsonDict;

--- a/src/keras_format/model_serialization.ts
+++ b/src/keras_format/model_serialization.ts
@@ -16,8 +16,8 @@ import {BaseSerialization, PyJsonDict} from './types';
 export type ModelConfig = {
   name: string,
   layers: LayerSerialization[],
-  inputLayers: TensorKeyArray[],
-  outputLayers: TensorKeyArray[],
+  input_layers: TensorKeyArray[],
+  output_layers: TensorKeyArray[],
 }&PyJsonDict;
 
 /**
@@ -26,7 +26,7 @@ export type ModelConfig = {
 export interface ModelSerialization extends
     BaseSerialization<'Model', ModelConfig> {
   backend?: string;
-  kerasVersion?: string;
+  keras_version?: string;
 }
 
 export type SequentialConfig = {
@@ -39,7 +39,7 @@ export type SequentialConfig = {
 export interface SequentialSerialization extends
     BaseSerialization<'Sequential', SequentialConfig> {
   backend?: string;
-  kerasVersion?: string;
+  keras_version?: string;
 }
 
 /**
@@ -56,7 +56,7 @@ export type LegacySequentialSerialization = {
 
   config: LayerSerialization[];
   backend?: string;
-  kerasVersion?: string;
+  keras_version?: string;
 }&PyJsonDict;
 
 /**

--- a/src/keras_format/node_config.ts
+++ b/src/keras_format/node_config.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ * =============================================================================
+ */
+
+import {PyJsonDict} from './types';
+
+/**
+ * The unique string name of a Layer.
+ */
+export type LayerName = string;
+
+/**
+ * The index of a Node, identifying a specific invocation of a given Layer.
+ */
+export type NodeIndex = number;
+
+/**
+ * The index of a Tensor output by a given Node of a given Layer.
+ */
+export type TensorIndex = number;
+
+/**
+ * Arguments to the apply(...) method that produced a specific Node.
+ */
+// tslint:disable-next-line:no-empty-interface
+export interface NodeArgs extends PyJsonDict {}
+/**
+ * A reference to a specific Tensor, given by its Layer name, Node index, and
+ * output index, including the apply() arguments associated with the Node.
+ *
+ * This is used in `NodeConfig` to specify the inputs to each Node.
+ */
+export type TensorKeyWithArgsArray =
+    [LayerName, NodeIndex, TensorIndex, NodeArgs];
+
+// TODO(soergel): verify behavior of Python Keras; maybe PR to standardize it.
+/**
+ * A reference to a specific Tensor, given by its Layer name, Node index, and
+ * output index.
+ *
+ * This does not include the apply() arguments associated with the Node.  It is
+ * used in the Model config to specify the inputLayers and outputLayers.  It
+ * seems to be an idiosyncrasy of Python Keras that the node arguments are not
+ * included here.
+ */
+export type TensorKeyArray = [LayerName, NodeIndex, TensorIndex];
+
+/**
+ * A Keras JSON entry representing a Node, i.e. a specific instance of a Layer.
+ *
+ * By Keras JSON convention, a Node is specified as an array of Tensor keys
+ * (i.e., references to Tensors output by other Layers) providing the inputs to
+ * this Layer in order.
+ */
+export type NodeConfig = TensorKeyWithArgsArray[];

--- a/src/keras_format/node_config.ts
+++ b/src/keras_format/node_config.ts
@@ -30,6 +30,7 @@ export type TensorIndex = number;
  */
 // tslint:disable-next-line:no-empty-interface
 export interface NodeArgs extends PyJsonDict {}
+
 /**
  * A reference to a specific Tensor, given by its Layer name, Node index, and
  * output index, including the apply() arguments associated with the Node.

--- a/src/keras_format/regularizer_config.ts
+++ b/src/keras_format/regularizer_config.ts
@@ -8,20 +8,26 @@
  * =============================================================================
  */
 
-export interface L1L2Serialization {
-  class_name: 'l1_l2';
-  config: {l1?: number; l2?: number;};
-}
+import {BaseSerialization} from './types';
 
-export interface L1Serialization {
-  class_name: 'l1';
-  config: {l1: number;};
-}
+export type L1L2Config = {
+  l1?: number;
+  l2?: number;
+};
 
-export interface L2Serialization {
-  class_name: 'l2';
-  config: {l2: number;};
-}
+export type L1L2Serialization = BaseSerialization<'l1_l2', L1L2Config>;
+
+export type L1Config = {
+  l1?: number;
+};
+
+export type L1Serialization = BaseSerialization<'l1', L1Config>;
+
+export type L2Config = {
+  l2?: number;
+};
+
+export type L2Serialization = BaseSerialization<'l2', L2Config>;
 
 export type RegularizerSerialization =
     L1L2Serialization|L1Serialization|L2Serialization;

--- a/src/keras_format/topology_config.ts
+++ b/src/keras_format/topology_config.ts
@@ -9,16 +9,34 @@
  */
 
 import {DataType} from '@tensorflow/tfjs-core';
+
 import {Shape} from './common';
+import {NodeConfig} from './node_config';
+import {BaseSerialization, PyJsonDict} from './types';
 
 /** Constructor arguments for Layer. */
-export interface LayerConfig {
-  inputShape?: Shape;
-  batchInputShape?: Shape;
-  batchSize?: number;
+export interface LayerConfig extends PyJsonDict {
+  input_shape?: Shape;
+  batch_input_shape?: Shape;
+  batch_size?: number;
   dtype?: DataType;
   name?: string;
   trainable?: boolean;
   updatable?: boolean;
-  inputDType?: DataType;
+  input_dtype?: DataType;
+}
+
+/**
+ * A Keras JSON entry representing a layer.
+ *
+ * The Keras JSON convention is to provide the `class_name` (i.e., the layer
+ * type) at the top level, and then to place the layer-specific configuration in
+ * a `config` subtree.  These layer-specific configurations are provided by
+ * subtypes of `LayerConfig`.  Thus, this `*Serialization` has a type parameter
+ * giving the specific type of the wrapped `LayerConfig`.
+ */
+export interface BaseLayerSerialization<N extends string, T extends LayerConfig>
+    extends BaseSerialization<N, T> {
+  name: string;
+  inbound_nodes?: NodeConfig[];
 }

--- a/src/keras_format/training_config.ts
+++ b/src/keras_format/training_config.ts
@@ -8,15 +8,8 @@
  * =============================================================================
  */
 
+import {SampleWeightMode} from './common';
 import {BaseSerialization, PyJsonDict} from './types';
-
-/**
- * Configuration of a Keras optimizer, containing both the type of the optimizer
- * and the configuration for the optimizer of that type.
- */
-export type OptimizerSerialization<N extends string,
-                                             C extends OptimizerConfig> =
-    BaseSerialization<N, C>;
 
 /**
  * Because of the limitations in the current Keras spec, there is no clear
@@ -26,6 +19,14 @@ export type OptimizerSerialization<N extends string,
  * See internal issue: b/121033602
  */
 export type OptimizerConfig = PyJsonDict;
+
+/**
+ * Configuration of a Keras optimizer, containing both the type of the optimizer
+ * and the configuration for the optimizer of that type.
+ */
+export type OptimizerSerialization<N extends string,
+                                             C extends OptimizerConfig> =
+    BaseSerialization<N, C>;
 
 /**
  * List of all known loss names, along with a string description.
@@ -51,15 +52,17 @@ export type LossKey = keyof LossOptions;
 // TODO(soergel): flesh out known metrics options
 export type MetricsKey = string;
 
+export type LossWeights = number[]|{[key: string]: number};
+
 /**
- * Configuration of that which is necessary to train a given model and
- * dataset. This includes the configuration to the optimizer, the loss, any
- * metrics to be calculated, etc.
+ * Configuration of the Keras trainer. This includes the configuration to the
+ * optimizer, the loss, any metrics to be calculated, etc.
  */
 export interface TrainingConfig {
-  optimizerConfig: OptimizerSerialization<string, PyJsonDict>;
-  loss: LossKey;
-  metrics: MetricsKey[];
-  sampleWeightMode: string;
-  lossWeights: null;  // TQDQ(soergel): wat
+  optimizer_config: OptimizerSerialization<string, PyJsonDict>;
+  loss: LossKey|LossKey[]|{[key: string]: LossKey};
+  metrics?: MetricsKey[];
+  weighted_metrics?: MetricsKey[];
+  sample_weight_mode?: SampleWeightMode;
+  loss_weights?: LossWeights;
 }

--- a/src/keras_format/training_config.ts
+++ b/src/keras_format/training_config.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ * =============================================================================
+ */
+
+/**
+ * Configuration of that which is necessary to train a given model and dataset.
+ * This includes the configuration to the optimizer, the loss, any metrics
+ * to be calculated, etc.
+ */
+
+import {BaseSerialization, PyJsonDict} from './types';
+
+export interface TrainingConfig {
+  optimizerConfig: OptimizerSerialization<string, PyJsonDict>;
+  loss: string;
+  metrics: string[];
+  sampleWeightMode: string;
+  lossWeights: null;
+}
+
+/**
+ * Configuration of a Keras optimizer, containing both the type of the optimizer
+ * and the configuration for the optimizer of that type.
+ */
+export type OptimizerSerialization<N extends string,
+                                             C extends OptimizerConfig> =
+    BaseSerialization<N, C>;
+
+/**
+ * Because of the limitations in the current Keras spec, there is no clear
+ * definition of what may or may not be the configuration of an optimizer.  Thus
+ * this empty interface represents a stopgap in the Keras spec.
+ *
+ * See internal issue : b/121033602
+ */
+export type OptimizerConfig = PyJsonDict;
+
+/**
+ * List of all known loss names, along with a string description.
+ */
+export const tfLossOptions = [
+  {label: 'Mean Squared Error', value: 'mean_squared_error'},
+  {label: 'Mean Absolute Error', value: 'mean_absolute_error'}, {
+    label: 'Mean Absolute Percentage Error',
+    value: 'mean_absolute_percentage_error',
+  },
+  {
+    label: 'Mean Squared Logarithmic Error',
+    value: 'mean_squared_logarithmic_error',
+  },
+  {label: 'Squared Hinge', value: 'squared_hinge'},
+  {label: 'Hinge', value: 'hinge'},
+  {label: 'Categorical Hinge', value: 'categorical_hinge'},
+  {label: 'Logcosh', value: 'logcosh'},
+  {label: 'Categorical Cross Entropy', value: 'categorical_crossentropy'}, {
+    label: 'Sparse Categorical Cross Entropy',
+    value: 'sparse_categorical_crossentropy',
+  },
+  {label: 'Binary Cross Entropy', value: 'binary_crossentropy'}, {
+    label: 'Kullback-Liebler Divergence',
+    value: 'kullback_leibler_divergence',
+  },
+  {label: 'Poisson', value: 'poisson'},
+  {label: 'Cosine Proximity', value: 'cosine_proximity'}
+];

--- a/src/keras_format/training_config.ts
+++ b/src/keras_format/training_config.ts
@@ -8,21 +8,7 @@
  * =============================================================================
  */
 
-/**
- * Configuration of that which is necessary to train a given model and dataset.
- * This includes the configuration to the optimizer, the loss, any metrics
- * to be calculated, etc.
- */
-
 import {BaseSerialization, PyJsonDict} from './types';
-
-export interface TrainingConfig {
-  optimizerConfig: OptimizerSerialization<string, PyJsonDict>;
-  loss: string;
-  metrics: string[];
-  sampleWeightMode: string;
-  lossWeights: null;
-}
 
 /**
  * Configuration of a Keras optimizer, containing both the type of the optimizer
@@ -37,35 +23,43 @@ export type OptimizerSerialization<N extends string,
  * definition of what may or may not be the configuration of an optimizer.  Thus
  * this empty interface represents a stopgap in the Keras spec.
  *
- * See internal issue : b/121033602
+ * See internal issue: b/121033602
  */
 export type OptimizerConfig = PyJsonDict;
 
 /**
  * List of all known loss names, along with a string description.
  */
-export const tfLossOptions = [
-  {label: 'Mean Squared Error', value: 'mean_squared_error'},
-  {label: 'Mean Absolute Error', value: 'mean_absolute_error'}, {
-    label: 'Mean Absolute Percentage Error',
-    value: 'mean_absolute_percentage_error',
-  },
-  {
-    label: 'Mean Squared Logarithmic Error',
-    value: 'mean_squared_logarithmic_error',
-  },
-  {label: 'Squared Hinge', value: 'squared_hinge'},
-  {label: 'Hinge', value: 'hinge'},
-  {label: 'Categorical Hinge', value: 'categorical_hinge'},
-  {label: 'Logcosh', value: 'logcosh'},
-  {label: 'Categorical Cross Entropy', value: 'categorical_crossentropy'}, {
-    label: 'Sparse Categorical Cross Entropy',
-    value: 'sparse_categorical_crossentropy',
-  },
-  {label: 'Binary Cross Entropy', value: 'binary_crossentropy'}, {
-    label: 'Kullback-Liebler Divergence',
-    value: 'kullback_leibler_divergence',
-  },
-  {label: 'Poisson', value: 'poisson'},
-  {label: 'Cosine Proximity', value: 'cosine_proximity'}
-];
+export type LossOptions = {
+  mean_squared_error: 'Mean Squared Error',
+  mean_absolute_error: 'Mean Absolute Error',
+  mean_absolute_percentage_error: 'Mean Absolute Percentage Error',
+  mean_squared_logarithmic_error: 'Mean Squared Logarithmic Error',
+  squared_hinge: 'Squared Hinge',
+  hinge: 'Hinge',
+  categorical_hinge: 'Categorical Hinge',
+  logcosh: 'Logcosh',
+  categorical_crossentropy: 'Categorical Cross Entropy',
+  sparse_categorical_crossentropy: 'Sparse Categorical Cross Entropy',
+  kullback_leibler_divergence: 'Kullback-Liebler Divergence',
+  poisson: 'Poisson',
+  cosine_proximity: 'Cosine Proximity',
+};
+
+export type LossKey = keyof LossOptions;
+
+// TODO(soergel): flesh out known metrics options
+export type MetricsKey = string;
+
+/**
+ * Configuration of that which is necessary to train a given model and
+ * dataset. This includes the configuration to the optimizer, the loss, any
+ * metrics to be calculated, etc.
+ */
+export interface TrainingConfig {
+  optimizerConfig: OptimizerSerialization<string, PyJsonDict>;
+  loss: LossKey;
+  metrics: MetricsKey[];
+  sampleWeightMode: string;
+  lossWeights: null;  // TQDQ(soergel): wat
+}

--- a/src/keras_format/types.ts
+++ b/src/keras_format/types.ts
@@ -44,3 +44,18 @@ export interface PyJsonDict {
  * @see PyJsonDict
  */
 export interface PyJsonArray extends Array<PyJsonValue> {}
+
+/**
+ * A Keras JSON entry representing a Keras object such as a Layer.
+ *
+ * The Keras JSON convention is to provide the `class_name` (e.g., the layer
+ * type) at the top level, and then to place the class-specific configuration in
+ * a `config` subtree.  These class-specific configurations are provided by
+ * subtypes of `PyJsonDict`.  Thus, this `*Serialization` has a type parameter
+ * giving the specific type of the wrapped `PyJsonDict`.
+ */
+export interface BaseSerialization<N extends string, T extends PyJsonDict>
+    extends PyJsonDict {
+  class_name: N;
+  config: T;
+}


### PR DESCRIPTION
This PR does three things (sorry):

1. Enforce that all *Serialization types extend PyJsonDict, so the types are definitely and easily serializable.
2. Add the training_config stuff in addition to model_config.
3. Add the top-level structure, so that the complete Keras JSON file has a type.

This did require creating *Config types throughout after all, instead of inlining them in *Serialization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/420)
<!-- Reviewable:end -->
