### PR TITLE
Small speedup in predict loop

### DIFF
--- a/integration_tests/benchmarks/README.md
+++ b/integration_tests/benchmarks/README.md
@@ -7,9 +7,23 @@ Python Keras backed by TensorFlow.
 NOTE: This benchmark requires that you have TensorFlow and Keras installed in your
 Python environment since it compares timing in Python to timing in the browser.
 
-To launch the benchmarks, do
+To launch the benchmarks, first make sure you have all the required Python
+packages installed:
 
 ```sh
 cd integration_tests/benchmarks
+pip install -r requirements.txt
+```
+
+Then, run the benchmarks in Python and build the benchmark page in JavaScript:
+
+```sh
 ./build-benchmarks.sh
+```
+
+Once the step above has been done, you can skip the Python benchmark part in
+future runs by using the `--skip_py_benchmarks` flag, i.e.,
+
+```sh
+./build-benchmarks.sh --skip_by_benchmarks
 ```

--- a/integration_tests/benchmarks/package.json
+++ b/integration_tests/benchmarks/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs-core": "^0.14.2",
+    "@tensorflow/tfjs-core": "^0.14.5",
     "@tensorflow/tfjs-layers": "../../dist"
   },
   "scripts": {

--- a/integration_tests/benchmarks/requirements.txt
+++ b/integration_tests/benchmarks/requirements.txt
@@ -1,0 +1,3 @@
+tensorflow>=1.12.0
+keras>=2.2.4
+tensorflowjs>=0.6.7

--- a/integration_tests/benchmarks/yarn.lock
+++ b/integration_tests/benchmarks/yarn.lock
@@ -642,10 +642,10 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@tensorflow/tfjs-core@^0.14.2":
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.14.3.tgz#1fd9d229fa3be6fc13ee8655785e9ebf13ebda24"
-  integrity sha512-HQWTZXTpd0wckBF+tJSJtxqhclElQ58UvovIIuYCI/YX1tGRK++KY3O8YFNUtefkTKdV9a0uTY4DdtK7b3qe5w==
+"@tensorflow/tfjs-core@^0.14.5":
+  version "0.14.5"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.14.5.tgz#17c3beeec31c4cd92b0f79a5ef30c4975a11e408"
+  integrity sha512-CSUgKuC17J1Ylr1s6iD1k2/tJr9lD16sUEjtzJbtiuTYCELOwujGK/1htunA7o3BwLuU7aqEI92MoKElEKa7qA==
   dependencies:
     "@types/seedrandom" "2.4.27"
     "@types/webgl-ext" "0.0.30"

--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -1003,7 +1003,11 @@ export class Model extends Container implements tfc.InferenceModel {
       //   iterating over the batches.
 
       const batches = makeBatches(numSamples, batchSize);
-      const outs: Tensor[] = [];
+      const outsBatches: Tensor[][] = [];
+      for (let i = 0; i < this.outputs.length; ++i) {
+        outsBatches.push([]);
+      }
+
       // TODO(cais): Can the scope() be pushed down inside the for loop?
       for (let batchIndex = 0; batchIndex < batches.length; ++batchIndex) {
         const batchOuts = tfc.tidy(() => {
@@ -1025,18 +1029,12 @@ export class Model extends Container implements tfc.InferenceModel {
           const feedDict = new FeedDict(feeds);
           return execute(this.outputs, feedDict) as Tensor[];
         });
-        if (batchIndex === 0) {
-          // Pre-allocate.
-          for (const batchOut of batchOuts) {
-            outs.push(batchOut);
-          }
-        } else {
-          for (let i = 0; i < batchOuts.length; ++i) {
-            outs[i] = K.concatAlongFirstAxis(outs[i], batchOuts[i]);
-          }
-        }
+        batchOuts.forEach((batchOut, i) => {
+          outsBatches[i].push(batchOut);
+        });
       }
-      return singletonOrArray(outs);
+      return singletonOrArray(
+          outsBatches.map(batches => tfc.concat(batches, 0)));
     });
   }
 

--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -1003,10 +1003,7 @@ export class Model extends Container implements tfc.InferenceModel {
       //   iterating over the batches.
 
       const batches = makeBatches(numSamples, batchSize);
-      const outsBatches: Tensor[][] = [];
-      for (let i = 0; i < this.outputs.length; ++i) {
-        outsBatches.push([]);
-      }
+      const outsBatches: Tensor[][] = this.outputs.map(output => []);
 
       // TODO(cais): Can the scope() be pushed down inside the for loop?
       for (let batchIndex = 0; batchIndex < batches.length; ++batchIndex) {
@@ -1029,9 +1026,7 @@ export class Model extends Container implements tfc.InferenceModel {
           const feedDict = new FeedDict(feeds);
           return execute(this.outputs, feedDict) as Tensor[];
         });
-        batchOuts.forEach((batchOut, i) => {
-          outsBatches[i].push(batchOut);
-        });
+        batchOuts.forEach((batchOut, i) => outsBatches[i].push(batchOut));
       }
       return singletonOrArray(
           outsBatches.map(batches => tfc.concat(batches, 0)));


### PR DESCRIPTION
- By replacing per-batch concat with a large concat at the end.

Example benchmark results (4 benchmark runs per condition) 
* Number of examples: 128
* Batch size: 32
* Therefore, the predict() call consists of 4 batches

- dense-tiny: Before: [3.9, 3.8, 4.0, 3.6], After: [3.5, 3.4, 3.4, 3.2]. 
  - Mean change: 3.825 --> 3.375 (-11.8%)
  - scipy.stats.ttest_ind(): p = 0.0054
- dense-large: Before: [10.6, 10.5, 10.7, 10.4], After: [10.3, 10.3, 10.4, 10.3]
  - Mean change: 10.55 --> 10.325 (-2.1%)
  - scipy.stats.ttest_ind(): p = 0.017

Also in this change:
- Add more information to integration_tests/benchmarks/README.md
- Add requirements.txt for the Python part of integration_tests/benchmarks
- Upgrade tfjs-core dependency to the latest (0.14.5)

PERF

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/430)
<!-- Reviewable:end -->
