### PR TITLE
Cherry pick to 0.10.x: Update to 0.10.1 and core to 0.15.1. Use tfc.batchNorm instead of tfc.batchNormalization

### DIFF
--- a/integration_tests/benchmarks/package.json
+++ b/integration_tests/benchmarks/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs-core": "^0.14.5",
+    "@tensorflow/tfjs-core": "^0.15.1",
     "@tensorflow/tfjs-layers": "../../dist"
   },
   "scripts": {

--- a/integration_tests/benchmarks/yarn.lock
+++ b/integration_tests/benchmarks/yarn.lock
@@ -642,10 +642,10 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@tensorflow/tfjs-core@^0.14.5":
-  version "0.14.5"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.14.5.tgz#17c3beeec31c4cd92b0f79a5ef30c4975a11e408"
-  integrity sha512-CSUgKuC17J1Ylr1s6iD1k2/tJr9lD16sUEjtzJbtiuTYCELOwujGK/1htunA7o3BwLuU7aqEI92MoKElEKa7qA==
+"@tensorflow/tfjs-core@^0.15.1":
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.15.1.tgz#6196d2a9630236c77d71e036f05d2d6eadc2a25a"
+  integrity sha512-csZ1GvRiwy0PJcJXz6Xt9W+ZZHf0JI+nyJPtJU4QSVJVIFRCCAWqn2SsYwNt2Bp2rw2ZHhfuStz3veFUgaDSMA==
   dependencies:
     "@types/seedrandom" "2.4.27"
     "@types/webgl-ext" "0.0.30"

--- a/integration_tests/tfjs2keras/package.json
+++ b/integration_tests/tfjs2keras/package.json
@@ -4,7 +4,7 @@
   "description": "Testing sending models from tfjs-layers to Keras",
   "private": false,
   "devDependencies": {
-    "@tensorflow/tfjs-core": "0.14.5",
+    "@tensorflow/tfjs-core": "0.15.1",
     "@tensorflow/tfjs-layers": "*",
     "@tensorflow/tfjs-node": "0.2.3",
     "clang-format": "~1.2.2"

--- a/integration_tests/tfjs2keras/yarn.lock
+++ b/integration_tests/tfjs2keras/yarn.lock
@@ -73,6 +73,16 @@
     "@types/webgl2" "0.0.4"
     seedrandom "2.4.3"
 
+"@tensorflow/tfjs-core@0.15.1":
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.15.1.tgz#6196d2a9630236c77d71e036f05d2d6eadc2a25a"
+  integrity sha512-csZ1GvRiwy0PJcJXz6Xt9W+ZZHf0JI+nyJPtJU4QSVJVIFRCCAWqn2SsYwNt2Bp2rw2ZHhfuStz3veFUgaDSMA==
+  dependencies:
+    "@types/seedrandom" "2.4.27"
+    "@types/webgl-ext" "0.0.30"
+    "@types/webgl2" "0.0.4"
+    seedrandom "2.4.3"
+
 "@tensorflow/tfjs-data@0.1.7":
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-data/-/tfjs-data-0.1.7.tgz#8a4e43313b3d63cdfab719c0c1c47ced2ef321e3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensorflow/tfjs-layers",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "TensorFlow layers API in JavaScript",
   "private": false,
   "main": "dist/index.js",
@@ -10,7 +10,7 @@
   "jsdelivr": "dist/tf-layers.min.js",
   "unpkg": "dist/tf-layers.min.js",
   "devDependencies": {
-    "@tensorflow/tfjs-core": "0.15.0",
+    "@tensorflow/tfjs-core": "0.15.1",
     "@types/jasmine": "~2.5.53",
     "clang-format": "~1.2.2",
     "http-server": "~0.10.0",
@@ -45,6 +45,6 @@
     "lint": "tslint -p . -t verbose"
   },
   "peerDependencies": {
-    "@tensorflow/tfjs-core": "0.15.0"
+    "@tensorflow/tfjs-core": "0.15.1"
   }
 }

--- a/src/layers/normalization.ts
+++ b/src/layers/normalization.ts
@@ -48,21 +48,21 @@ export function batchNormalization(
     epsilon = 1e-3): Tensor {
   let out: Tensor;
   if (x.rank === 2) {
-    out = tfc.batchNormalization2d(
+    out = tfc.batchNorm2d(
         x as Tensor2D, mean as Tensor2D | Tensor1D,
-        variance as Tensor2D | Tensor1D, epsilon, gamma as Tensor2D | Tensor1D,
-        beta as Tensor2D | Tensor1D);
+        variance as Tensor2D | Tensor1D, beta as Tensor2D | Tensor1D,
+        gamma as Tensor2D | Tensor1D, epsilon);
   } else if (x.rank === 3) {
     // TODO(cais): Check rank; give proper error message.
-    out = tfc.batchNormalization3d(
+    out = tfc.batchNorm3d(
         x as Tensor3D, mean as Tensor3D | Tensor1D,
-        variance as Tensor3D | Tensor1D, epsilon, gamma as Tensor3D | Tensor1D,
-        beta as Tensor3D | Tensor1D);
+        variance as Tensor3D | Tensor1D, beta as Tensor3D | Tensor1D,
+        gamma as Tensor3D | Tensor1D, epsilon);
   } else if (x.rank === 4) {
-    out = tfc.batchNormalization4d(
+    out = tfc.batchNorm4d(
         x as Tensor4D, mean as Tensor4D | Tensor1D,
-        variance as Tensor4D | Tensor1D, epsilon, gamma as Tensor4D | Tensor1D,
-        beta as Tensor4D | Tensor1D);
+        variance as Tensor4D | Tensor1D, beta as Tensor4D | Tensor1D,
+        gamma as Tensor4D | Tensor1D, epsilon);
   } else {
     throw new NotImplementedError(
         `batchNormalization is not implemented for array of rank ${x.rank} ` +

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,5 +1,5 @@
 /** @license See the LICENSE file. */
 
 // This code is auto-generated, do not modify this file!
-const version = '0.10.0';
+const version = '0.10.1';
 export {version};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@tensorflow/tfjs-core@0.15.0":
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.15.0.tgz#c85f1141e42ce5103ae73fdf170b2d4736038533"
-  integrity sha512-YITCsLeF8lqFQdepdv+a0wRQ4sVtg31cvqRzsuQBeQHyR04Xb3CH0kgKcwTj8FUXn+IlDsjE7m+v8Gier7YfuA==
+"@tensorflow/tfjs-core@0.15.1":
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.15.1.tgz#6196d2a9630236c77d71e036f05d2d6eadc2a25a"
+  integrity sha512-csZ1GvRiwy0PJcJXz6Xt9W+ZZHf0JI+nyJPtJU4QSVJVIFRCCAWqn2SsYwNt2Bp2rw2ZHhfuStz3veFUgaDSMA==
   dependencies:
     "@types/seedrandom" "2.4.27"
     "@types/webgl-ext" "0.0.30"


### PR DESCRIPTION
This is a partial cherry pick of https://github.com/tensorflow/tfjs-layers/pull/453

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/454)
<!-- Reviewable:end -->
