### PR TITLE
Fix l2Normalize rank error in epsilon-flooring of sum

### DIFF
--- a/src/engine/training_test.ts
+++ b/src/engine/training_test.ts
@@ -496,11 +496,11 @@ describeMathCPUAndGPU('LayersModel.fit', () => {
     expect(history.history.loss.length).toEqual(2);
     expect(history.history.val_loss.length).toEqual(2);
     test_util.expectArraysClose(
-      history.history['loss'] as number[], 
-      [-0.70710688829422, -0.7077317237854004]);
+        history.history['loss'] as number[], 
+        [-0.70710688829422, -0.7077317237854004]);
     test_util.expectArraysClose(
-      history.history['val_loss'] as number[], 
-      [-0.70710688829422, -0.7077317237854004]);
+        history.history['val_loss'] as number[], 
+        [-0.70710688829422, -0.7077317237854004]);
   });
 
   it('training with custom loss', async () => {

--- a/src/engine/training_test.ts
+++ b/src/engine/training_test.ts
@@ -495,8 +495,12 @@ describeMathCPUAndGPU('LayersModel.fit', () => {
     expect(history.epoch).toEqual([0, 1]);
     expect(history.history.loss.length).toEqual(2);
     expect(history.history.val_loss.length).toEqual(2);
-    test_util.expectArraysClose(history.history['loss'] as number[], [-0.70710688829422, -0.7077317237854004]);
-    test_util.expectArraysClose(history.history['val_loss'] as number[], [-0.70710688829422, -0.7077317237854004]);
+    test_util.expectArraysClose(
+      history.history['loss'] as number[], 
+      [-0.70710688829422, -0.7077317237854004]);
+    test_util.expectArraysClose(
+      history.history['val_loss'] as number[], 
+      [-0.70710688829422, -0.7077317237854004]);
   });
 
   it('training with custom loss', async () => {

--- a/src/engine/training_test.ts
+++ b/src/engine/training_test.ts
@@ -485,6 +485,18 @@ describeMathCPUAndGPU('LayersModel.fit', () => {
     }
   });
 
+  it('training with cosineProximity loss should not crash', async () => {
+    createDenseModelAndData();
+    model.compile({optimizer: 'SGD', loss: 'cosineProximity'});
+    // Use batchSize === numSamples to get exactly one batch.
+    const history = await model.fit(
+        inputs, targets,
+        {batchSize: numSamples, epochs: 2, validationSplit: 0.2});
+    expect(history.epoch).toEqual([0, 1]);
+    expect(history.history.loss.length).toEqual(2);
+    expect(history.history.val_loss.length).toEqual(2);
+  });
+
   it('training with custom loss', async () => {
     // Use the following Python code snippet to get reference values
     // for assertion:

--- a/src/engine/training_test.ts
+++ b/src/engine/training_test.ts
@@ -485,8 +485,8 @@ describeMathCPUAndGPU('LayersModel.fit', () => {
     }
   });
 
-  it('training with cosineProximity loss should not crash', async () => {
-    createDenseModelAndData();
+  it('training with cosineProximity loss', async () => {
+    createDenseCategoricalModelAndData();
     model.compile({optimizer: 'SGD', loss: 'cosineProximity'});
     // Use batchSize === numSamples to get exactly one batch.
     const history = await model.fit(
@@ -495,6 +495,8 @@ describeMathCPUAndGPU('LayersModel.fit', () => {
     expect(history.epoch).toEqual([0, 1]);
     expect(history.history.loss.length).toEqual(2);
     expect(history.history.val_loss.length).toEqual(2);
+    test_util.expectArraysClose(history.history['loss'] as number[], [-0.70710688829422, -0.7077317237854004]);
+    test_util.expectArraysClose(history.history['val_loss'] as number[], [-0.70710688829422, -0.7077317237854004]);
   });
 
   it('training with custom loss', async () => {

--- a/src/losses.ts
+++ b/src/losses.ts
@@ -10,7 +10,7 @@
 
 /* Original Source: losses.py */
 import * as tfc from '@tensorflow/tfjs-core';
-import {scalar, Tensor, Tensor1D, tidy, util} from '@tensorflow/tfjs-core';
+import {Tensor, Tensor1D, tidy, util} from '@tensorflow/tfjs-core';
 
 import {epsilon} from './backend/common';
 import {getScalar} from './backend/state';

--- a/src/losses.ts
+++ b/src/losses.ts
@@ -27,7 +27,7 @@ import {LossOrMetricFn} from './types';
 export function l2Normalize(x: Tensor, axis?: number): Tensor {
   return tidy(() => {
     const squareSum = tfc.sum(K.square(x), axis, true);
-    const epsilonTensor = tfc.mul(scalar(epsilon()), tfc.onesLike(x));
+    const epsilonTensor = tfc.mul(scalar(epsilon()), tfc.onesLike(squareSum));
     const norm = tfc.sqrt(tfc.maximum(squareSum, epsilonTensor));
     return tfc.div(x, norm);
   });

--- a/src/losses.ts
+++ b/src/losses.ts
@@ -27,7 +27,7 @@ import {LossOrMetricFn} from './types';
 export function l2Normalize(x: Tensor, axis?: number): Tensor {
   return tidy(() => {
     const squareSum = tfc.sum(K.square(x), axis, true);
-    const epsilonTensor = tfc.mul(scalar(epsilon()), tfc.onesLike(squareSum));
+    const epsilonTensor = tfc.fill(squareSum.shape, epsilon());
     const norm = tfc.sqrt(tfc.maximum(squareSum, epsilonTensor));
     return tfc.div(x, norm);
   });


### PR DESCRIPTION
See https://stackoverflow.com/questions/55159903/tensorflow-js-error-in-gradient-for-op-maximum-the-gradient-of-input-a-has for details and an example of code that breaks while this bug isn't fixed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/499)
<!-- Reviewable:end -->
