### PR TITLE
Model.fitDataset(): Set default verbose level to 1

### DIFF
--- a/src/engine/training_dataset.ts
+++ b/src/engine/training_dataset.ts
@@ -317,8 +317,9 @@ export async function fitDataset<T extends TensorContainer>(
     }
 
     const callbacks = standardizeCallbacks(args.callbacks);
+    const verbose = args.verbose == null ? 1 : args.verbose;
     const {callbackList, history} = configureCallbacks(
-        callbacks, args.yieldEvery, args.verbose, args.epochs, null, null,
+        callbacks, args.yieldEvery, verbose, args.epochs, null, null,
         args.batchesPerEpoch,
         null,  // Batch size determined by the dataset itself.
         doValidation, callbackMetrics);


### PR DESCRIPTION
Now that the progress bar callback has been made working for fitDataset() (see https://github.com/tensorflow/tfjs-node/pull/194), we are ready to change the default verbose level of `fitDataset()` to 1, to be consistent with `fit()`. This causes the progress bar logger to be enabled by default when `fitDataset()` is called in tfjs-node/tfjs-node-gpu.

BUG

Fixes https://github.com/tensorflow/tfjs/issues/1101

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/435)
<!-- Reviewable:end -->
