### PR TITLE
Allow tf.layers.global(Max|Average)Pooling1d() to take no args

### DIFF
--- a/src/exports_layers.ts
+++ b/src/exports_layers.ts
@@ -499,7 +499,7 @@ export function avgPooling2d(args: Pooling2DLayerArgs): Layer {
  *   configParamIndices: [0]
  * }
  */
-export function globalAveragePooling1d(args: LayerArgs): Layer {
+export function globalAveragePooling1d(args?: LayerArgs): Layer {
   return new GlobalAveragePooling1D(args);
 }
 
@@ -525,7 +525,7 @@ export function globalAveragePooling2d(args: GlobalPooling2DLayerArgs): Layer {
  *   configParamIndices: [0]
  * }
  */
-export function globalMaxPooling1d(args: LayerArgs): Layer {
+export function globalMaxPooling1d(args?: LayerArgs): Layer {
   return new GlobalMaxPooling1D(args);
 }
 
@@ -538,7 +538,7 @@ export function globalMaxPooling1d(args: LayerArgs): Layer {
  *   configParamIndices: [0]
  * }
  */
-export function globalMaxPooling2d(args: GlobalPooling2DLayerArgs): Layer {
+export function globalMaxPooling2d(args?: GlobalPooling2DLayerArgs): Layer {
   return new GlobalMaxPooling2D(args);
 }
 

--- a/src/exports_layers.ts
+++ b/src/exports_layers.ts
@@ -538,7 +538,7 @@ export function globalMaxPooling1d(args?: LayerArgs): Layer {
  *   configParamIndices: [0]
  * }
  */
-export function globalMaxPooling2d(args?: GlobalPooling2DLayerArgs): Layer {
+export function globalMaxPooling2d(args: GlobalPooling2DLayerArgs): Layer {
   return new GlobalMaxPooling2D(args);
 }
 

--- a/src/layers/pooling.ts
+++ b/src/layers/pooling.ts
@@ -445,8 +445,8 @@ export abstract class GlobalPooling1D extends Layer {
  */
 export class GlobalAveragePooling1D extends GlobalPooling1D {
   static className = 'GlobalAveragePooling1D';
-  constructor(args: LayerArgs) {
-    super(args);
+  constructor(args?: LayerArgs) {
+    super(args || {});
   }
 
   call(inputs: Tensor|Tensor[], kwargs: Kwargs): Tensor|Tensor[] {
@@ -468,7 +468,7 @@ serialization.registerClass(GlobalAveragePooling1D);
 export class GlobalMaxPooling1D extends GlobalPooling1D {
   static className = 'GlobalMaxPooling1D';
   constructor(args: LayerArgs) {
-    super(args);
+    super(args || {});
   }
 
   call(inputs: Tensor|Tensor[], kwargs: Kwargs): Tensor|Tensor[] {

--- a/src/layers/pooling_test.ts
+++ b/src/layers/pooling_test.ts
@@ -399,19 +399,21 @@ describe('1D Global pooling Layers: Symbolic', () => {
       [tfl.layers.globalAveragePooling1d, tfl.layers.globalMaxPooling1d];
 
   for (const globalPoolingLayer of globalPoolingLayers) {
-    const testTitle = `layer=${globalPoolingLayer.name}`;
-    it(testTitle, () => {
-      const inputShape = [2, 11, 9];
-      const symbolicInput =
-          new SymbolicTensor('float32', inputShape, null, [], null);
+    for (const hasArgs of [true, false]) {
+      const testTitle = `layer=${globalPoolingLayer.name}; hasArgs=${hasArgs}`;
+      it(testTitle, () => {
+        const inputShape = [2, 11, 9];
+        const symbolicInput =
+            new SymbolicTensor('float32', inputShape, null, [], null);
 
-      const layer = globalPoolingLayer({});
-      const output = layer.apply(symbolicInput) as SymbolicTensor;
+        const layer = globalPoolingLayer(hasArgs ? {} : undefined);
+        const output = layer.apply(symbolicInput) as SymbolicTensor;
 
-      const expectedShape = [2, 9];
-      expect(output.shape).toEqual(expectedShape);
-      expect(output.dtype).toEqual(symbolicInput.dtype);
-    });
+        const expectedShape = [2, 9];
+        expect(output.shape).toEqual(expectedShape);
+        expect(output.dtype).toEqual(symbolicInput.dtype);
+      });
+    }
   }
 });
 


### PR DESCRIPTION
Fixes https://github.com/tensorflow/tfjs/issues/1080

BUG

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/422)
<!-- Reviewable:end -->
