### PR TITLE
VarianceScaling initializer: Fix default arg values

### DIFF
--- a/src/initializers.ts
+++ b/src/initializers.ts
@@ -323,13 +323,13 @@ function computeFans(
 
 export interface VarianceScalingArgs {
   /** Scaling factor (positive float). */
-  scale: number;
+  scale?: number;
 
   /** Fanning mode for inputs and outputs. */
-  mode: FanMode;
+  mode?: FanMode;
 
   /** Probabilistic distribution of the values. */
-  distribution: Distribution;
+  distribution?: Distribution;
 
   /** Random number generator seed. */
   seed?: number;

--- a/src/initializers.ts
+++ b/src/initializers.ts
@@ -366,9 +366,10 @@ export class VarianceScaling extends Initializer {
           `scale must be a positive float. Got: ${args.scale}`);
     }
     this.scale = args.scale == null ? 1.0 : args.scale;
-    this.mode = args.mode;
+    this.mode = args.mode == null ? 'fanIn' : args.mode;
     checkFanMode(this.mode);
-    this.distribution = args.distribution;
+    this.distribution =
+        args.distribution == null ? 'normal' : args.distribution;
     checkDistribution(this.distribution);
     this.seed = args.seed;
   }

--- a/src/initializers_test.ts
+++ b/src/initializers_test.ts
@@ -410,6 +410,19 @@ describeMathCPU('Glorot uniform initializer', () => {
   });
 });
 
+describeMathCPU('VarianceScaling initializer', () => {
+  ['varianceScaling', 'VarianceScaling'].forEach(initializer => {
+    it('Default argument values', () => {
+      const init = getInitializer(initializer);
+      const config = init.getConfig();
+      expect(config['scale']).toEqual(1);
+      expect(config['mode']).toEqual('fanIn');
+      expect(config['distribution']).toEqual('normal');
+      expect(config['seed']).toEqual(undefined);
+    });
+  });
+});
+
 describeMathCPU('Glorot normal initializer', () => {
   ['glorotNormal', 'GlorotNormal'].forEach(initializer => {
     it('1D ' + initializer, () => {

--- a/src/keras_format/initializer_config.ts
+++ b/src/keras_format/initializer_config.ts
@@ -62,10 +62,10 @@ export type TruncatedNormalSerialization =
     BaseSerialization<'TruncatedNormal', TruncatedNormalConfig>;
 
 export type VarianceScalingConfig = {
-  scale: number;
+  scale?: number;
 
-  mode: FanModeSerialization;
-  distribution: Distribution;
+  mode?: FanModeSerialization;
+  distribution?: Distribution;
   seed?: number;
 };
 


### PR DESCRIPTION
- The VarianceScaling initializer is the base class of initializers
  such as GlorotNormal, HeNormal and LeCunNormal. But in relatively
  rare occasions, it is used by itself.
- Previously, the default values of the `mode` and `distribution`
  were not set properly, leading to inconsistent behavior with keras.
  This CL fixes that.

Re https://github.com/tensorflow/tfjs/issues/1434

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/505)
<!-- Reviewable:end -->
