### PR TITLE
Model.fitDataset(): Use size when available & there's no batchesPerEpochs

### DIFF
--- a/src/engine/dataset_fakes.ts
+++ b/src/engine/dataset_fakes.ts
@@ -183,6 +183,7 @@ export class FakeNumericDataset extends
     tfc.util.assert(
         args.numBatches > 0 && Number.isInteger(args.numBatches),
         `numBatches must be positive integer, but got ${args.numBatches}`);
+    this.size = args.numBatches;
   }
 
   async iterator():

--- a/src/engine/dataset_stub.ts
+++ b/src/engine/dataset_stub.ts
@@ -26,7 +26,7 @@ export abstract class LazyIterator<T> {
 
 export abstract class Dataset<T extends TensorContainer> {
   abstract async iterator(): Promise<LazyIterator<T>>;
-  readonly size: number;
+  size: number;
 }
 
 export type TensorMap = {

--- a/src/engine/dataset_stub.ts
+++ b/src/engine/dataset_stub.ts
@@ -26,6 +26,7 @@ export abstract class LazyIterator<T> {
 
 export abstract class Dataset<T extends TensorContainer> {
   abstract async iterator(): Promise<LazyIterator<T>>;
+  readonly size: number;
 }
 
 export type TensorMap = {

--- a/src/engine/training_dataset.ts
+++ b/src/engine/training_dataset.ts
@@ -320,7 +320,7 @@ export async function fitDataset<T extends TensorContainer>(
     const verbose = args.verbose == null ? 1 : args.verbose;
     const {callbackList, history} = configureCallbacks(
         callbacks, args.yieldEvery, verbose, args.epochs, null, null,
-        args.batchesPerEpoch,
+        getBatchesPerEpoch(dataset, args),
         null,  // Batch size determined by the dataset itself.
         doValidation, callbackMetrics);
     callbackList.setModel(model);
@@ -431,6 +431,19 @@ export async function fitDataset<T extends TensorContainer>(
   } finally {
     model.isTraining = false;
   }
+}
+
+/** Helper function that determines number of batches per epoch. */
+function getBatchesPerEpoch<T extends TensorContainer>(
+    dataset: Dataset<T>, args: ModelFitDatasetArgs<T>): number {
+  // Attempt to determine # of batches in an epoch.
+  let stepsPerEpoch: number;
+  if (args.batchesPerEpoch != null) {
+    stepsPerEpoch = args.batchesPerEpoch;
+  } else if (dataset.size != null && Number.isFinite(dataset.size)) {
+    stepsPerEpoch = dataset.size;
+  }
+  return stepsPerEpoch;
 }
 
 // Check if provided object is a Dataset object by checking it's .iterator

--- a/src/engine/training_dataset.ts
+++ b/src/engine/training_dataset.ts
@@ -320,7 +320,7 @@ export async function fitDataset<T extends TensorContainer>(
     const verbose = args.verbose == null ? 1 : args.verbose;
     const {callbackList, history} = configureCallbacks(
         callbacks, args.yieldEvery, verbose, args.epochs, null, null,
-        getBatchesPerEpoch(dataset, args),
+        geStepsPerEpoch(dataset, args),
         null,  // Batch size determined by the dataset itself.
         doValidation, callbackMetrics);
     callbackList.setModel(model);
@@ -433,8 +433,8 @@ export async function fitDataset<T extends TensorContainer>(
   }
 }
 
-/** Helper function that determines number of batches per epoch. */
-function getBatchesPerEpoch<T extends TensorContainer>(
+/** Helper function that determines number of batches (steps) per epoch. */
+function geStepsPerEpoch<T extends TensorContainer>(
     dataset: Dataset<T>, args: ModelFitDatasetArgs<T>): number {
   // Attempt to determine # of batches in an epoch.
   let stepsPerEpoch: number = null;

--- a/src/engine/training_dataset.ts
+++ b/src/engine/training_dataset.ts
@@ -320,7 +320,7 @@ export async function fitDataset<T extends TensorContainer>(
     const verbose = args.verbose == null ? 1 : args.verbose;
     const {callbackList, history} = configureCallbacks(
         callbacks, args.yieldEvery, verbose, args.epochs, null, null,
-        geStepsPerEpoch(dataset, args),
+        getStepsPerEpoch(dataset, args),
         null,  // Batch size determined by the dataset itself.
         doValidation, callbackMetrics);
     callbackList.setModel(model);
@@ -433,8 +433,8 @@ export async function fitDataset<T extends TensorContainer>(
   }
 }
 
-/** Helper function that determines number of batches (steps) per epoch. */
-function geStepsPerEpoch<T extends TensorContainer>(
+/** Helper function that determines number of steps (batches) per epoch. */
+function getStepsPerEpoch<T extends TensorContainer>(
     dataset: Dataset<T>, args: ModelFitDatasetArgs<T>): number {
   // Attempt to determine # of batches in an epoch.
   let stepsPerEpoch: number = null;

--- a/src/engine/training_dataset.ts
+++ b/src/engine/training_dataset.ts
@@ -440,7 +440,7 @@ function getBatchesPerEpoch<T extends TensorContainer>(
   let stepsPerEpoch: number = null;
   if (args.batchesPerEpoch != null) {
     stepsPerEpoch = args.batchesPerEpoch;
-  } else if (dataset.size != null && Number.isFinite(dataset.size)) {
+  } else if (Number.isFinite(dataset.size)) {
     stepsPerEpoch = dataset.size;
   }
   return stepsPerEpoch;

--- a/src/engine/training_dataset.ts
+++ b/src/engine/training_dataset.ts
@@ -437,7 +437,7 @@ export async function fitDataset<T extends TensorContainer>(
 function getBatchesPerEpoch<T extends TensorContainer>(
     dataset: Dataset<T>, args: ModelFitDatasetArgs<T>): number {
   // Attempt to determine # of batches in an epoch.
-  let stepsPerEpoch: number;
+  let stepsPerEpoch: number = null;
   if (args.batchesPerEpoch != null) {
     stepsPerEpoch = args.batchesPerEpoch;
   } else if (dataset.size != null && Number.isFinite(dataset.size)) {

--- a/src/engine/training_dataset_test.ts
+++ b/src/engine/training_dataset_test.ts
@@ -22,6 +22,7 @@ import {describeMathCPUAndGPU, expectTensorsClose} from '../utils/test_utils';
 
 import {FakeNumericDataset} from './dataset_fakes';
 import {TensorMap} from './dataset_stub';
+import {CustomCallback} from '../base_callbacks';
 
 function createDenseModel(): tfl.Model {
   const model = tfl.sequential();
@@ -504,6 +505,50 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
     // Assert that the the first log and the second logs do not overwrite each
     // other.
     expect(trainLogs[0].loss).not.toEqual(trainLogs[1].loss);
+  });
+
+  it('dataset.size != null feeds stepPerEpoch to callbacks', async () => {
+    const batchSize = 8;
+    const batchesPerEpoch = 3;
+    const xTensorsFunc =
+        () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
+          batchSize, 1
+        ])];
+    const yTensorsFunc =
+        () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
+          batchSize, 1
+        ])];
+    const dataset = new FakeNumericDataset({
+      xShape: [1],
+      yShape: [1],
+      batchSize,
+      numBatches: batchesPerEpoch,
+      xTensorsFunc,
+      yTensorsFunc
+    });
+
+    let recordedSteps: number;
+    class TestCallback extends CustomCallback {
+      constructor() {
+        super({
+          onTrainBegin: async (logs?: Logs) => {
+            recordedSteps = this.params.steps as number;
+          }
+        });
+      }
+    }
+
+    const model = createDenseModel();
+    model.compile(
+        {loss: 'meanSquaredError', optimizer: 'sgd', metrics: ['accuracy']});
+    const epochs = 1;
+    await model.fitDataset(dataset, {
+      epochs,
+      callbacks: new TestCallback()
+    });
+
+    expect(dataset.size).toEqual(batchesPerEpoch);
+    expect(recordedSteps).toEqual(batchesPerEpoch);
   });
 
   // Reference Python tf.keras code:


### PR DESCRIPTION
- This make it possible for callbacks such as ProgbarLogger to render the
  progress bar when `fitDataset()` is called without a `batchesPerEpoch`
  argument but with a `Dataset` object that has a finite `size` attribute.
- This is made possible by https://github.com/tensorflow/tfjs-data/pull/126 and
  https://github.com/tensorflow/tfjs-node/pull/194

Fixes: https://github.com/tensorflow/tfjs/issues/1101

FEATURE

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/439)
<!-- Reviewable:end -->
