### PR TITLE
Update configParamIndices to display details of args in jsdoc

### DIFF
--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -13,8 +13,7 @@
 import * as tfc from '@tensorflow/tfjs-core';
 import {io, ModelPredictConfig as ModelPredictArgs, Optimizer, Scalar, serialization, Tensor, Tensor1D, tensor1d, util} from '@tensorflow/tfjs-core';
 import {TensorContainer} from '@tensorflow/tfjs-core/dist/tensor_types';
-
-import {getScalar,} from '../backend/state';
+import {getScalar} from '../backend/state';
 import * as K from '../backend/tfjs_backend';
 import {History, ModelLoggingVerbosity} from '../base_callbacks';
 import {nameScope} from '../common';
@@ -28,13 +27,13 @@ import {count, pyListRepeat, singletonOrArray, unique} from '../utils/generic_ut
 import {printSummary} from '../utils/layer_utils';
 import {range} from '../utils/math_utils';
 import {LayerVariable} from '../variables';
-
 import {Container, ContainerArgs} from './container';
 import {Dataset} from './dataset_stub';
 import {execute, FeedDict} from './executor';
 import {SymbolicTensor} from './topology';
 import {evaluateDataset, fitDataset, ModelEvaluateDatasetArgs, ModelFitDatasetArgs} from './training_dataset';
 import {checkBatchSize, disposeNewTensors, ensureTensorsRank2OrHigher, fitTensors, makeBatches, ModelFitArgs, sliceArrays, sliceArraysByIndices} from './training_tensors';
+
 
 /**
  * Helper function for polymorphic input data: 1. singleton Tensor.
@@ -839,7 +838,7 @@ export class Model extends Container implements tfc.InferenceModel {
    * @returns Loss and metric values as an Array of `Scalar` objects.
    */
   /**
-   * @doc {heading: 'Models', subheading: 'Classes', configParamIndices: [2]}
+   * @doc {heading: 'Models', subheading: 'Classes', configParamIndices: [1]}
    */
   async evaluateDataset<T extends TensorContainer>(
       dataset: Dataset<T>,
@@ -1414,7 +1413,7 @@ export class Model extends Container implements tfc.InferenceModel {
    *   information collected during training.
    */
   /**
-   * @doc {heading: 'Models', subheading: 'Classes', configParamIndices: [2]}
+   * @doc {heading: 'Models', subheading: 'Classes', configParamIndices: [1]}
    */
   async fitDataset<T extends TensorContainer>(
       dataset: Dataset<T>, args: ModelFitDatasetArgs<T>): Promise<History> {

--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -13,7 +13,8 @@
 import * as tfc from '@tensorflow/tfjs-core';
 import {io, ModelPredictConfig as ModelPredictArgs, Optimizer, Scalar, serialization, Tensor, Tensor1D, tensor1d, util} from '@tensorflow/tfjs-core';
 import {TensorContainer} from '@tensorflow/tfjs-core/dist/tensor_types';
-import {getScalar} from '../backend/state';
+
+import {getScalar,} from '../backend/state';
 import * as K from '../backend/tfjs_backend';
 import {History, ModelLoggingVerbosity} from '../base_callbacks';
 import {nameScope} from '../common';
@@ -27,13 +28,13 @@ import {count, pyListRepeat, singletonOrArray, unique} from '../utils/generic_ut
 import {printSummary} from '../utils/layer_utils';
 import {range} from '../utils/math_utils';
 import {LayerVariable} from '../variables';
+
 import {Container, ContainerArgs} from './container';
 import {Dataset} from './dataset_stub';
 import {execute, FeedDict} from './executor';
 import {SymbolicTensor} from './topology';
 import {evaluateDataset, fitDataset, ModelEvaluateDatasetArgs, ModelFitDatasetArgs} from './training_dataset';
 import {checkBatchSize, disposeNewTensors, ensureTensorsRank2OrHigher, fitTensors, makeBatches, ModelFitArgs, sliceArrays, sliceArraysByIndices} from './training_tensors';
-
 
 /**
  * Helper function for polymorphic input data: 1. singleton Tensor.

--- a/src/models.ts
+++ b/src/models.ts
@@ -12,6 +12,7 @@
 
 import {io, Scalar, serialization, Tensor, util} from '@tensorflow/tfjs-core';
 import {TensorContainer} from '@tensorflow/tfjs-core/dist/tensor_types';
+
 import {getUid} from './backend/state';
 import {History} from './base_callbacks';
 import {Dataset} from './engine/dataset_stub';

--- a/src/models.ts
+++ b/src/models.ts
@@ -12,7 +12,6 @@
 
 import {io, Scalar, serialization, Tensor, util} from '@tensorflow/tfjs-core';
 import {TensorContainer} from '@tensorflow/tfjs-core/dist/tensor_types';
-
 import {getUid} from './backend/state';
 import {History} from './base_callbacks';
 import {Dataset} from './engine/dataset_stub';
@@ -29,7 +28,6 @@ import {Kwargs, NamedTensorMap} from './types';
 import * as generic_utils from './utils/generic_utils';
 import {convertPythonicToTs} from './utils/serialization_utils';
 import {getExactlyOneShape} from './utils/types_utils';
-
 
 
 /**
@@ -708,7 +706,7 @@ export class Sequential extends Model {
    * @returns Loss and metric values as an Array of `Scalar` objects.
    */
   /**
-   * @doc {heading: 'Models', subheading: 'Classes', configParamIndices: [2]}
+   * @doc {heading: 'Models', subheading: 'Classes', configParamIndices: [1]}
    */
   async evaluateDataset<T extends TensorContainer>(
       dataset: Dataset<T>,
@@ -852,7 +850,7 @@ export class Sequential extends Model {
    *   information collected during training.
    */
   /**
-   * @doc {heading: 'Models', subheading: 'Classes', configParamIndices: [2]}
+   * @doc {heading: 'Models', subheading: 'Classes', configParamIndices: [1]}
    */
   async fitDataset<T extends TensorContainer>(
       dataset: Dataset<T>, args: ModelFitDatasetArgs<T>): Promise<History> {


### PR DESCRIPTION
Fix jsdoc to display details of ModelFitDatasetArgs and ModelEvaluateDatasetArgs.

This fixes https://github.com/tensorflow/tfjs/issues/1135

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/437)
<!-- Reviewable:end -->
