### PR TITLE
Switch all asserts to take a function that returns a string.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,7 @@
   "clang-format.style": "Google",
   "files.insertFinalNewline": true,
   "editor.detectIndentation": false,
+  "editor.rulers": [80],
   "editor.wrappingIndent": "none",
   "typescript.tsdk": "node_modules/typescript/lib",
   "typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": false,

--- a/src/base_callbacks.ts
+++ b/src/base_callbacks.ts
@@ -578,7 +578,7 @@ export class CallbackConstructorRegistry {
       verbosityLevel: number, callbackConstructor: BaseCallbackConstructor) {
     util.assert(
         verbosityLevel >= 0 && Number.isInteger(verbosityLevel),
-        `Verbosity level is expected to be an integer >= 0, ` +
+        () => `Verbosity level is expected to be an integer >= 0, ` +
             `but got ${verbosityLevel}`);
     CallbackConstructorRegistry.checkForDuplicate(callbackConstructor);
     if (CallbackConstructorRegistry.constructors[verbosityLevel] == null) {

--- a/src/engine/dataset_fakes.ts
+++ b/src/engine/dataset_fakes.ts
@@ -108,7 +108,7 @@ class FakeNumericIterator extends LazyIterator<FitDatasetElement> {
     tfc.util.assert(
         this.xTensorsFunc == null && this.yTensorsFunc == null ||
             this.xTensorsFunc != null && this.yTensorsFunc != null,
-        'presetXTensors and presetYTensors must be both null/undefined ' +
+        () => 'presetXTensors and presetYTensors must be both null/undefined ' +
             'or both set.');
   }
 
@@ -140,17 +140,18 @@ class FakeNumericIterator extends LazyIterator<FitDatasetElement> {
         xs = (this.xTensorValues as tfc.Tensor[])[index];
         tfc.util.assert(
             tfc.util.arraysEqual(xs.shape, this.xBatchShape as Shape),
-            `Shape mismatch: expected: ${JSON.stringify(this.xBatchShape)}; ` +
-                `actual: ${JSON.stringify(xs.shape)}`);
+            () => `Shape mismatch: expected: ${
+                      JSON.stringify(this.xBatchShape)}; ` +
+                `actual: ${JSON.stringify((xs as tfc.Tensor).shape)}`);
       } else {
         xs = {};
         for (const key in this.xTensorValues) {
           xs[key] = this.xTensorValues[key][index];
           tfc.util.assert(
               tfc.util.arraysEqual(xs[key].shape, this.xBatchShape as Shape),
-              `Shape mismatch: expected: ${
-                  JSON.stringify(this.xBatchShape)}; ` +
-                  `actual: ${JSON.stringify(xs.shape)}`);
+              () => `Shape mismatch: expected: ${
+                        JSON.stringify(this.xBatchShape)}; ` +
+                  `actual: ${JSON.stringify((xs as tfc.Tensor).shape)}`);
         }
       }
 
@@ -160,8 +161,9 @@ class FakeNumericIterator extends LazyIterator<FitDatasetElement> {
         ys = (this.yTensorValues as tfc.Tensor[])[index];
         tfc.util.assert(
             tfc.util.arraysEqual(ys.shape, this.yBatchShape as Shape),
-            `Shape mismatch: expected: ${JSON.stringify(this.yBatchShape)}; ` +
-                `actual: ${JSON.stringify(ys.shape)}`);
+            () => `Shape mismatch: expected: ${
+                      JSON.stringify(this.yBatchShape)}; ` +
+                `actual: ${JSON.stringify((ys as tfc.Tensor).shape)}`);
       } else {
         // Get preset ys tensors for multi-output models.
         ys = {};
@@ -171,9 +173,11 @@ class FakeNumericIterator extends LazyIterator<FitDatasetElement> {
           tfc.util.assert(
               tfc.util.arraysEqual(
                   ys[key].shape, this.yBatchShape[key] as Shape),
-              `Shape mismatch: expected: ${
-                  JSON.stringify(this.yBatchShape)}; ` +
-                  `actual: ${JSON.stringify(ys.shape)}`);
+              () => `Shape mismatch: expected: ${
+                        JSON.stringify(this.yBatchShape)}; ` +
+                  `actual: ${
+                        JSON.stringify(
+                            (ys as {[name: string]: tfc.Tensor})[key].shape)}`);
         }
       }
 
@@ -194,10 +198,12 @@ export class FakeNumericDataset extends Dataset<FitDatasetElement> {
     super();
     tfc.util.assert(
         args.batchSize > 0 && Number.isInteger(args.batchSize),
-        `batchSize must be a positive integer, but got ${args.batchSize}`);
+        () =>
+            `batchSize must be a positive integer, but got ${args.batchSize}`);
     tfc.util.assert(
         args.numBatches > 0 && Number.isInteger(args.numBatches),
-        `numBatches must be positive integer, but got ${args.numBatches}`);
+        () =>
+            `numBatches must be positive integer, but got ${args.numBatches}`);
     this.size = args.numBatches;
   }
 

--- a/src/engine/executor.ts
+++ b/src/engine/executor.ts
@@ -386,7 +386,7 @@ function getTopologicalSortAndRecipientCounts(
     {sorted: SymbolicTensor[], recipientCounts: RecipientCounts} {
   util.assert(
       fetches != null && fetches.length > 0,
-      `Exepcted at least one fetch, got none`);
+      () => `Exepcted at least one fetch, got none`);
 
   let finalSorted: SymbolicTensor[] = [];
   let finalRecipientMap: RecipientMap = {};

--- a/src/engine/executor.ts
+++ b/src/engine/executor.ts
@@ -386,7 +386,7 @@ function getTopologicalSortAndRecipientCounts(
     {sorted: SymbolicTensor[], recipientCounts: RecipientCounts} {
   util.assert(
       fetches != null && fetches.length > 0,
-      () => `Exepcted at least one fetch, got none`);
+      () => `Expected at least one fetch, got none`);
 
   let finalSorted: SymbolicTensor[] = [];
   let finalRecipientMap: RecipientMap = {};

--- a/src/engine/training_dataset.ts
+++ b/src/engine/training_dataset.ts
@@ -192,7 +192,7 @@ function standardizeDataIteratorOutput(
         'map of string to Tensor. ');
     tfc.util.assert(
         iteratorOut.length === 2,
-        'When using the legacy array input form, a ' +
+        () => 'When using the legacy array input form, a ' +
             'Dataset iterator for fitDataset() is expected to generate ' +
             'an Array of length 2: `[xs, ys]`, but instead generates ' +
             iteratorOut);
@@ -205,10 +205,11 @@ function standardizeDataIteratorOutput(
     ys = iteratorOutObj['ys'];
     tfc.util.assert(
         xs != null && ys != null,
-        'A Dataset iterator for fitDataset() is expected to generate objects ' +
-            'of the form `{xs: xVal, ys: yVal}`, where the two values may be ' +
-            '`tf.Tensor`, an array of Tensors, or a map of string to ' +
-            'Tensor.  The provided Dataset instead generates ' + iteratorOut);
+        () => 'A Dataset iterator for fitDataset() is expected to generate ' +
+            'objects of the form `{xs: xVal, ys: yVal}`, where the two ' +
+            'values may be `tf.Tensor`, an array of Tensors, or a map of ' +
+            'string to Tensor.  The provided Dataset instead generates ' +
+            iteratorOut);
   }
 
   const flattenedXs: tfc.Tensor[] =
@@ -220,31 +221,31 @@ function standardizeDataIteratorOutput(
 
   tfc.util.assert(
       flattenedXs.length === model.inputs.length,
-      `Model has ${model.inputs.length} inputs, but the dataset ` +
+      () => `Model has ${model.inputs.length} inputs, but the dataset ` +
           `provides ${flattenedXs.length} inputs.  (Expected input keys: ` +
           `${JSON.stringify(model.inputNames)})`);
 
   tfc.util.assert(
       flattenedYs.length === model.outputs.length,
-      `Model has ${model.outputs.length} outputs, but the dataset ` +
+      () => `Model has ${model.outputs.length} outputs, but the dataset ` +
           `provides ${flattenedYs.length} outputs.  (Expected output keys: ` +
           `${JSON.stringify(model.outputNames)})`);
 
   for (const xIndex in flattenedXs) {
     tfc.util.assert(
         flattenedXs[xIndex].shape[0] === batchSize,
-        `Batch size mismatch: input ` +
+        () => `Batch size mismatch: input ` +
             `${model.inputNames[xIndex]} has ${
-                flattenedXs[xIndex].shape[0]}; ` +
+                  flattenedXs[xIndex].shape[0]}; ` +
             `expected  ${batchSize} based on input ${model.inputNames[0]}.`);
   }
 
   for (const yIndex in flattenedYs) {
     tfc.util.assert(
         flattenedYs[yIndex].shape[0] === batchSize,
-        `Batch size mismatch: output ` +
+        () => `Batch size mismatch: output ` +
             `${model.outputNames[yIndex]} has ${
-                flattenedYs[yIndex].shape[0]}; ` +
+                  flattenedYs[yIndex].shape[0]}; ` +
             `expected  ${batchSize} based on input ${model.inputNames[0]}.`);
   }
 
@@ -258,7 +259,7 @@ function flattenTensorOrArrayOrMap(
   } else if (isArray(values)) {
     tfc.util.assert(
         values.length === names.length,
-        `Received an array of ${values.length} Tensors, but expected ${
+        () => `Received an array of ${values.length} Tensors, but expected ${
             names.length} to match the ${inputOrOutput} keys ${names}.`);
     return values;
   } else {
@@ -298,26 +299,26 @@ export async function fitDataset<T>(
   const hasBatchesPerEpoch = args.batchesPerEpoch != null;
   tfc.util.assert(
       model.optimizer != null,
-      'You must compile a model before training/testing. Use ' +
+      () => 'You must compile a model before training/testing. Use ' +
           'Model.compile(modelCompileConfig).');
 
   tfc.util.assert(
       args != null,
-      `For fitDataset(), the 2nd argument (config) is required, ` +
+      () => `For fitDataset(), the 2nd argument (config) is required, ` +
           `but it is not provided in this call.`);
   tfc.util.assert(
       args.epochs != null && args.epochs > 0 && Number.isInteger(args.epochs),
-      `For fitDataset(), config.epochs is expected to be a positive ` +
+      () => `For fitDataset(), config.epochs is expected to be a positive ` +
           `integer, but got ${args.epochs}`);
   tfc.util.assert(
       !hasBatchesPerEpoch ||
           (args.batchesPerEpoch > 0 && Number.isInteger(args.batchesPerEpoch)),
-      `For fitDataset(), config.batchesPerEpoch is expected to be a ` +
+      () => `For fitDataset(), config.batchesPerEpoch is expected to be a ` +
           `positive integer if specified, but got ${args.batchesPerEpoch}`);
   tfc.util.assert(
       // tslint:disable-next-line:no-any
       (args as any)['validationSplit'] == null,
-      '`validationSplit` is not supported by `fitDataset()`. ' +
+      () => '`validationSplit` is not supported by `fitDataset()`. ' +
           'Use validationData instead.');
 
   if (model.isTraining) {
@@ -336,7 +337,7 @@ export async function fitDataset<T>(
             args.validationBatches == null ||
                 (args.validationBatches > 0 &&
                  Number.isInteger(args.validationBatches)),
-            `For fitDataset() with dataset-based validation, ` +
+            () => `For fitDataset() with dataset-based validation, ` +
                 `config.validationBatches is expected not to be provided, ` +
                 `or to be a positive integer, ` +
                 `but got ${args.validationBatches}`);
@@ -526,7 +527,7 @@ export async function evaluateDataset<T>(
 
   tfc.util.assert(
       !hasBatches || (args.batches > 0 && Number.isInteger(args.batches)),
-      'Test loop expects `batches` to be a positive integer, but ' +
+      () => 'Test loop expects `batches` to be a positive integer, but ' +
           `received ${JSON.stringify(args.batches)}`);
   const dataIterator = isLazyIteratorObject(dataset) ?
       dataset as LazyIterator<T>:

--- a/src/engine/training_tensors.ts
+++ b/src/engine/training_tensors.ts
@@ -142,7 +142,8 @@ export interface ModelFitArgs {
 export function checkBatchSize(batchSize: number) {
   tfc.util.assert(
       batchSize > 0 && Number.isInteger(batchSize),
-      `batchSize is required to be a positive integer, but got ${batchSize}`);
+      () => `batchSize is required to be a positive integer, but got ${
+          batchSize}`);
 }
 
 

--- a/src/layers/merge.ts
+++ b/src/layers/merge.ts
@@ -994,11 +994,11 @@ function batchDot(x: Tensor, y: Tensor, axes: number|[number, number]): Tensor {
   }
   tfc.util.assert(
       x.shape.length >= 2,
-      `batchDot requires the rank of x to be >= 2, ` +
+      () => `batchDot requires the rank of x to be >= 2, ` +
           `but got ${x.shape.length}`);
   tfc.util.assert(
       x.shape.length >= 2,
-      `batchDot requires the rank of y to be >= 2, ` +
+      () => `batchDot requires the rank of y to be >= 2, ` +
           `but got ${y.shape.length}`);
 
   if (typeof axes === 'number') {
@@ -1110,7 +1110,7 @@ export class Dot extends Merge {
     tfc.util.assert(
         Array.isArray(inputShape) && inputShape.length === 2 &&
             Array.isArray(inputShape[0]) && Array.isArray(inputShape[1]),
-        'A `Dot` layer should be called on a list of exactly 2 inputs.');
+        () => 'A `Dot` layer should be called on a list of exactly 2 inputs.');
     const shape1 = inputShape[0] as Shape;
     const shape2 = inputShape[1] as Shape;
     if (shape1.length > 3 || shape2.length > 3) {
@@ -1172,7 +1172,7 @@ export class Dot extends Merge {
     tfc.util.assert(
         Array.isArray(inputShape) && inputShape.length === 2 &&
             Array.isArray(inputShape[0]) && Array.isArray(inputShape[1]),
-        'A `Dot` layer should be called on a list of exactly 2 inputs.');
+        () => 'A `Dot` layer should be called on a list of exactly 2 inputs.');
     const shape1 = (inputShape[0] as Shape).slice();
     const shape2 = (inputShape[1] as Shape).slice();
     if (shape1.length > 3 || shape2.length > 3) {

--- a/src/models.ts
+++ b/src/models.ts
@@ -926,7 +926,8 @@ export class Sequential extends Model {
     } else {
       util.assert(
           config['layers'] != null,
-          `When the config data for a Sequential model is not an Array, ` +
+          () =>
+              `When the config data for a Sequential model is not an Array, ` +
               `it must be an Object that contains the 'layers' field.`);
       configArray = config['layers'] as serialization.ConfigDictArray;
       delete config['layers'];

--- a/src/utils/generic_utils.ts
+++ b/src/utils/generic_utils.ts
@@ -439,13 +439,14 @@ export function checkArrayTypeAndLength(
  */
 export function assertPositiveInteger(value: number|number[], name: string) {
   if (Array.isArray(value)) {
-    util.assert(value.length > 0, `${name} is unexpectedly an empty array.`);
+    util.assert(
+        value.length > 0, () => `${name} is unexpectedly an empty array.`);
     value.forEach(
         (v, i) => assertPositiveInteger(v, `element ${i + 1} of ${name}`));
   } else {
     util.assert(
         Number.isInteger(value) && value > 0,
-        `Expected ${name} to be a positive integer, but got ` +
+        () => `Expected ${name} to be a positive integer, but got ` +
             `${formatAsFriendlyString(value)}.`);
   }
 }


### PR DESCRIPTION
This allows us to lazily evaluate the string for better performance.

Currently string concatenating a tensor happens eagerly, causing a dataSync() on the tensor and slows down the train loop.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/475)
<!-- Reviewable:end -->
