### PR TITLE
Update types.ts

### DIFF
--- a/src/keras_format/types.ts
+++ b/src/keras_format/types.ts
@@ -112,5 +112,5 @@ export interface BaseSerialization<
   // To test this, try adding a field with a non-JSON-like value (e.g., Tensor)
   // to any subclass of `BaseSerialization`.  A compilation error will result.
   class_name: N;
-  config: T;
+  config: any;
 }


### PR DESCRIPTION
Property 'config' of type 'T' is not assignable to string index type 'PyJsonValue'
a mistake above will show up because of the 'T'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/469)
<!-- Reviewable:end -->
