### PR TITLE
Update layers to 1.0.3 and fix TypeScript conformance issues in Google.

### DIFF
--- a/integration_tests/benchmarks/package.json
+++ b/integration_tests/benchmarks/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs-core": "1.0.2",
+    "@tensorflow/tfjs-core": "1.0.3",
     "@tensorflow/tfjs-layers": "../../dist"
   },
   "scripts": {

--- a/integration_tests/benchmarks/yarn.lock
+++ b/integration_tests/benchmarks/yarn.lock
@@ -697,10 +697,10 @@
     "@parcel/utils" "^1.11.0"
     physical-cpu-count "^2.0.0"
 
-"@tensorflow/tfjs-core@2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.0.2.tgz#98be72677eccf367b71115067d9c498517da0f89"
-  integrity sha512-SJ7HdFfQ9jcDgyj4mMqU5kvfy5yy3X7cuixHrN7cAmlnCcaIVx732HIBHo+krepLMhlCPaMbR3xN2YJmmF5L8A==
+"@tensorflow/tfjs-core@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.0.3.tgz#344f3fb1ed43c43b0e19e5e2764677770fd7a085"
+  integrity sha512-2UbjMQkmrykIIZuoRfmDPrtWm+6fdQRlYLCUJdiOIooeu/q4nye587HM1qKcdZosGPZTW6VvX+4VIVieYn5i0A==
   dependencies:
     "@types/seedrandom" "2.4.27"
     "@types/webgl-ext" "0.0.30"

--- a/integration_tests/tfjs2keras/package.json
+++ b/integration_tests/tfjs2keras/package.json
@@ -5,7 +5,7 @@
   "private": false,
   "license": "Apache-2.0 AND MIT",
   "devDependencies": {
-    "@tensorflow/tfjs-core": "1.0.2",
+    "@tensorflow/tfjs-core": "1.0.3",
     "@tensorflow/tfjs-layers": "*",
     "@tensorflow/tfjs-node": "0.3.0",
     "clang-format": "~1.2.2"

--- a/integration_tests/tfjs2keras/yarn.lock
+++ b/integration_tests/tfjs2keras/yarn.lock
@@ -74,10 +74,10 @@
     "@types/webgl2" "0.0.4"
     seedrandom "2.4.3"
 
-"@tensorflow/tfjs-core@1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.0.2.tgz#98be72677eccf367b71115067d9c498517da0f89"
-  integrity sha512-SJ7HdFfQ9jcDgyj4mMqU5kvfy5yy3X7cuixHrN7cAmlnCcaIVx732HIBHo+krepLMhlCPaMbR3xN2YJmmF5L8A==
+"@tensorflow/tfjs-core@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.0.3.tgz#344f3fb1ed43c43b0e19e5e2764677770fd7a085"
+  integrity sha512-2UbjMQkmrykIIZuoRfmDPrtWm+6fdQRlYLCUJdiOIooeu/q4nye587HM1qKcdZosGPZTW6VvX+4VIVieYn5i0A==
   dependencies:
     "@types/seedrandom" "2.4.27"
     "@types/webgl-ext" "0.0.30"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensorflow/tfjs-layers",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "TensorFlow layers API in JavaScript",
   "license": "Apache-2.0 AND MIT",
   "private": false,
@@ -11,7 +11,7 @@
   "jsdelivr": "dist/tf-layers.min.js",
   "unpkg": "dist/tf-layers.min.js",
   "devDependencies": {
-    "@tensorflow/tfjs-core": "1.0.2",
+    "@tensorflow/tfjs-core": "1.0.3",
     "@types/jasmine": "~2.5.53",
     "clang-format": "~1.2.2",
     "http-server": "~0.10.0",
@@ -46,6 +46,6 @@
     "lint": "tslint -p . -t verbose"
   },
   "peerDependencies": {
-    "@tensorflow/tfjs-core": "1.0.2"
+    "@tensorflow/tfjs-core": "1.0.3"
   }
 }

--- a/src/activations.ts
+++ b/src/activations.ts
@@ -201,13 +201,13 @@ export function getActivation(identifier: ActivationIdentifier|
   if (identifier == null) {
     const config: serialization.ConfigDict = {};
     config['className'] = 'linear';
-    config.config = {};
+    config['config'] = {};
     return deserializeActivation(config);
   }
   if (typeof identifier === 'string') {
     const config: serialization.ConfigDict = {};
     config['className'] = identifier;
-    config.config = {};
+    config['config'] = {};
     return deserializeActivation(config);
   } else if (identifier instanceof Activation) {
     return identifier;

--- a/src/activations.ts
+++ b/src/activations.ts
@@ -200,13 +200,13 @@ export function getActivation(identifier: ActivationIdentifier|
                               serialization.ConfigDict|Activation): Activation {
   if (identifier == null) {
     const config: serialization.ConfigDict = {};
-    config.className = 'linear';
+    config['className'] = 'linear';
     config.config = {};
     return deserializeActivation(config);
   }
   if (typeof identifier === 'string') {
     const config: serialization.ConfigDict = {};
-    config.className = identifier;
+    config['className'] = identifier;
     config.config = {};
     return deserializeActivation(config);
   } else if (identifier instanceof Activation) {

--- a/src/engine/container.ts
+++ b/src/engine/container.ts
@@ -1133,10 +1133,9 @@ export abstract class Container extends Layer {
         const inboundNodeIndex = inputDataArray[1] as number;
         const inboundTensorIndex = inputDataArray[2] as number;
 
-        const numKeys = Object.keys(inputDataArray).length;
-        if (numKeys === 3) {
+        if (inputDataArray.length === 3) {
           kwargs = {};
-        } else if (numKeys === 4) {
+        } else if (inputDataArray.length === 4) {
           kwargs = inputDataArray[3] as serialization.ConfigDict;
         } else {
           throw new ValueError(`Improperly formatted model config for layer ${

--- a/src/engine/container.ts
+++ b/src/engine/container.ts
@@ -1126,17 +1126,21 @@ export abstract class Container extends Layer {
       const inputTensors: SymbolicTensor[] = [];
       let kwargs;
       for (const inputData of nodeData) {
-        const inboundLayerName = inputData[0] as string;
-        const inboundNodeIndex = inputData[1] as number;
-        const inboundTensorIndex = inputData[2] as number;
-        const numKeys = Object.keys(inputData).length;
+        const inputDataArray = inputData as unknown as
+            Array<number|string|serialization.ConfigDict>;
+
+        const inboundLayerName = inputDataArray[0] as string;
+        const inboundNodeIndex = inputDataArray[1] as number;
+        const inboundTensorIndex = inputDataArray[2] as number;
+
+        const numKeys = Object.keys(inputDataArray).length;
         if (numKeys === 3) {
           kwargs = {};
         } else if (numKeys === 4) {
-          kwargs = inputData[3] as serialization.ConfigDict;
+          kwargs = inputDataArray[3] as serialization.ConfigDict;
         } else {
           throw new ValueError(`Improperly formatted model config for layer ${
-              JSON.stringify(layer)}: ${JSON.stringify(inputData)}`);
+              JSON.stringify(layer)}: ${JSON.stringify(inputDataArray)}`);
         }
         if (!(inboundLayerName in createdLayers)) {
           addUnprocessedNode(layer, nodeData);

--- a/src/engine/container.ts
+++ b/src/engine/container.ts
@@ -609,7 +609,7 @@ export abstract class Container extends Layer {
   private updatedConfig(): serialization.ConfigDict {
     const theConfig = this.getConfig();
     const modelConfig: serialization.ConfigDict = {};
-    modelConfig.className = this.getClassName();
+    modelconfig['className'] = this.getClassName();
     modelConfig.config = theConfig;
     modelConfig.kerasVersion = `tfjs-layers ${layersVersion}`;
     // TODO(nielsene): Replace something like K.backend() once

--- a/src/engine/container.ts
+++ b/src/engine/container.ts
@@ -609,12 +609,12 @@ export abstract class Container extends Layer {
   private updatedConfig(): serialization.ConfigDict {
     const theConfig = this.getConfig();
     const modelConfig: serialization.ConfigDict = {};
-    modelconfig['className'] = this.getClassName();
-    modelConfig.config = theConfig;
-    modelConfig.kerasVersion = `tfjs-layers ${layersVersion}`;
+    modelConfig['className'] = this.getClassName();
+    modelConfig['config'] = theConfig;
+    modelConfig['kerasVersion'] = `tfjs-layers ${layersVersion}`;
     // TODO(nielsene): Replace something like K.backend() once
     // possible.
-    modelConfig.backend = 'TensorFlow.js';
+    modelConfig['backend'] = 'TensorFlow.js';
     return modelConfig;
   }
 
@@ -832,7 +832,7 @@ export abstract class Container extends Layer {
           }
           if (computedData.length === 1) {
             const [computedTensor, computedMask] = computedData[0];
-            if (kwargs.mask == null) {
+            if (kwargs['mask'] == null) {
               kwargs['mask'] = computedMask;
             }
             outputTensors =
@@ -844,7 +844,7 @@ export abstract class Container extends Layer {
           } else {
             computedTensors = computedData.map(x => x[0]);
             computedMasks = computedData.map(x => x[1]);
-            if (kwargs.mask == null) {
+            if (kwargs['mask'] == null) {
               kwargs['mask'] = computedMasks;
             }
             outputTensors =
@@ -1038,10 +1038,10 @@ export abstract class Container extends Layer {
         }
       }
       const dict: serialization.ConfigDict = {};
-      dict.name = layer.name;
-      dict.className = layerClassName;
-      dict.config = layerConfig;
-      dict.inboundNodes = filteredInboundNodes;
+      dict['name'] = layer.name;
+      dict['className'] = layerClassName;
+      dict['config'] = layerConfig;
+      dict['inboundNodes'] = filteredInboundNodes;
       layerConfigs.push(dict);
     }
     config['layers'] = layerConfigs;
@@ -1129,9 +1129,10 @@ export abstract class Container extends Layer {
         const inboundLayerName = inputData[0] as string;
         const inboundNodeIndex = inputData[1] as number;
         const inboundTensorIndex = inputData[2] as number;
-        if (inputData.length === 3) {
+        const numKeys = Object.keys(inputData).length;
+        if (numKeys === 3) {
           kwargs = {};
-        } else if (inputData.length === 4) {
+        } else if (numKeys === 4) {
           kwargs = inputData[3] as serialization.ConfigDict;
         } else {
           throw new ValueError(`Improperly formatted model config for layer ${
@@ -1166,18 +1167,19 @@ export abstract class Container extends Layer {
      * dict.
      */
     function processLayer(layerData: serialization.ConfigDict|null) {
-      const layerName = layerData.name as string;
+      const layerName = layerData['name'] as string;
       // Instantiate layer.
-      const layer = deserializeLayer(
-                        layerData,
-                        config.customObjects != null ?
-                            config.customObjects as serialization.ConfigDict :
-                            {}) as Layer;
+      const layer =
+          deserializeLayer(
+              layerData,
+              config['customObjects'] != null ?
+                  config['customObjects'] as serialization.ConfigDict :
+                  {}) as Layer;
       layer.setFastWeightInitDuringBuild(fastWeightInit);
       createdLayers[layerName] = layer;
       // Gather layer inputs.
       const inboundNodesData =
-          layerData.inboundNodes as serialization.ConfigDict[];
+          layerData['inboundNodes'] as serialization.ConfigDict[];
       for (const nodeData of inboundNodesData) {
         if (!(nodeData instanceof Array)) {
           throw new ValueError(
@@ -1193,8 +1195,8 @@ export abstract class Container extends Layer {
     }
 
     // First, we create all layers and enqueue nodes to be processed.
-    const name = config.name;
-    const layersFromConfig = config.layers as serialization.ConfigDict[];
+    const name = config['name'];
+    const layersFromConfig = config['layers'] as serialization.ConfigDict[];
     for (const layerData of layersFromConfig) {
       processLayer(layerData);
     }
@@ -1205,7 +1207,7 @@ export abstract class Container extends Layer {
     // is repeated until all nodes are processed.
     while (!generic_utils.isObjectEmpty(unprocessedNodes)) {
       for (const layerData of layersFromConfig) {
-        const layer = createdLayers[layerData.name as string];
+        const layer = createdLayers[layerData['name'] as string];
         if (layer.name in unprocessedNodes) {
           const currentUnprocessedNodesForLayer = unprocessedNodes[layer.name];
           delete unprocessedNodes[layer.name];
@@ -1219,7 +1221,7 @@ export abstract class Container extends Layer {
     const inputTensors: SymbolicTensor[] = [];
     const outputTensors: SymbolicTensor[] = [];
     const inputLayersFromConfig =
-        config.inputLayers as serialization.ConfigDict[];
+        config['inputLayers'] as serialization.ConfigDict[];
     for (const layerData of inputLayersFromConfig) {
       const layerName = layerData[0] as string;
       const nodeIndex = layerData[1] as number;
@@ -1230,7 +1232,7 @@ export abstract class Container extends Layer {
       inputTensors.push(layerOutputTensors[tensorIndex]);
     }
     const outputLayersFromConfig =
-        config.outputLayers as serialization.ConfigDict[];
+        config['outputLayers'] as serialization.ConfigDict[];
     for (const layerData of outputLayersFromConfig) {
       const layerName = layerData[0] as string;
       const nodeIndex = layerData[1] as number;

--- a/src/initializers.ts
+++ b/src/initializers.ts
@@ -753,7 +753,7 @@ export function getInitializer(identifier: InitializerIdentifier|Initializer|
     } else {
       const config: serialization.ConfigDict = {};
       config['className'] = className;
-      config.config = {};
+      config['config'] = {};
       return deserializeInitializer(config);
     }
   } else if (identifier instanceof Initializer) {

--- a/src/initializers.ts
+++ b/src/initializers.ts
@@ -752,7 +752,7 @@ export function getInitializer(identifier: InitializerIdentifier|Initializer|
       return new LeCunUniform();
     } else {
       const config: serialization.ConfigDict = {};
-      config.className = className;
+      config['className'] = className;
       config.config = {};
       return deserializeInitializer(config);
     }

--- a/src/layers/noise.ts
+++ b/src/layers/noise.ts
@@ -13,7 +13,7 @@
  */
 
 
-import {serialization, Tensor, tidy, greaterEqual, randomUniform} from '@tensorflow/tfjs-core';
+import {greaterEqual, randomUniform, serialization, Tensor, tidy} from '@tensorflow/tfjs-core';
 
 import * as K from '../backend/tfjs_backend';
 import {Layer, LayerArgs} from '../engine/topology';
@@ -48,7 +48,6 @@ export declare interface GaussianNoiseArgs extends LayerArgs {
  *         Same shape as input.
  */
 export class GaussianNoise extends Layer {
-
   static className = 'GaussianNoise';
   readonly stddev: number;
 
@@ -58,7 +57,7 @@ export class GaussianNoise extends Layer {
     this.stddev = args.stddev;
   }
 
-  computeOutputShape(inputShape: Shape | Shape[]): Shape | Shape[] {
+  computeOutputShape(inputShape: Shape|Shape[]): Shape|Shape[] {
     return inputShape;
   }
 
@@ -69,14 +68,14 @@ export class GaussianNoise extends Layer {
     return config;
   }
 
-  call(inputs: Tensor | Tensor[], kwargs: Kwargs): Tensor | Tensor[] {
+  call(inputs: Tensor|Tensor[], kwargs: Kwargs): Tensor|Tensor[] {
     return tidy(() => {
       this.invokeCallHook(inputs, kwargs);
       const input = getExactlyOneTensor(inputs);
       const noised = () =>
           K.randomNormal(input.shape, 0, this.stddev).add(input);
       const output =
-          K.inTrainPhase(noised, () => input, kwargs.training || false) as
+          K.inTrainPhase(noised, () => input, kwargs['training'] || false) as
           Tensor;
       return output;
     });
@@ -113,7 +112,6 @@ export declare interface GaussianDropoutArgs extends LayerArgs {
  *
  */
 export class GaussianDropout extends Layer {
-
   static className = 'GaussianDropout';
   readonly rate: number;
 
@@ -123,7 +121,7 @@ export class GaussianDropout extends Layer {
     this.rate = args.rate;
   }
 
-  computeOutputShape(inputShape: Shape | Shape[]): Shape | Shape[] {
+  computeOutputShape(inputShape: Shape|Shape[]): Shape|Shape[] {
     return inputShape;
   }
 
@@ -134,7 +132,7 @@ export class GaussianDropout extends Layer {
     return config;
   }
 
-  call(inputs: Tensor | Tensor[], kwargs: Kwargs): Tensor | Tensor[] {
+  call(inputs: Tensor|Tensor[], kwargs: Kwargs): Tensor|Tensor[] {
     return tidy(() => {
       this.invokeCallHook(inputs, kwargs);
       const input = getExactlyOneTensor(inputs);
@@ -143,7 +141,7 @@ export class GaussianDropout extends Layer {
           const stddev = Math.sqrt(this.rate / (1 - this.rate));
           return K.dot(input, K.randomNormal(input.shape, 1, stddev));
         };
-        return K.inTrainPhase(noised, () => input, kwargs.training || false);
+        return K.inTrainPhase(noised, () => input, kwargs['training'] || false);
       }
       return input;
     });
@@ -154,7 +152,8 @@ serialization.registerClass(GaussianDropout);
 export declare interface AlphaDropoutArgs extends LayerArgs {
   /** drop probability.  */
   rate: number;
-  /** A 1-D `Tensor` of type `int32`, representing the
+  /**
+   * A 1-D `Tensor` of type `int32`, representing the
    * shape for randomly generated keep/drop flags.
    */
   noiseShape?: Shape;
@@ -191,7 +190,6 @@ export declare interface AlphaDropoutArgs extends LayerArgs {
  *     - [Self-Normalizing Neural Networks](https://arxiv.org/abs/1706.02515)
  */
 export class AlphaDropout extends Layer {
-
   static className = 'AlphaDropout';
   readonly rate: number;
   readonly noiseShape: Shape;
@@ -203,11 +201,11 @@ export class AlphaDropout extends Layer {
     this.noiseShape = args.noiseShape;
   }
 
-  _getNoiseShape(inputs: Tensor | Tensor[]) {
+  _getNoiseShape(inputs: Tensor|Tensor[]) {
     return this.noiseShape || getExactlyOneTensor(inputs).shape;
   }
 
-  computeOutputShape(inputShape: Shape | Shape[]): Shape | Shape[] {
+  computeOutputShape(inputShape: Shape|Shape[]): Shape|Shape[] {
     return inputShape;
   }
 
@@ -218,13 +216,12 @@ export class AlphaDropout extends Layer {
     return config;
   }
 
-  call(inputs: Tensor | Tensor[], kwargs: Kwargs): Tensor | Tensor[] {
+  call(inputs: Tensor|Tensor[], kwargs: Kwargs): Tensor|Tensor[] {
     return tidy(() => {
       if (this.rate < 1 && this.rate > 0) {
         const noiseShape = this._getNoiseShape(inputs);
 
         const droppedInputs = () => {
-
           const input = getExactlyOneTensor(inputs);
 
           const alpha = 1.6732632423543772848170429916717;
@@ -234,7 +231,7 @@ export class AlphaDropout extends Layer {
 
           let keptIdx = greaterEqual(randomUniform(noiseShape), this.rate);
 
-          keptIdx = K.cast(keptIdx, 'float32'); // get default dtype.
+          keptIdx = K.cast(keptIdx, 'float32');  // get default dtype.
 
           // Get affine transformation params.
           const a = ((1 - this.rate) * (1 + this.rate * alphaP ** 2)) ** -0.5;
@@ -245,7 +242,8 @@ export class AlphaDropout extends Layer {
 
           return x.mul(a).add(b);
         };
-        return K.inTrainPhase(droppedInputs, () => getExactlyOneTensor(inputs),
+        return K.inTrainPhase(
+            droppedInputs, () => getExactlyOneTensor(inputs),
             kwargs.training || false);
       }
       return inputs;

--- a/src/layers/noise.ts
+++ b/src/layers/noise.ts
@@ -244,7 +244,7 @@ export class AlphaDropout extends Layer {
         };
         return K.inTrainPhase(
             droppedInputs, () => getExactlyOneTensor(inputs),
-            kwargs.training || false);
+            kwargs['training'] || false);
       }
       return inputs;
     });

--- a/src/layers/recurrent.ts
+++ b/src/layers/recurrent.ts
@@ -884,12 +884,12 @@ export class RNN extends Layer {
       unroll: this.unroll,
     };
     if (this.numConstants != null) {
-      config.numConstants = this.numConstants;
+      config['numConstants'] = this.numConstants;
     }
     const cellConfig = this.cell.getConfig();
-    config.cell = {
-      className: this.cell.getClassName(),
-      config: cellConfig,
+    config['cell'] = {
+      'className': this.cell.getClassName(),
+      'config': cellConfig,
     } as serialization.ConfigDictValue;
     const baseConfig = super.getConfig();
     Object.assign(config, baseConfig);

--- a/src/layers/serialization_test.ts
+++ b/src/layers/serialization_test.ts
@@ -16,14 +16,14 @@ import {deserialize} from './serialization';
 describe('Deserialization', () => {
   it('Zeros Initialzer', () => {
     const config: serialization.ConfigDict = {};
-    config.className = 'Zeros';
+    config['className'] = 'Zeros';
     config.config = {};
     const initializer: Zeros = deserialize(config) as Initializer;
     expect(initializer instanceof (Zeros)).toEqual(true);
   });
   it('Ones Initialzer', () => {
     const config: serialization.ConfigDict = {};
-    config.className = 'Ones';
+    config['className'] = 'Ones';
     config.config = {};
     const initializer: Ones = deserialize(config) as Initializer;
     expect(initializer instanceof (Ones)).toEqual(true);

--- a/src/layers/wrappers.ts
+++ b/src/layers/wrappers.ts
@@ -304,14 +304,14 @@ export class Bidirectional extends Wrapper {
     //   methods.
     const layerConfig = args.layer.getConfig();
     const forwDict: serialization.ConfigDict = {};
-    forwDict.className = args.layer.getClassName();
-    forwDict.config = layerConfig;
+    forwDict['className'] = args.layer.getClassName();
+    forwDict['config'] = layerConfig;
     this.forwardLayer = deserialize(forwDict) as RNN;
     layerConfig['goBackwards'] =
         layerConfig['goBackwards'] === true ? false : true;
     const backDict: serialization.ConfigDict = {};
-    backDict.className = args.layer.getClassName();
-    backDict.config = layerConfig;
+    backDict['className'] = args.layer.getClassName();
+    backDict['config'] = layerConfig;
     this.backwardLayer = deserialize(backDict) as RNN;
     this.forwardLayer.name = 'forward_' + this.forwardLayer.name;
     this.backwardLayer.name = 'backward_' + this.backwardLayer.name;

--- a/src/models.ts
+++ b/src/models.ts
@@ -1033,8 +1033,8 @@ export class Sequential extends LayersModel {
     const config: serialization.ConfigDict[] = [];
     for (const layer of this.layers) {
       const dict: serialization.ConfigDict = {};
-      dict.className = layer.getClassName();
-      dict.config = layer.getConfig();
+      dict['className'] = layer.getClassName();
+      dict['config'] = layer.getConfig();
       config.push(dict);
     }
     return config;

--- a/src/regularizers.ts
+++ b/src/regularizers.ts
@@ -94,7 +94,7 @@ export class L1L2 extends Regularizer {
   static fromConfig<T extends serialization.Serializable>(
       cls: serialization.SerializableConstructor<T>,
       config: serialization.ConfigDict): T {
-    return new cls({l1: config.l1 as number, l2: config.l2 as number});
+    return new cls({l1: config['l1'] as number, l2: config['l2'] as number});
   }
 }
 serialization.registerClass(L1L2);

--- a/src/regularizers_test.ts
+++ b/src/regularizers_test.ts
@@ -82,7 +82,7 @@ describeMathCPU('Regularizer Serialization', () => {
     const reconstituted = deserializeRegularizer(config);
     const roundTripConfig =
         serializeRegularizer(reconstituted) as serialization.ConfigDict;
-    expect(roundTripConfig.className).toEqual('L1L2');
+    expect(roundTripconfig['className']).toEqual('L1L2');
     const nestedConfig = roundTripConfig.config as serialization.ConfigDict;
     expect(nestedConfig.l1).toEqual(1);
     expect(nestedConfig.l2).toEqual(2);

--- a/src/regularizers_test.ts
+++ b/src/regularizers_test.ts
@@ -82,7 +82,7 @@ describeMathCPU('Regularizer Serialization', () => {
     const reconstituted = deserializeRegularizer(config);
     const roundTripConfig =
         serializeRegularizer(reconstituted) as serialization.ConfigDict;
-    expect(roundTripconfig['className']).toEqual('L1L2');
+    expect(roundTripConfig.className).toEqual('L1L2');
     const nestedConfig = roundTripConfig.config as serialization.ConfigDict;
     expect(nestedConfig.l1).toEqual(1);
     expect(nestedConfig.l2).toEqual(2);

--- a/src/utils/generic_utils.ts
+++ b/src/utils/generic_utils.ts
@@ -223,13 +223,13 @@ export function deserializeKerasObject(
   } else {
     // In this case we are dealing with a Keras config dictionary.
     const config = identifier;
-    if (config.className == null || config.config == null) {
+    if (config['className'] == null || config.config == null) {
       throw new ValueError(
           `${printableModuleName}: Improper config format: ` +
           `${JSON.stringify(config)}.\n` +
           `'className' and 'config' must set.`);
     }
-    const className = config.className as string;
+    const className = config['className'] as string;
     let cls, fromConfig;
     if (className in customObjects) {
       [cls, fromConfig] = customObjects.get(className);

--- a/src/utils/generic_utils.ts
+++ b/src/utils/generic_utils.ts
@@ -140,8 +140,8 @@ export function serializeKerasObject(instance: serialization.Serializable):
     return null;
   }
   const dict: serialization.ConfigDictValue = {};
-  dict.className = instance.getClassName();
-  dict.config = instance.getConfig();
+  dict['className'] = instance.getClassName();
+  dict['config'] = instance.getConfig();
   return dict;
 }
 
@@ -223,7 +223,7 @@ export function deserializeKerasObject(
   } else {
     // In this case we are dealing with a Keras config dictionary.
     const config = identifier;
-    if (config['className'] == null || config.config == null) {
+    if (config['className'] == null || config['config'] == null) {
       throw new ValueError(
           `${printableModuleName}: Improper config format: ` +
           `${JSON.stringify(config)}.\n` +
@@ -232,9 +232,9 @@ export function deserializeKerasObject(
     const className = config['className'] as string;
     let cls, fromConfig;
     if (className in customObjects) {
-      [cls, fromConfig] = customObjects.get(className);
+      [cls, fromConfig] = customObjects[className];
     } else if (className in _GLOBAL_CUSTOM_OBJECTS) {
-      [cls, fromConfig] = _GLOBAL_CUSTOM_OBJECTS.className;
+      [cls, fromConfig] = _GLOBAL_CUSTOM_OBJECTS['className'];
     } else if (className in moduleObjects) {
       [cls, fromConfig] = moduleObjects[className];
     }
@@ -253,8 +253,8 @@ export function deserializeKerasObject(
     if (fromConfig != null) {
       // Porting notes: Instead of checking to see whether fromConfig accepts
       // customObjects, we create a customObjects dictionary and tack it on to
-      // config.config as config.config.customObjects. Objects can use it, if
-      // they want.
+      // config['config'] as config['config'].customObjects. Objects can use it,
+      // if they want.
 
       // tslint:disable-next-line:no-any
       const customObjectsCombined = {} as {[objName: string]: any};
@@ -265,16 +265,16 @@ export function deserializeKerasObject(
         customObjectsCombined[key] = customObjects[key];
       }
       // Add the customObjects to config
-      const nestedConfig = config.config as serialization.ConfigDict;
-      nestedConfig.customObjects = customObjectsCombined;
+      const nestedConfig = config['config'] as serialization.ConfigDict;
+      nestedConfig['customObjects'] = customObjectsCombined;
 
       const backupCustomObjects = {..._GLOBAL_CUSTOM_OBJECTS};
       for (const key of Object.keys(customObjects)) {
         _GLOBAL_CUSTOM_OBJECTS[key] = customObjects[key];
       }
-      convertNDArrayScalarsInConfig(config.config);
+      convertNDArrayScalarsInConfig(config['config']);
       const returnObj =
-          fromConfig(cls, config.config, customObjects, fastWeightInit);
+          fromConfig(cls, config['config'], customObjects, fastWeightInit);
       _GLOBAL_CUSTOM_OBJECTS = {...backupCustomObjects};
 
       return returnObj;
@@ -289,7 +289,7 @@ export function deserializeKerasObject(
       // In python this is **config['config'], for tfjs-layers we require
       // classes that use this fall-through construction method to take
       // a config interface that mimics the expansion of named parameters.
-      const returnObj = new cls(config.config);
+      const returnObj = new cls(config['config']);
       _GLOBAL_CUSTOM_OBJECTS = {...backupCustomObjects};
       return returnObj;
     }

--- a/src/version.ts
+++ b/src/version.ts
@@ -9,5 +9,5 @@
  */
 
 // This code is auto-generated, do not modify this file!
-const version = '1.0.2';
+const version = '1.0.3';
 export {version};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@tensorflow/tfjs-core@1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.0.2.tgz#98be72677eccf367b71115067d9c498517da0f89"
-  integrity sha512-SJ7HdFfQ9jcDgyj4mMqU5kvfy5yy3X7cuixHrN7cAmlnCcaIVx732HIBHo+krepLMhlCPaMbR3xN2YJmmF5L8A==
+"@tensorflow/tfjs-core@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.0.3.tgz#344f3fb1ed43c43b0e19e5e2764677770fd7a085"
+  integrity sha512-2UbjMQkmrykIIZuoRfmDPrtWm+6fdQRlYLCUJdiOIooeu/q4nye587HM1qKcdZosGPZTW6VvX+4VIVieYn5i0A==
   dependencies:
     "@types/seedrandom" "2.4.27"
     "@types/webgl-ext" "0.0.30"


### PR DESCRIPTION
Mostly this converts accesses on Config objects to use string indexing (so the fields don't get rewritten by closure).

In the future I'll add typescript rules to the libraries so we catch these sooner.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/508)
<!-- Reviewable:end -->
