### PR TITLE
engine/input_layer: fix ValueError message spacing

### DIFF
--- a/src/engine/input_layer.ts
+++ b/src/engine/input_layer.ts
@@ -113,7 +113,7 @@ export class InputLayer extends Layer {
       // TODO(michaelterry): Backport to PyKeras
       if (args.batchSize != null) {
         throw new ValueError(
-            'Cannot specify batchSize if batchInputShape is' +
+            'Cannot specify batchSize if batchInputShape is ' +
             'specified when creating an InputLayer.');
       }
     }


### PR DESCRIPTION
This adds a missing space between words to the error message.

Basically,
```diff
- Cannot specify batchSize if batchInputShape isspecified when creating an InputLayer.
+ Cannot specify batchSize if batchInputShape is specified when creating an InputLayer.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/474)
<!-- Reviewable:end -->
