### PR TITLE
tf.Model.evaluateDataset(): Allow omitting config object

### DIFF
--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -843,7 +843,7 @@ export class Model extends Container implements tfc.InferenceModel {
    */
   async evaluateDataset<T extends TensorContainer>(
       dataset: Dataset<T>,
-      args: ModelEvaluateDatasetArgs): Promise<Scalar|Scalar[]> {
+      args?: ModelEvaluateDatasetArgs): Promise<Scalar|Scalar[]> {
     this.makeTestFunction();
     return evaluateDataset(this, dataset, args);
   }

--- a/src/engine/training_dataset.ts
+++ b/src/engine/training_dataset.ts
@@ -456,6 +456,9 @@ export async function evaluateDataset<T extends TensorContainer>(
     // tslint:disable-next-line:no-any
     model: any, dataset: Dataset<T>|LazyIterator<T>,
     args: ModelEvaluateDatasetArgs): Promise<tfc.Scalar|tfc.Scalar[]> {
+  if (args == null) {
+    args = {};
+  }
   const hasBatches = args.batches != null;
   const f = model.testFunction;
   const outs: tfc.Scalar[] = [];

--- a/src/engine/training_dataset.ts
+++ b/src/engine/training_dataset.ts
@@ -456,9 +456,7 @@ export async function evaluateDataset<T extends TensorContainer>(
     // tslint:disable-next-line:no-any
     model: any, dataset: Dataset<T>|LazyIterator<T>,
     args: ModelEvaluateDatasetArgs): Promise<tfc.Scalar|tfc.Scalar[]> {
-  if (args == null) {
-    args = {};
-  }
+  args = args || {};
   const hasBatches = args.batches != null;
   const f = model.testFunction;
   const outs: tfc.Scalar[] = [];


### PR DESCRIPTION
- In case where the `tf.data.Dataset` object terminates itself
  with `done: true`, it is not necessary to specify `batches`.
  This PR makes it possible to omit the 2nd arg (the config object)
  entirely.

Fixes https://github.com/tensorflow/tfjs/issues/1096

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/427)
<!-- Reviewable:end -->
