### PR TITLE
Allow `null`(`None` in Python) in `Shape`

### DIFF
--- a/src/engine/input_layer_test.ts
+++ b/src/engine/input_layer_test.ts
@@ -108,6 +108,13 @@ describeMathCPU('InputLayer', () => {
     });
   });
 
+  // See https://github.com/tensorflow/tfjs/issues/1341
+  it('allow `null` in shape', () => {
+    const inputShape = [null, 2];
+    const inputs = tfl.layers.inputLayer({inputShape});
+    expect(inputs.inputSpec[0].shape).toEqual([null].concat(inputShape));
+  });
+
   it('throws an exception if both inputShape and batchInputShape ' +
          'are specified during initialization.',
      () => {

--- a/src/keras_format/common.ts
+++ b/src/keras_format/common.ts
@@ -8,6 +8,7 @@
  * =============================================================================
  */
 
+// TODO(huan): add layer-specific input shape types (see: https://github.com/tensorflow/tfjs-layers/pull/492)
 /** @docalias (null | number)[] */
 export type Shape = (null | number)[];
 

--- a/src/keras_format/common.ts
+++ b/src/keras_format/common.ts
@@ -10,7 +10,7 @@
 
 // TODO(huan): add layer-specific input shape types (see: https://github.com/tensorflow/tfjs-layers/pull/492)
 /** @docalias (null | number)[] */
-export type Shape = (null | number)[];
+export type Shape = Array<null | number>;
 
 // The tfjs-core version of DataType must stay synced with this.
 export type DataType = 'float32'|'int32'|'bool'|'complex64'|'string';

--- a/src/keras_format/common.ts
+++ b/src/keras_format/common.ts
@@ -8,7 +8,7 @@
  * =============================================================================
  */
 
-/** @docalias number[] */
+/** @docalias (null | number)[] */
 export type Shape = (null | number)[];
 
 // The tfjs-core version of DataType must stay synced with this.

--- a/src/keras_format/common.ts
+++ b/src/keras_format/common.ts
@@ -9,7 +9,7 @@
  */
 
 /** @docalias number[] */
-export type Shape = number[];
+export type Shape = (null | number)[];
 
 // The tfjs-core version of DataType must stay synced with this.
 export type DataType = 'float32'|'int32'|'bool'|'complex64'|'string';


### PR DESCRIPTION
See: https://github.com/tensorflow/tfjs/issues/1341

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/492)
<!-- Reviewable:end -->
