### PR TITLE
cherry-pick to 0.10.x: Add tf.loadLayersModel(); deprecating tf.loadModel()

### DIFF
--- a/src/exports.ts
+++ b/src/exports.ts
@@ -147,7 +147,104 @@ export function sequential(config?: SequentialArgs): Sequential {
  */
 export function loadModel(
     pathOrIOHandler: string|io.IOHandler, strict = true): Promise<Model> {
-  return loadModelInternal(pathOrIOHandler, strict);
+  return loadModelInternal(pathOrIOHandler, {strict});
+}
+
+/**
+ * Load a model composed of Layer objects, including its topology and optionally
+ * weights. See the Tutorial named "How to import a Keras Model" for usage
+ * examples.
+ *
+ * This method is applicable to:
+ *
+ * 1. Models created with the `tf.layers.*`, `tf.sequential`, and `tf.model`
+ *    APIs of TensorFlow.js and later saved with the `tf.Model.save` method.
+ * 2. Models converted from Keras or TensorFlow tf.keras using
+ *    the [tensorflowjs_converter](https://github.com/tensorflow/tfjs-converter)
+ *
+ * This mode is *not* applicable to TensorFlow `SavedModel`s or their converted
+ * forms. For those models, use `tf.loadGraphModel`.
+ *
+ * Example 1. Load a model from an HTTP server.
+ *
+ * ```js
+ * const model = await tf.loadLayersModel(
+ *     'https://storage.googleapis.com/tfjs-models/tfjs/iris_v1/model.json');
+ * model.summary();
+ * ```
+ *
+ * Example 2: Save `model`'s topology and weights to browser [local
+ * storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage);
+ * then load it back.
+ *
+ * ```js
+ * const model = tf.sequential(
+ *     {layers: [tf.layers.dense({units: 1, inputShape: [3]})]});
+ * console.log('Prediction from original model:');
+ * model.predict(tf.ones([1, 3])).print();
+ *
+ * const saveResults = await model.save('localstorage://my-model-1');
+ *
+ * const loadedModel = await tf.loadLayersModel('localstorage://my-model-1');
+ * console.log('Prediction from loaded model:');
+ * loadedModel.predict(tf.ones([1, 3])).print();
+ * ```
+ *
+ * Example 3. Saving `model`'s topology and weights to browser
+ * [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API);
+ * then load it back.
+ *
+ * ```js
+ * const model = tf.sequential(
+ *     {layers: [tf.layers.dense({units: 1, inputShape: [3]})]});
+ * console.log('Prediction from original model:');
+ * model.predict(tf.ones([1, 3])).print();
+ *
+ * const saveResults = await model.save('indexeddb://my-model-1');
+ *
+ * const loadedModel = await tf.loadLayersModel('indexeddb://my-model-1');
+ * console.log('Prediction from loaded model:');
+ * loadedModel.predict(tf.ones([1, 3])).print();
+ * ```
+ *
+ * Example 4. Load a model from user-selected files from HTML
+ * [file input
+ * elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file).
+ *
+ * ```js
+ * // Note: this code snippet will not work without the HTML elements in the
+ * //   page
+ * const jsonUpload = document.getElementById('json-upload');
+ * const weightsUpload = document.getElementById('weights-upload');
+ *
+ * const model = await tf.loadLayersModel(
+ *     tf.io.browserFiles([jsonUpload.files[0], weightsUpload.files[0]]));
+ * ```
+ *
+ * @param pathOrIOHandler Can be either of the two formats
+ *   1. A string path to the `ModelAndWeightsConfig` JSON describing
+ *      the model in the canonical TensorFlow.js format. For file://
+ *      (tfjs-node-only), http:// and https:// schemas, the path can be
+ *      either absolute or relative.
+ *   2. An `tf.io.IOHandler` object that loads model artifacts with its `load`
+ *      method.
+ * @param options Optional configuration arguments for the model loading,
+ *   including:
+ *   - `strict`: Require that the provided weights exactly match those required
+ *     by the layers.  Default true.  Passing false means that both extra
+ *     weights and missing weights will be silently ignored.
+ *   - ｀onProgress｀: A function of the signature `(fraction: number) => void',
+ *     that can be used as the progress callback for the model loading.
+ * @returns A `Promise` of `tf.Model`, with the topology and weights loaded.
+ */
+/** @doc {heading: 'Models', subheading: 'Loading'} */
+export function loadLayersModel(
+    pathOrIOHandler: string|io.IOHandler, options?: io.LoadOptions):
+    Promise<Model> {
+  if (options == null) {
+    options = {};
+  }
+  return loadModelInternal(pathOrIOHandler, options);
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ export {InputSpec, SymbolicTensor} from './engine/topology';
 export {Model, ModelCompileArgs, ModelEvaluateArgs} from './engine/training';
 export {ModelFitDatasetArgs} from './engine/training_dataset';
 export {ModelFitArgs} from './engine/training_tensors';
-export {input, loadModel, model, registerCallbackConstructor, sequential} from './exports';
+export {input, loadLayersModel, loadModel, model, registerCallbackConstructor, sequential} from './exports';
 export {Shape} from './keras_format/common';
 // tslint:disable-next-line:max-line-length
 export {GRUCellLayerArgs, GRULayerArgs, LSTMCellLayerArgs, LSTMLayerArgs, RNN, RNNLayerArgs, SimpleRNNCellLayerArgs, SimpleRNNLayerArgs} from './layers/recurrent';

--- a/src/models_test.ts
+++ b/src/models_test.ts
@@ -544,7 +544,7 @@ describeMathCPU('modelFromJSON', () => {
   });
 });
 
-describeMathCPU('loadModel from URL', () => {
+describeMathCPU('loadLayersModel from URL', () => {
   const setupFakeWeightFiles =
       (fileBufferMap:
            {[filename: string]: Float32Array|Int32Array|ArrayBuffer}) => {
@@ -663,6 +663,65 @@ describeMathCPU('loadModel from URL', () => {
     expect(weightValues.length).toEqual(2);
     expectTensorsClose(weightValues[0], ones([32, 32]));
     expectTensorsClose(weightValues[1], zeros([32]));
+  });
+
+  it('loadLayersModel: with onProgress callback', async () => {
+    const modelTopology =
+        JSON.parse(JSON.stringify(fakeSequentialModel)).modelTopology;
+    const weightsManifest: io.WeightsManifestConfig = [
+      {
+        'paths': ['weight_0'],
+        'weights':
+            [{'name': `dense_6/kernel`, 'dtype': 'float32', 'shape': [32, 32]}],
+      },
+      {
+        'paths': ['weight_1'],
+        'weights':
+            [{'name': `dense_6/bias`, 'dtype': 'float32', 'shape': [32]}],
+      }
+    ];
+
+    spyOn(window, 'fetch').and.callFake((path: string) => {
+      return new Promise((resolve, reject) => {
+        if (path === 'model/model.json') {
+          resolve(new Response(
+              JSON.stringify({
+                modelTopology,
+                weightsManifest,
+              }),
+              {'headers': {'Content-Type': JSON_TYPE}}));
+        } else if (path === 'model/weight_0') {
+          resolve(new Response(
+              ones([32, 32], 'float32').dataSync() as Float32Array,
+              {'headers': {'Content-Type': OCTET_STREAM_TYPE}}));
+        } else if (path === 'model/weight_1') {
+          resolve(new Response(
+              zeros([32], 'float32').dataSync() as Float32Array,
+              {'headers': {'Content-Type': OCTET_STREAM_TYPE}}));
+        } else {
+          reject(new Error(`Invalid path: ${path}`));
+        }
+      });
+    });
+
+    const progressFractions: number[] = [];
+    const model = await tfl.loadLayersModel('model/model.json', {
+      onProgress: (fraction: number) => {
+        progressFractions.push(fraction);
+      }
+    });
+    expect(model.layers.length).toEqual(2);
+    expect(model.inputs.length).toEqual(1);
+    expect(model.inputs[0].shape).toEqual([null, 32]);
+    expect(model.outputs.length).toEqual(1);
+    expect(model.outputs[0].shape).toEqual([null, 32]);
+    const weightValues = model.getWeights();
+    expect(weightValues.length).toEqual(2);
+    expectTensorsClose(weightValues[0], ones([32, 32]));
+    expectTensorsClose(weightValues[1], zeros([32]));
+    // There are three files: a JSON file and two weight files. So the progress
+    // callback should have been called four, times.
+    expect(progressFractions).toEqual([0.25, 0.5, 0.75, 1]);
   });
 
   it('load topology and weights from implicit relative http path: HDF5 format',
@@ -1054,7 +1113,7 @@ describeMathCPU('loadModel from URL', () => {
   });
 });
 
-describeMathCPU('loadModel from IOHandler', () => {
+describeMathCPU('loadLayersModel from IOHandler', () => {
   // The model topology JSON can be obtained with the following Python Keras
   // code:
   //


### PR DESCRIPTION
Cherry pick of https://github.com/tensorflow/tfjs-layers/pull/459
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/460)
<!-- Reviewable:end -->
