### PR TITLE
Make dataset_fakes support multi-input with different shapes

### DIFF
--- a/src/engine/dataset_fakes.ts
+++ b/src/engine/dataset_fakes.ts
@@ -138,20 +138,25 @@ class FakeNumericIterator extends
 
       let xs: tfc.Tensor|{[name: string]: tfc.Tensor};
       if (Array.isArray(this.xTensorValues)) {
+        // Get preset xs tensors for single-input models.
         xs = (this.xTensorValues as tfc.Tensor[])[index];
         tfc.util.assert(
             tfc.util.arraysEqual(xs.shape, this.xBatchShape as Shape),
             `Shape mismatch: expected: ${JSON.stringify(this.xBatchShape)}; ` +
                 `actual: ${JSON.stringify(xs.shape)}`);
       } else {
+        // Get preset xs tensors for multi-input models.
         xs = {};
+        this.xBatchShape = this.xBatchShape as {[name: string]: Shape};
         for (const key in this.xTensorValues) {
           xs[key] = this.xTensorValues[key][index];
           tfc.util.assert(
-              tfc.util.arraysEqual(xs[key].shape, this.xBatchShape as Shape),
+              tfc.util.arraysEqual(xs[key].shape,
+                  this.xBatchShape[key] as Shape),
               `Shape mismatch: expected: ${
-                  JSON.stringify(this.xBatchShape)}; ` +
-                  `actual: ${JSON.stringify(xs.shape)}`);
+                JSON.stringify(this.xBatchShape)}; ` +
+              `actual: ${JSON.stringify(xs.shape)}`
+          );
         }
       }
 

--- a/src/engine/dataset_fakes_test.ts
+++ b/src/engine/dataset_fakes_test.ts
@@ -8,6 +8,7 @@
  * =============================================================================
  */
 
+import * as tfc from '@tensorflow/tfjs-core';
 import {Tensor} from '@tensorflow/tfjs-core';
 
 import {describeMathCPUAndGPU} from '../utils/test_utils';
@@ -82,6 +83,153 @@ describeMathCPUAndGPU('FakeNumericDataset', () => {
         expect(result.done).toEqual(true);
       }
     }
+  });
+
+  it('Multiple 1D features, 1D targets, with tensors function', async () => {
+
+    const batchSize = 8;
+
+    // Training data.
+    // Feature with different shapes
+    const xTensorsFunction = () => {
+      const output: {[name: string]: tfc.Tensor[]} = {};
+      output['input1'] = [
+        tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
+        tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
+        tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])
+      ];
+      output['input2'] = [
+        tfc.ones([batchSize, 2]), tfc.ones([batchSize, 2]),
+        tfc.ones([batchSize, 2]), tfc.ones([batchSize, 2]),
+        tfc.ones([batchSize, 2]), tfc.ones([batchSize, 2])
+      ];
+      return output;
+    };
+    const yTensorsFunction = () => [
+      tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
+      tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
+      tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])
+    ];
+
+    const xShapes: {[name:string]: number[]} = {};
+    xShapes['input1'] = [1];
+    xShapes['input2'] = [2];
+    const dataset = new FakeNumericDataset({
+      xShape: xShapes,
+      yShape: [1],
+      batchSize: 8,
+      numBatches: 6,
+      xTensorsFunc: xTensorsFunction,
+      yTensorsFunc: yTensorsFunction
+    });
+
+    for (let k = 0; k < 2; ++k) {
+      // Run twice to make sure that calling iteartor() multiple times works.
+
+      const numTensors0 = tfc.memory().numTensors;
+      const iterator = await dataset.iterator();
+      for (let i = 0; i < 6; ++i) {
+        const result = await iterator.next();
+        expect(result.value.length).toEqual(2);
+        const xs = result.value[0] as TensorMap;
+        expect(xs['input1'].shape).toEqual([8, 1]);
+        const xsInput1Data = (xs['input1'] as Tensor).dataSync();
+        expect(xsInput1Data[0]).toEqual(1);
+        expect(xs['input2'].shape).toEqual([8, 2]);
+        const xsInput2Data = (xs['input2'] as Tensor).dataSync();
+        expect(xsInput2Data[0]).toEqual(1);
+        expect(xsInput2Data[1]).toEqual(1);
+        const ys = result.value[1] as Tensor;
+        expect(ys.shape).toEqual([8, 1]);
+        const ysData = ys.dataSync();
+        expect(ysData[0]).toEqual(1);
+        expect(result.done).toEqual(false);
+        tfc.dispose(result.value);
+      }
+      for (let i = 0; i < 3; ++i) {
+        const result = await iterator.next();
+        expect(result.value).toBeNull();
+        expect(result.done).toEqual(true);
+      }
+
+      // Make sure no memory leak
+      const numTensors1 = tfc.memory().numTensors;
+      expect(numTensors1).toEqual(numTensors0);
+    }
+
+  });
+
+  it('1D features, multiple 1D targets, with tensors function', async () => {
+
+    const batchSize = 8;
+
+    // Training data.
+    const xTensorsFunction = () => [
+      tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
+      tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
+      tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])
+    ];
+    // Target with different shapes
+    const yTensorsFunction = () => {
+      const output: {[name: string]: tfc.Tensor[]} = {};
+      output['output1'] = [
+        tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
+        tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
+        tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])
+      ];
+      output['output2'] = [
+        tfc.ones([batchSize, 2]), tfc.ones([batchSize, 2]),
+        tfc.ones([batchSize, 2]), tfc.ones([batchSize, 2]),
+        tfc.ones([batchSize, 2]), tfc.ones([batchSize, 2])
+      ];
+      return output;
+    };
+
+    const yShapes: {[name:string]: number[]} = {};
+    yShapes['output1'] = [1];
+    yShapes['output2'] = [2];
+    const dataset = new FakeNumericDataset({
+      xShape: [1],
+      yShape: yShapes,
+      batchSize: 8,
+      numBatches: 6,
+      xTensorsFunc: xTensorsFunction,
+      yTensorsFunc: yTensorsFunction
+    });
+
+    for (let k = 0; k < 2; ++k) {
+      // Run twice to make sure that calling iteartor() multiple times works.
+
+      const numTensors0 = tfc.memory().numTensors;
+      const iterator = await dataset.iterator();
+      for (let i = 0; i < 6; ++i) {
+        const result = await iterator.next();
+        expect(result.value.length).toEqual(2);
+        const xs = result.value[0] as Tensor;
+        expect(xs.shape).toEqual([8, 1]);
+        const xsData = xs.dataSync();
+        expect(xsData[0]).toEqual(1);
+        const ys = result.value[1] as TensorMap;
+        expect(ys['output1'].shape).toEqual([8, 1]);
+        const ysOutput1Data = (ys['output1'] as Tensor).dataSync();
+        expect(ysOutput1Data[0]).toEqual(1);
+        expect(ys['output2'].shape).toEqual([8, 2]);
+        const ysOutput2Data = (ys['output2'] as Tensor).dataSync();
+        expect(ysOutput2Data[0]).toEqual(1);
+        expect(ysOutput2Data[1]).toEqual(1);
+        tfc.dispose(result.value);
+      }
+      for (let i = 0; i < 3; ++i) {
+        const result = await iterator.next();
+        expect(result.value).toBeNull();
+        expect(result.done).toEqual(true);
+      }
+
+      // Make sure no memory leak
+      const numTensors1 = tfc.memory().numTensors;
+      expect(numTensors1).toEqual(numTensors0);
+    }
+
   });
 
   it('Invalid batchSize leads to Error', () => {

--- a/src/engine/training_dataset_test.ts
+++ b/src/engine/training_dataset_test.ts
@@ -1207,8 +1207,12 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
            [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
             tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
             tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])];
+
+       const xShape: {[name:string]: number[]} = {};
+       xShape[model.inputNames[0]] = [1];
+       xShape[model.inputNames[1]] = [1];
        const dataset = new FakeNumericDataset({
-         xShape: [1],
+         xShape,
          yShape: [1],
          batchSize,
          numBatches: batchesPerEpoch * epochs,
@@ -1273,8 +1277,12 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
            () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
              batchSize, 1
            ])];
+
+       const xShape: {[name:string]: number[]} = {};
+       xShape[model.inputNames[0]] = [1];
+       xShape[model.inputNames[1]] = [1];
        const dataset = new FakeNumericDataset({
-         xShape: [1],
+         xShape,
          yShape: [1],
          batchSize,
          numBatches: batchesPerEpoch,
@@ -1388,8 +1396,12 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
            [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
             tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
             tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])];
+
+       const xShape: {[name:string]: number[]} = {};
+       xShape[model.inputNames[0]] = [1];
+       xShape[model.inputNames[1]] = [1];
        const dataset = new FakeNumericDataset({
-         xShape: [1],
+         xShape,
          yShape: [1],
          batchSize,
          numBatches: batchesPerEpoch * epochs,
@@ -1479,8 +1491,12 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
            () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
              batchSize, 1
            ])];
+
+       const xShape: {[name:string]: number[]} = {};
+       xShape[model.inputNames[0]] = [1];
+       xShape[model.inputNames[1]] = [1];
        const dataset = new FakeNumericDataset({
-         xShape: [1],
+         xShape,
          yShape: [1],
          batchSize,
          numBatches: batchesPerEpoch,
@@ -1577,7 +1593,7 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
   // print(model.get_weights()[0])
   // print(model.get_weights()[1])
   // ```
-  it('2 input, 1 output, 1 metric, tensor array validation, ' +
+  it('2 inputs, 1 output, 1 metric, tensor array validation, ' +
          'with batchesPerEpoch',
      async () => {
        // Create a functional model with 2 inputs.
@@ -1617,8 +1633,12 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
            [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
             tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
             tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])];
+
+       const xShape: {[name:string]: number[]} = {};
+       xShape[model.inputNames[0]] = [1];
+       xShape[model.inputNames[1]] = [1];
        const dataset = new FakeNumericDataset({
-         xShape: [1],
+         xShape,
          yShape: [1],
          batchSize,
          numBatches: batchesPerEpoch * epochs,
@@ -1671,7 +1691,7 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
        expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.103377]));
      });
 
-  it('2 input, 1 output, 1 metric, tensor array validation, ' +
+  it('2 inputs, 1 output, 1 metric, tensor array validation, ' +
          'no batchesPerEpoch',
      async () => {
        // Create a functional model with 2 inputs.
@@ -1709,8 +1729,12 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
            () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
              batchSize, 1
            ])];
+
+       const xShape: {[name:string]: number[]} = {};
+       xShape[model.inputNames[0]] = [1];
+       xShape[model.inputNames[1]] = [1];
        const dataset = new FakeNumericDataset({
-         xShape: [1],
+         xShape,
          yShape: [1],
          batchSize,
          numBatches: batchesPerEpoch,
@@ -1761,7 +1785,7 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
        expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.103377]));
      });
 
-  it('2 input, 1 missing input in dataset, with batchesPerEpoch', async () => {
+  it('2 inputs, 1 missing input in dataset, with batchesPerEpoch', async () => {
     // Create a functional model with 2 inputs.
     const input1 = tfl.layers.input({shape: [1]});
     const input2 = tfl.layers.input({shape: [1]});
@@ -1792,8 +1816,12 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
         [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
          tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]),
          tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1])];
+
+    const xShape: {[name:string]: number[]} = {};
+    xShape[model.inputNames[0]] = [1];
+    xShape[model.inputNames[1]] = [1];
     const dataset = new FakeNumericDataset({
-      xShape: [1],
+      xShape,
       yShape: [1],
       batchSize,
       numBatches: batchesPerEpoch * epochs,
@@ -1813,7 +1841,7 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
             `input key '${input2.name}'.`);
   });
 
-  it('2 input, 1 missing input in dataset, no batchesPerEpoch', async () => {
+  it('2 inputs, 1 missing input in dataset, no batchesPerEpoch', async () => {
     // Create a functional model with 2 inputs.
     const input1 = tfl.layers.input({shape: [1]});
     const input2 = tfl.layers.input({shape: [1]});
@@ -1843,8 +1871,12 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
         () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
           batchSize, 1
         ])];
+
+    const xShape: {[name:string]: number[]} = {};
+    xShape[model.inputNames[0]] = [1];
+    xShape[model.inputNames[1]] = [1];
     const dataset = new FakeNumericDataset({
-      xShape: [1],
+      xShape,
       yShape: [1],
       batchSize,
       numBatches: batchesPerEpoch,
@@ -2605,11 +2637,14 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
       return output;
     };
 
+    const xShape: {[name:string]: number[]} = {};
+    xShape[model.inputNames[0]] = [1];
+    xShape[model.inputNames[1]] = [1];
     const yShape: {[name:string]: number[]} = {};
     yShape[model.outputNames[0]] = [1];
     yShape[model.outputNames[1]] = [1];
     const dataset = new FakeNumericDataset({
-      xShape: [1],
+      xShape,
       yShape,
       batchSize,
       numBatches: batchesPerEpoch * epochs,
@@ -2710,11 +2745,14 @@ describeMathCPUAndGPU('Model.fitDataset', () => {
       return output;
     };
 
+    const xShape: {[name:string]: number[]} = {};
+    xShape[model.inputNames[0]] = [1];
+    xShape[model.inputNames[1]] = [1];
     const yShape: {[name:string]: number[]} = {};
     yShape[model.outputNames[0]] = [1];
     yShape[model.outputNames[1]] = [1];
     const dataset = new FakeNumericDataset({
-      xShape: [1],
+      xShape,
       yShape,
       batchSize,
       numBatches: batchesPerEpoch,
@@ -3287,8 +3325,12 @@ describeMathCPUAndGPU('Model.evaluateDataset', () => {
            () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
              batchSize, 1
            ])];
+
+       const xShape: {[name:string]: number[]} = {};
+       xShape[model.inputNames[0]] = [1];
+       xShape[model.inputNames[1]] = [1];
        const dataset = new FakeNumericDataset({
-         xShape: [1],
+         xShape,
          yShape: [1],
          batchSize,
          numBatches: batches,
@@ -3348,8 +3390,12 @@ describeMathCPUAndGPU('Model.evaluateDataset', () => {
            () => [tfc.ones([batchSize, 1]), tfc.ones([batchSize, 1]), tfc.ones([
              batchSize, 1
            ])];
+
+       const xShape: {[name:string]: number[]} = {};
+       xShape[model.inputNames[0]] = [1];
+       xShape[model.inputNames[1]] = [1];
        const dataset = new FakeNumericDataset({
-         xShape: [1],
+         xShape,
          yShape: [1],
          batchSize,
          numBatches: batches,


### PR DESCRIPTION
FEATURE

This PR include three parts:

* Make `dataset_fake` work with well with the case: configure `tensor function` and different shapes for inputs. It seems that previously when providing tensor function, `dataset_fake` can only accept multiple input shapes with the same shape.
```javascript
const xShapes: {[name:string]: number[]} = {};
xShapes['input1'] = [1];
xShapes['input2'] = [2];
const dataset = new FakeNumericDataset({
  // multiple inputs with different shapes
  xShape: xShapes,
  yShape: [1],
  batchSize: 8,
  numBatches: 6,
  // tensor function for xs and ys
  xTensorsFunc: xTensorsFunction,
  yTensorsFunc: yTensorsFunction
});
```

* Change usage of `dataset_fake` in `training_dataset_test` to work well with this feature.

* Add two relative test cases

| Input number | input shape | output number | output shape | tensor function |
| ----------- | ----------- | ----------- | ----------- | ----------- | 
| 2 | [1], [2] | 1 | [1] | with |
| 1 | [1] | 2 | [1], [2] | with |

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/456)
<!-- Reviewable:end -->
