### PR TITLE
Make layers compile in google

### DIFF
--- a/src/engine/dataset_stub.ts
+++ b/src/engine/dataset_stub.ts
@@ -9,8 +9,6 @@
  */
 
 import * as tfc from '@tensorflow/tfjs-core';
-// NOTE: It is necessary to import `TensorContainer` from dist currently,
-// because it is not exposed in the public API of tfjs-core.
 
 /**
  * Stub interfaces and classes for testing tf.Model.fitDataset().

--- a/src/engine/dataset_stub.ts
+++ b/src/engine/dataset_stub.ts
@@ -11,7 +11,6 @@
 import * as tfc from '@tensorflow/tfjs-core';
 // NOTE: It is necessary to import `TensorContainer` from dist currently,
 // because it is not exposed in the public API of tfjs-core.
-import {TensorContainer} from '@tensorflow/tfjs-core/dist/tensor_types';
 
 /**
  * Stub interfaces and classes for testing tf.Model.fitDataset().
@@ -24,7 +23,7 @@ export abstract class LazyIterator<T> {
   abstract async next(): Promise<IteratorResult<T>>;
 }
 
-export abstract class Dataset<T extends TensorContainer> {
+export abstract class Dataset<T> {
   abstract async iterator(): Promise<LazyIterator<T>>;
   size: number;
 }

--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -12,8 +12,6 @@
 
 import * as tfc from '@tensorflow/tfjs-core';
 import {io, ModelPredictConfig as ModelPredictArgs, Optimizer, Scalar, serialization, Tensor, Tensor1D, tensor1d, util} from '@tensorflow/tfjs-core';
-import {TensorContainer} from '@tensorflow/tfjs-core/dist/tensor_types';
-
 import {getScalar,} from '../backend/state';
 import * as K from '../backend/tfjs_backend';
 import {History, ModelLoggingVerbosity} from '../base_callbacks';
@@ -590,7 +588,7 @@ export class Model extends Container implements tfc.InferenceModel {
       lossFunctions = theLosses.map(l => losses.get(l));
     } else {
       const lossFunction = losses.get(args.loss);
-      this.outputs.map(layer => {
+      this.outputs.forEach(_ => {
         lossFunctions.push(lossFunction);
       });
     }
@@ -1415,8 +1413,8 @@ export class Model extends Container implements tfc.InferenceModel {
   /**
    * @doc {heading: 'Models', subheading: 'Classes', configParamIndices: [1]}
    */
-  async fitDataset<T extends TensorContainer>(
-      dataset: Dataset<T>, args: ModelFitDatasetArgs<T>): Promise<History> {
+  async fitDataset<T>(dataset: Dataset<T>, args: ModelFitDatasetArgs<T>):
+      Promise<History> {
     return fitDataset(this, dataset, args);
   }
 

--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -840,8 +840,8 @@ export class Model extends Container implements tfc.InferenceModel {
   /**
    * @doc {heading: 'Models', subheading: 'Classes', configParamIndices: [2]}
    */
-  async evaluateDataset<T extends TensorContainer>(
-      dataset: Dataset<T>,
+  async evaluateDataset(
+      dataset: Dataset<{}>,
       config: ModelEvaluateDatasetConfig): Promise<Scalar|Scalar[]> {
     this.makeTestFunction();
     return evaluateDataset(this, dataset, config);

--- a/src/models.ts
+++ b/src/models.ts
@@ -708,8 +708,8 @@ export class Sequential extends Model {
   /**
    * @doc {heading: 'Models', subheading: 'Classes', configParamIndices: [2]}
    */
-  async evaluateDataset<T extends TensorContainer>(
-      dataset: Dataset<T>,
+  async evaluateDataset(
+      dataset: Dataset<{}>,
       config: ModelEvaluateDatasetConfig): Promise<Scalar|Scalar[]> {
     if (!this.built) {
       throw new RuntimeError(

--- a/src/models.ts
+++ b/src/models.ts
@@ -11,8 +11,6 @@
 /* Original source keras/models.py */
 
 import {io, Scalar, serialization, Tensor, util} from '@tensorflow/tfjs-core';
-import {TensorContainer} from '@tensorflow/tfjs-core/dist/tensor_types';
-
 import {getUid} from './backend/state';
 import {History} from './base_callbacks';
 import {Dataset} from './engine/dataset_stub';
@@ -852,8 +850,8 @@ export class Sequential extends Model {
   /**
    * @doc {heading: 'Models', subheading: 'Classes', configParamIndices: [1]}
    */
-  async fitDataset<T extends TensorContainer>(
-      dataset: Dataset<T>, args: ModelFitDatasetArgs<T>): Promise<History> {
+  async fitDataset<T>(dataset: Dataset<T>, args: ModelFitDatasetArgs<T>):
+      Promise<History> {
     if (!this.built) {
       throw new RuntimeError(
           'The model needs to be compiled before ' +

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -325,7 +325,7 @@ export function batchGetValue(xs: LayerVariable[]): Tensor[] {
  */
 export function batchSetValue(
     variablesAndValues: Array<[LayerVariable, Tensor]>): void {
-  variablesAndValues.map((variableAndValue) => {
+  variablesAndValues.forEach(variableAndValue => {
     const variable: LayerVariable = variableAndValue[0];
     variable.write(variableAndValue[1]);
   });


### PR DESCRIPTION
Fix compiler errors when porting layers internally.

- Replace .map() with .forEach() where the result is not used.
- Remove imports from non-public tfjs-core API. In this case the type `<T extends TensorContainer>` got relaxed to just `<T>`, which has no consequence for the user. The constraint `<T extends TensorContainer>` is still imposed upon dataset creation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/440)
<!-- Reviewable:end -->
