### PR TITLE
Deprecate the use of node isArray method.

### DIFF
--- a/src/engine/training_dataset.ts
+++ b/src/engine/training_dataset.ts
@@ -13,7 +13,6 @@
  */
 
 import * as tfc from '@tensorflow/tfjs-core';
-import {isArray} from 'util';
 
 import {getScalar} from '../backend/state';
 import {BaseCallback, configureCallbacks, CustomCallbackArgs, History, ModelLoggingVerbosity, standardizeCallbacks, YieldEveryOptions} from '../base_callbacks';
@@ -255,7 +254,7 @@ function flattenTensorOrArrayOrMap(
     inputOrOutput: string, names: string[], values: TensorOrArrayOrMap) {
   if (values instanceof tfc.Tensor) {
     return [values];
-  } else if (isArray(values)) {
+  } else if (Array.isArray(values)) {
     tfc.util.assert(
         values.length === names.length,
         `Received an array of ${values.length} Tensors, but expected ${


### PR DESCRIPTION
This will reduce the number of dependencies on this file.
Also util.isArray is being deprecated. 
Link: https://nodejs.org/api/util.html#util_util_isarray_object

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/473)
<!-- Reviewable:end -->
