### PR TITLE
Fix namespace of tf.models.modelFromJSON() in documentation

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -59,7 +59,7 @@ import {getExactlyOneShape} from './utils/types_utils';
  * @returns A TensorFlow.js Layers `tf.Model` instance (uncompiled).
  */
 /**
- * @doc {heading: 'Models',subheading: 'Loading'}
+ * @doc {heading: 'Models', subheading: 'Loading', namespace: 'models'}
  */
 export async function modelFromJSON(
     modelAndWeightsConfig: ModelAndWeightsConfig|PyJsonDict,


### PR DESCRIPTION
DOC

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/445)
<!-- Reviewable:end -->
