### PR TITLE
API doc spelling mistake fixed

### DIFF
--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -1585,7 +1585,7 @@ export class Model extends Container implements tfc.InferenceModel {
    * ```
    *
    * Example 4. Send  `model`'s topology and weights to an HTTP server.
-   * See the documentation of `tf.io.browserHTTPRequests` for more details
+   * See the documentation of `tf.io.browserHTTPRequest` for more details
    * including specifying request parameters and implementation of the
    * server.
    *


### PR DESCRIPTION
No "s" for `tf.io.browserHTTPRequest`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/438)
<!-- Reviewable:end -->
