### PR TITLE
Really enforce JSON; add missing Layers; fix more CamelCase vs snake_case issues

### DIFF
--- a/src/keras_format/common.ts
+++ b/src/keras_format/common.ts
@@ -14,9 +14,14 @@ export type Shape = number[];
 // The tfjs-core version of DataType must stay synced with this.
 export type DataType = 'float32'|'int32'|'bool'|'complex64'|'string';
 
+// TODO(soergel): Move the CamelCase versions back out of keras_format
+// e.g. to src/common.ts.  Maybe even duplicate *all* of these to be pedantic?
 /** @docinline */
 export type DataFormat = 'channelsFirst'|'channelsLast';
 export const VALID_DATA_FORMAT_VALUES = ['channelsFirst', 'channelsLast'];
+
+// This is the only set of constants here with a snake vs. camel distinction.
+export type DataFormatSerialization = 'channels_first'|'channels_last';
 
 /** @docinline */
 export type PaddingMode = 'valid'|'same'|'causal';

--- a/src/keras_format/initializer_config.ts
+++ b/src/keras_format/initializer_config.ts
@@ -10,17 +10,22 @@
 
 import {BaseSerialization} from './types';
 
+
+// TODO(soergel): Move the CamelCase versions back out of keras_format
+// e.g. to src/common.ts.  Maybe even duplicate *all* of these to be pedantic?
 /** @docinline */
 export type FanMode = 'fanIn'|'fanOut'|'fanAvg';
 export const VALID_FAN_MODE_VALUES = ['fanIn', 'fanOut', 'fanAvg'];
+
+export type FanModeSerialization = 'fan_in'|'fan_out'|'fan_avg';
 
 /** @docinline */
 export type Distribution = 'normal'|'uniform';
 export const VALID_DISTRIBUTION_VALUES = ['normal', 'uniform'];
 
-export type ZerosSerialization = BaseSerialization<'Zeros', null>;
+export type ZerosSerialization = BaseSerialization<'Zeros', {}>;
 
-export type OnesSerialization = BaseSerialization<'Ones', null>;
+export type OnesSerialization = BaseSerialization<'Ones', {}>;
 
 export type ConstantConfig = {
   value: number;
@@ -59,7 +64,7 @@ export type TruncatedNormalSerialization =
 export type VarianceScalingConfig = {
   scale: number;
 
-  mode: FanMode;
+  mode: FanModeSerialization;
   distribution: Distribution;
   seed?: number;
 };
@@ -82,7 +87,7 @@ export type IdentityConfig = {
 export type IdentitySerialization =
     BaseSerialization<'Identity', IdentityConfig>;
 
-export type InitializerSerialization =
+export type InitializerSerialization = ZerosSerialization|OnesSerialization|
     ConstantSerialization|RandomUniformSerialization|RandomNormalSerialization|
     TruncatedNormalSerialization|IdentitySerialization|
     VarianceScalingSerialization|OrthogonalSerialization;

--- a/src/keras_format/input_config.ts
+++ b/src/keras_format/input_config.ts
@@ -11,16 +11,18 @@
 import {DataType} from '@tensorflow/tfjs-core';
 
 import {Shape} from './common';
-import {BaseSerialization} from './types';
+import {BaseLayerSerialization} from './topology_config';
 
 export type InputLayerConfig = {
+  name: string;
   input_shape?: Shape;
   batch_size?: number;
   batch_input_shape?: Shape;
   dtype?: DataType;
   sparse?: boolean;
-  name?: string;
 };
 
+// This really should be BaseSerialization because an input layer has no
+// inbound_nodes. But, that makes type safety more difficult.
 export type InputLayerSerialization =
-    BaseSerialization<'Input', InputLayerConfig>;
+    BaseLayerSerialization<'InputLayer', InputLayerConfig>;

--- a/src/keras_format/layers/convolutional_serialization.ts
+++ b/src/keras_format/layers/convolutional_serialization.ts
@@ -8,7 +8,7 @@
  * =============================================================================
  */
 
-import {DataFormat, PaddingMode} from '../common';
+import {DataFormatSerialization, PaddingMode} from '../common';
 import {ConstraintSerialization} from '../constraint_config';
 import {InitializerSerialization} from '../initializer_config';
 import {RegularizerSerialization} from '../regularizer_config';
@@ -18,7 +18,7 @@ export interface BaseConvLayerConfig extends LayerConfig {
   kernel_size: number|number[];
   strides?: number|number[];
   padding?: PaddingMode;
-  data_format?: DataFormat;
+  data_format?: DataFormatSerialization;
   dilation_rate?: number|[number]|[number, number];
   activation?: string;
   use_bias?: boolean;
@@ -35,5 +35,46 @@ export interface ConvLayerConfig extends BaseConvLayerConfig {
   filters: number;
 }
 
-export type ConvLayerSerialization =
-    BaseLayerSerialization<'Conv', ConvLayerConfig>;
+export type Conv1DLayerSerialization =
+    BaseLayerSerialization<'Conv1D', ConvLayerConfig>;
+
+export type Conv2DLayerSerialization =
+    BaseLayerSerialization<'Conv2D', ConvLayerConfig>;
+
+export type Conv2DTransposeLayerSerialization =
+    BaseLayerSerialization<'Conv2DTranspose', ConvLayerConfig>;
+
+export interface SeparableConvLayerConfig extends ConvLayerConfig {
+  depthMultiplier?: number;
+  depthwise_initializer?: InitializerSerialization;
+  pointwise_initializer?: InitializerSerialization;
+  depthwise_regularizer?: RegularizerSerialization;
+  pointwise_regularizer?: RegularizerSerialization;
+  depthwise_constraint?: ConstraintSerialization;
+  pointwise_constraint?: ConstraintSerialization;
+}
+
+export type SeparableConv2DLayerSerialization =
+    BaseLayerSerialization<'SeparableConv2D', ConvLayerConfig>;
+
+
+export interface Cropping2DLayerConfig extends LayerConfig {
+  cropping: number|[number, number]|[[number, number], [number, number]];
+  dataFormat?: DataFormatSerialization;
+}
+
+export type Cropping2DLayerSerialization =
+    BaseLayerSerialization<'Cropping2D', Cropping2DLayerConfig>;
+
+export interface UpSampling2DLayerConfig extends LayerConfig {
+  size?: number[];
+  dataFormat?: DataFormatSerialization;
+}
+
+export type UpSampling2DLayerSerialization =
+    BaseLayerSerialization<'UpSampling2D', UpSampling2DLayerConfig>;
+
+export type ConvolutionalSerialization =
+    Conv1DLayerSerialization|Conv2DLayerSerialization|
+    Conv2DTransposeLayerSerialization|SeparableConv2DLayerSerialization|
+    Cropping2DLayerSerialization|UpSampling2DLayerSerialization;

--- a/src/keras_format/layers/core_serialization.ts
+++ b/src/keras_format/layers/core_serialization.ts
@@ -41,6 +41,9 @@ export interface DenseLayerConfig extends LayerConfig {
 export type DenseLayerSerialization =
     BaseLayerSerialization<'Dense', DenseLayerConfig>;
 
+export type FlattenLayerSerialization =
+    BaseLayerSerialization<'Flatten', LayerConfig>;
+
 export interface ActivationLayerConfig extends LayerConfig {
   activation: ActivationIdentifier;
 }
@@ -70,6 +73,6 @@ export type PermuteLayerSerialization =
     BaseLayerSerialization<'Permute', PermuteLayerConfig>;
 
 export type CoreLayerSerialization =
-    DropoutLayerSerialization|DenseLayerSerialization|
+    DropoutLayerSerialization|DenseLayerSerialization|FlattenLayerSerialization|
     ActivationLayerSerialization|RepeatVectorLayerSerialization|
     ReshapeLayerSerialization|PermuteLayerSerialization;

--- a/src/keras_format/layers/layer_serialization.ts
+++ b/src/keras_format/layers/layer_serialization.ts
@@ -8,9 +8,11 @@
  * =============================================================================
  */
 
+import {InputLayerSerialization} from '../input_config';
+
 import {AdvancedActivationLayerSerialization} from './advanced_activation_serialization';
 import {DepthwiseConv2DLayerSerialization} from './convolutional_depthwise_serialization';
-import {ConvLayerSerialization} from './convolutional_serialization';
+import {ConvolutionalSerialization} from './convolutional_serialization';
 import {CoreLayerSerialization} from './core_serialization';
 import {MergeLayerSerialization} from './merge_serialization';
 import {BatchNormalizationLayerSerialization} from './normalization_serialization';
@@ -20,8 +22,9 @@ import {RecurrentLayerSerialization} from './recurrent_serialization';
 
 export type LayerSerialization =
     AdvancedActivationLayerSerialization|DepthwiseConv2DLayerSerialization|
-    ConvLayerSerialization|CoreLayerSerialization|MergeLayerSerialization|
+    ConvolutionalSerialization|CoreLayerSerialization|MergeLayerSerialization|
     BatchNormalizationLayerSerialization|ZeroPadding2DLayerSerialization|
-    PoolingLayerSerialization|RecurrentLayerSerialization;
+    PoolingLayerSerialization|RecurrentLayerSerialization|
+    InputLayerSerialization;
 
 export type LayerClassName = LayerSerialization['class_name'];

--- a/src/keras_format/layers/merge_serialization.ts
+++ b/src/keras_format/layers/merge_serialization.ts
@@ -10,6 +10,22 @@
 
 import {BaseLayerSerialization, LayerConfig} from '../topology_config';
 
+
+
+export type AddLayerSerialization = BaseLayerSerialization<'Add', LayerConfig>;
+
+export type MultiplyLayerSerialization =
+    BaseLayerSerialization<'Multiply', LayerConfig>;
+
+export type AverageLayerSerialization =
+    BaseLayerSerialization<'Average', LayerConfig>;
+
+export type MaximumLayerSerialization =
+    BaseLayerSerialization<'Maximum', LayerConfig>;
+
+export type MinimumLayerSerialization =
+    BaseLayerSerialization<'Minimum', LayerConfig>;
+
 export interface ConcatenateLayerConfig extends LayerConfig {
   axis?: number;
 }
@@ -26,4 +42,6 @@ export type DotLayerSerialization =
     BaseLayerSerialization<'Dot', DotLayerConfig>;
 
 export type MergeLayerSerialization =
+    AddLayerSerialization|MultiplyLayerSerialization|AverageLayerSerialization|
+    MaximumLayerSerialization|MinimumLayerSerialization|
     ConcatenateLayerSerialization|DotLayerSerialization;

--- a/src/keras_format/layers/padding_serialization.ts
+++ b/src/keras_format/layers/padding_serialization.ts
@@ -8,12 +8,12 @@
  * =============================================================================
  */
 
-import {DataFormat} from '../common';
+import {DataFormatSerialization} from '../common';
 import {BaseLayerSerialization, LayerConfig} from '../topology_config';
 
 export interface ZeroPadding2DLayerConfig extends LayerConfig {
   padding?: number|[number, number]|[[number, number], [number, number]];
-  data_format?: DataFormat;
+  data_format?: DataFormatSerialization;
 }
 
 export type ZeroPadding2DLayerSerialization =

--- a/src/keras_format/layers/pooling_serialization.ts
+++ b/src/keras_format/layers/pooling_serialization.ts
@@ -8,7 +8,7 @@
  * =============================================================================
  */
 
-import {DataFormat, PaddingMode} from '../common';
+import {DataFormatSerialization, PaddingMode} from '../common';
 import {BaseLayerSerialization, LayerConfig} from '../topology_config';
 
 
@@ -17,25 +17,46 @@ export interface Pooling1DLayerConfig extends LayerConfig {
   strides?: number;
   padding?: PaddingMode;
 }
-export type Pooling1DLayerSerialization =
-    BaseLayerSerialization<'Pooling1D', Pooling1DLayerConfig>;
+
+export type MaxPooling1DLayerSerialization =
+    BaseLayerSerialization<'MaxPooling1D', Pooling1DLayerConfig>;
+
+export type AveragePooling1DLayerSerialization =
+    BaseLayerSerialization<'AveragePooling1D', Pooling1DLayerConfig>;
 
 export interface Pooling2DLayerConfig extends LayerConfig {
   pool_size?: number|[number, number];
   strides?: number|[number, number];
   padding?: PaddingMode;
-  data_format?: DataFormat;
+  data_format?: DataFormatSerialization;
 }
 
-export type Pooling2DLayerSerialization =
-    BaseLayerSerialization<'Pooling2D', Pooling2DLayerConfig>;
+export type MaxPooling2DLayerSerialization =
+    BaseLayerSerialization<'MaxPooling2D', Pooling2DLayerConfig>;
+
+export type AveragePooling2DLayerSerialization =
+    BaseLayerSerialization<'AveragePooling2D', Pooling2DLayerConfig>;
+
+export type GlobalAveragePooling1DLayerSerialization =
+    BaseLayerSerialization<'GlobalAveragePooling1D', LayerConfig>;
+
+export type GlobalMaxPooling1DLayerSerialization =
+    BaseLayerSerialization<'GlobalMaxPooling1D', LayerConfig>;
 
 export interface GlobalPooling2DLayerConfig extends LayerConfig {
-  data_format?: DataFormat;
+  data_format?: DataFormatSerialization;
 }
 
-export type GlobalPooling2DLayerSerialization =
-    BaseLayerSerialization<'GlobalPooling2D', GlobalPooling2DLayerConfig>;
+export type GlobalAveragePooling2DLayerSerialization = BaseLayerSerialization<
+    'GlobalAveragePooling2D', GlobalPooling2DLayerConfig>;
 
-export type PoolingLayerSerialization = Pooling1DLayerSerialization|
-    Pooling2DLayerSerialization|GlobalPooling2DLayerSerialization;
+export type GlobalMaxPooling2DLayerSerialization =
+    BaseLayerSerialization<'GlobalMaxPooling2D', GlobalPooling2DLayerConfig>;
+
+export type PoolingLayerSerialization = MaxPooling1DLayerSerialization|
+    AveragePooling1DLayerSerialization|MaxPooling2DLayerSerialization|
+    AveragePooling2DLayerSerialization|GlobalAveragePooling1DLayerSerialization|
+    GlobalMaxPooling1DLayerSerialization|
+    GlobalAveragePooling2DLayerSerialization|
+    GlobalMaxPooling2DLayerSerialization;
+;

--- a/src/keras_format/model_serialization.ts
+++ b/src/keras_format/model_serialization.ts
@@ -52,7 +52,7 @@ export interface SequentialSerialization extends
  */
 export type LegacySequentialSerialization = {
   // Note this cannot extend `BaseSerialization` because of the bug.
-  className: 'Sequential';
+  class_name: 'Sequential';
 
   config: LayerSerialization[];
   backend?: string;

--- a/src/keras_format/model_serialization.ts
+++ b/src/keras_format/model_serialization.ts
@@ -11,14 +11,14 @@
 import {LayerSerialization} from './layers/layer_serialization';
 import {TensorKeyArray} from './node_config';
 import {TrainingConfig} from './training_config';
-import {BaseSerialization, PyJsonDict} from './types';
+import {BaseSerialization} from './types';
 
 export type ModelConfig = {
   name: string,
   layers: LayerSerialization[],
   input_layers: TensorKeyArray[],
   output_layers: TensorKeyArray[],
-}&PyJsonDict;
+};
 
 /**
  * A standard Keras JSON 'Model' configuration.
@@ -31,7 +31,7 @@ export interface ModelSerialization extends
 
 export type SequentialConfig = {
   layers: LayerSerialization[]
-}&PyJsonDict;
+};
 
 /**
  * A standard Keras JSON 'Sequential' configuration.
@@ -57,7 +57,7 @@ export type LegacySequentialSerialization = {
   config: LayerSerialization[];
   backend?: string;
   keras_version?: string;
-}&PyJsonDict;
+};
 
 /**
  * Contains the description of a KerasModel, as well as the configuration
@@ -68,4 +68,4 @@ export type KerasFileSerialization = {
   model_config: ModelSerialization|SequentialSerialization|
   LegacySequentialSerialization;
   training_config: TrainingConfig;
-}&PyJsonDict;
+};

--- a/src/keras_format/topology_config.ts
+++ b/src/keras_format/topology_config.ts
@@ -12,10 +12,11 @@ import {DataType} from '@tensorflow/tfjs-core';
 
 import {Shape} from './common';
 import {NodeConfig} from './node_config';
-import {BaseSerialization, PyJsonDict} from './types';
+import {BaseSerialization, PyJson} from './types';
 
 /** Constructor arguments for Layer. */
-export interface LayerConfig extends PyJsonDict {
+export interface LayerConfig extends
+    PyJson<Extract<keyof LayerConfig, string>> {
   input_shape?: Shape;
   batch_input_shape?: Shape;
   batch_size?: number;
@@ -35,7 +36,8 @@ export interface LayerConfig extends PyJsonDict {
  * subtypes of `LayerConfig`.  Thus, this `*Serialization` has a type parameter
  * giving the specific type of the wrapped `LayerConfig`.
  */
-export interface BaseLayerSerialization<N extends string, T extends LayerConfig>
+export interface BaseLayerSerialization<N extends string, T extends LayerConfig&
+                                        PyJson<Extract<keyof T, string>>>
     extends BaseSerialization<N, T> {
   name: string;
   inbound_nodes?: NodeConfig[];

--- a/src/keras_format/topology_config.ts
+++ b/src/keras_format/topology_config.ts
@@ -15,8 +15,7 @@ import {NodeConfig} from './node_config';
 import {BaseSerialization, PyJson} from './types';
 
 /** Constructor arguments for Layer. */
-export interface LayerConfig extends
-    PyJson<Extract<keyof LayerConfig, string>> {
+export interface LayerConfig {
   input_shape?: Shape;
   batch_input_shape?: Shape;
   batch_size?: number;
@@ -36,9 +35,10 @@ export interface LayerConfig extends
  * subtypes of `LayerConfig`.  Thus, this `*Serialization` has a type parameter
  * giving the specific type of the wrapped `LayerConfig`.
  */
-export interface BaseLayerSerialization<N extends string, T extends LayerConfig&
-                                        PyJson<Extract<keyof T, string>>>
-    extends BaseSerialization<N, T> {
+export interface BaseLayerSerialization<
+    N extends string, T extends PyJson<Extract<keyof T, string>>> extends
+    BaseSerialization<N, T> {
+  // T should actually extend L;yerConfig, but that is hard to enforce.
   name: string;
   inbound_nodes?: NodeConfig[];
 }

--- a/src/keras_format/training_config.ts
+++ b/src/keras_format/training_config.ts
@@ -30,22 +30,42 @@ export type OptimizerSerialization<
 
 /**
  * List of all known loss names, along with a string description.
+ *
+ * Representing this as a class allows both type-checking using the keys and
+ * generating an appropriate options array for use in select fields.
  */
-export type LossOptions = {
-  mean_squared_error: 'Mean Squared Error',
-  mean_absolute_error: 'Mean Absolute Error',
-  mean_absolute_percentage_error: 'Mean Absolute Percentage Error',
-  mean_squared_logarithmic_error: 'Mean Squared Logarithmic Error',
-  squared_hinge: 'Squared Hinge',
-  hinge: 'Hinge',
-  categorical_hinge: 'Categorical Hinge',
-  logcosh: 'Logcosh',
-  categorical_crossentropy: 'Categorical Cross Entropy',
-  sparse_categorical_crossentropy: 'Sparse Categorical Cross Entropy',
-  kullback_leibler_divergence: 'Kullback-Liebler Divergence',
-  poisson: 'Poisson',
-  cosine_proximity: 'Cosine Proximity',
-};
+export class LossOptions {
+  [key: string]: string;
+  // tslint:disable:variable-name
+  public readonly mean_squared_error = 'Mean Squared Error';
+  public readonly mean_absolute_error = 'Mean Absolute Error';
+  public readonly mean_absolute_percentage_error =
+      'Mean Absolute Percentage Error';
+  public readonly mean_squared_logarithmic_error =
+      'Mean Squared Logarithmic Error';
+  public readonly squared_hinge = 'Squared Hinge';
+  public readonly hinge = 'Hinge';
+  public readonly categorical_hinge = 'Categorical Hinge';
+  public readonly logcosh = 'Logcosh';
+  public readonly categorical_crossentropy = 'Categorical Cross Entropy';
+  public readonly sparse_categorical_crossentropy =
+      'Sparse Categorical Cross Entropy';
+  public readonly kullback_leibler_divergence = 'Kullback-Liebler Divergence';
+  public readonly poisson = 'Poisson';
+  public readonly cosine_proximity = 'Cosine Proximity';
+  // tslint:enable:variable-name
+}
+
+function convertLossOptions(): Array<{value: string, label: string}> {
+  const options = new LossOptions();
+  const result: Array<{value: string, label: string}> = [];
+  for (const key in Object.keys(options)) {
+    result.push({value: key, label: options[key]});
+  }
+  return result;
+}
+
+export const lossOptions = convertLossOptions();
 
 export type LossKey = keyof LossOptions;
 
@@ -59,6 +79,7 @@ export type LossWeights = number[]|{[key: string]: number};
  * optimizer, the loss, any metrics to be calculated, etc.
  */
 export interface TrainingConfig {
+  // tslint:disable-next-line:no-any
   optimizer_config: OptimizerSerialization<string, OptimizerConfig<any>>;
   loss: LossKey|LossKey[]|{[key: string]: LossKey};
   metrics?: MetricsKey[];

--- a/src/keras_format/training_config.ts
+++ b/src/keras_format/training_config.ts
@@ -9,7 +9,7 @@
  */
 
 import {SampleWeightMode} from './common';
-import {BaseSerialization, PyJsonDict} from './types';
+import {BaseSerialization, PyJson} from './types';
 
 /**
  * Because of the limitations in the current Keras spec, there is no clear
@@ -18,14 +18,14 @@ import {BaseSerialization, PyJsonDict} from './types';
  *
  * See internal issue: b/121033602
  */
-export type OptimizerConfig = PyJsonDict;
+export type OptimizerConfig<C extends PyJson<Extract<keyof C, string>>> = C;
 
 /**
- * Configuration of a Keras optimizer, containing both the type of the optimizer
- * and the configuration for the optimizer of that type.
+ * Configuration of a Keras optimizer, containing both the type of the
+ * optimizer and the configuration for the optimizer of that type.
  */
-export type OptimizerSerialization<N extends string,
-                                             C extends OptimizerConfig> =
+export type OptimizerSerialization<
+    N extends string, C extends PyJson<Extract<keyof C, string>>> =
     BaseSerialization<N, C>;
 
 /**
@@ -59,7 +59,7 @@ export type LossWeights = number[]|{[key: string]: number};
  * optimizer, the loss, any metrics to be calculated, etc.
  */
 export interface TrainingConfig {
-  optimizer_config: OptimizerSerialization<string, PyJsonDict>;
+  optimizer_config: OptimizerSerialization<string, OptimizerConfig<any>>;
   loss: LossKey|LossKey[]|{[key: string]: LossKey};
   metrics?: MetricsKey[];
   weighted_metrics?: MetricsKey[];

--- a/src/keras_format/types.ts
+++ b/src/keras_format/types.ts
@@ -36,6 +36,40 @@ export interface PyJsonDict {
 }
 
 /**
+ * A key-value dict like @see PyJsonDict, but with restricted keys.
+ *
+ * This makes it possible to create subtypes that have only the specified
+ * fields, while requiring that the values are JSON-compatible.
+ *
+ * That is in contrast to extending `PyJsonDict`, or using an intersection type
+ * `Foo & PyJsonDict`.  In both of those cases, the fields of Foo are actually
+ * allowed to be of types that are incompatible with `PyJsonValue`.  Worse, the
+ * index signature of `PyJsonValue` means that *any* key is accepted: eg.
+ * `const foo: Foo = ...; foo.bogus = 12; const x = foo.bogus` works for both
+ * reading and assignment, even if `bogus` is not a field of the type `Foo`,
+ * because the index signature inherited from `PyJsonDict` accepts all strings.
+ *
+ * Here, we *both* restrict the keys to known values, *and* guarantee that the
+ * values associated with those keys are compatible with `PyJsonValue`.
+ *
+ * This guarantee is easiest to apply via an additional incantation:
+ *
+ * ```
+ * export interface Foo extends PyJson<keyof Foo> {
+ *   a: SomeType;
+ *   b: SomeOtherType;
+ * }
+ * ```
+ *
+ * Now instances of `Foo` have *only* the fields `a` and `b`, and furthermore,
+ * if either the type `SomeType` or `SomeOtherType` is incompatible with
+ * `PyJsonValue`, the compiler produces a typing error.
+ */
+export type PyJson<Keys extends string> = {
+  [x in Keys]?: PyJsonValue;
+};
+
+/**
  * An array of values within the JSON-serialized form of a serializable object.
  *
  * The keys of any nested dicts should be in snake_case (i.e., using Python
@@ -54,8 +88,29 @@ export interface PyJsonArray extends Array<PyJsonValue> {}
  * subtypes of `PyJsonDict`.  Thus, this `*Serialization` has a type parameter
  * giving the specific type of the wrapped `PyJsonDict`.
  */
-export interface BaseSerialization<N extends string, T extends PyJsonDict>
-    extends PyJsonDict {
+export interface BaseSerialization<
+    N extends string, T extends PyJson<Extract<keyof T, string>>> extends
+    PyJsonDict {
+  // The above type voodoo does this:
+  // * `keyof T` obtains the known keys of the specific config type.
+  //   `keyof`  returns `string | number | symbol`; see
+  //   (https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-9.html)
+  // * `Extract<keyof T, string>` selects the string values.  This amounts to
+  //    assuming that we are dealing with a type with string keys, as opposed to
+  //    an array.  In our usage, this assumption always holds.
+  // * `PyJson<Extract<keyof T, string>>` is a type whose keys are constrained
+  //    to the provided ones, and whose values must be JSON-compatible.
+  // * `T extends PyJson<Extract<keyof T, string>> means that we can provide any
+  //    config type with known keys, provided that the associated values are
+  //    JSON-compatible.
+  //
+  // The upshot is that we can extend `BaseSerialization` with whatever config
+  // type `T` that we like-- remaining confident that the result can be
+  // trivially rendered as JSON, because the compiler will produce a typing
+  // error if that guarantee does not hold.
+  //
+  // To test this, try adding a field with a non-JSON-like value (e.g., Tensor)
+  // to any subclass of `BaseSerialization`.  A compilation error will result.
   class_name: N;
   config: T;
 }

--- a/src/models.ts
+++ b/src/models.ts
@@ -846,7 +846,7 @@ export class Sequential extends Model {
    *   a sequential model). The latter case is for models with multiple
    *   inputs and/or multiple outputs. Of the two items in the array, the
    *   first is the input feature(s) and the second is the output target(s).
-   * @param args A `ModelFitDatasetConfig`, containing optional fields.
+   * @param args A `ModelFitDatasetArgs`, containing optional fields.
    *
    * @return A `History` instance. Its `history` attribute contains all
    *   information collected during training.


### PR DESCRIPTION
1.  My previous attempt to enforce that *Serializations contained only JSON-compatible fields did not work right.  Here it is actually enforced correctly.  Please see the new comments in src/keras_format/types.ts for details.

2.  I had overlooked a bunch of layer types that didn't have their own *Args, and most of the Convolutions.  Those are added in here.

3.  A few hiccups remained re CamelCase vs. snake_case, especially in the values of restricted string types such as DataFormat (e.g., 'channelsLast' vs 'channels_last'). 