### PR TITLE
Fix documentation of tf.LayerModel.fitDataset()

### DIFF
--- a/src/engine/training_dataset.ts
+++ b/src/engine/training_dataset.ts
@@ -74,8 +74,7 @@ export interface ModelFitDatasetArgs<T> {
    *   - Similarly, an array ` [xVal, yVal, valSampleWeights]`
    *     (not implemented yet).
    *   - a `Dataset` object with elements of the form `{xs: xVal, ys: yVal}`,
-   *     where the two values may be `tf.Tensor`, an array of Tensors, or a map
-   *     of string to Tensor.
+   *     where `xs` and `ys` are the feature and label tensors, respectively.
    *
    * If `validationData` is an Array of Tensor objects, each `tf.Tensor` will be
    * sliced into batches during validation, using the parameter

--- a/src/models.ts
+++ b/src/models.ts
@@ -889,14 +889,46 @@ export class Sequential extends LayersModel {
    *   generate a dataset iterator object, the `next()` method of which is
    *   expected to produce data batches for evaluation. The return value of the
    *   `next()` call ought to contain a boolean `done` field and a `value`
-   *   field. The `value` field is expected to be an object of with fields
+   *   field.
+   *
+   *   The `value` field is expected to be an object of with fields
    *   `xs` and `ys`, which point to the feature tensor and the target tensor,
    *   respectively. This case is for models with exactly one input and one
-   *   output (e.g.. a sequential model).
+   *   output (e.g.. a sequential model). For example:
+   *   ```js
+   *   {value: {xs: xsTensor, ys: ysTensor}, done: false}
+   *   ```
+   *
    *   If the model has multiple inputs, the `xs` field of `value` should
    *   be an object mapping input names to their respective feature tensors.
+   *   For example:
+   *   ```js
+   *   {
+   *     value: {
+   *       xs: {
+   *         input_1: xsTensor1,
+   *         input_2: xsTensor2
+   *       },
+   *       ys: ysTensor
+   *     },
+   *     done: false
+   *   }
+   *   ```
    *   If the model has multiple outputs, the `ys` field of `value` should
    *   be an object mapping output names to their respective target tensors.
+   *   For example:
+   *   ```js
+   *   {
+   *     value: {
+   *       xs: xsTensor,
+   *       ys: {
+   *         output_1: ysTensor1,
+   *         output_2: ysTensor2
+   *       },
+   *     },
+   *     done: false
+   *   }
+   *   ```
    * @param args A `ModelFitDatasetArgs`, containing optional fields.
    *
    * @return A `History` instance. Its `history` attribute contains all

--- a/src/models.ts
+++ b/src/models.ts
@@ -889,12 +889,14 @@ export class Sequential extends LayersModel {
    *   generate a dataset iterator object, the `next()` method of which is
    *   expected to produce data batches for evaluation. The return value of the
    *   `next()` call ought to contain a boolean `done` field and a `value`
-   *   field. The `value` field is expected to be an array of two `tf.Tensor`s
-   *   or an array of two nested `tf.Tensor` structures. The former case is for
-   *   models with exactly one input and one output (e.g.. a sequential model).
-   *   The latter case is for models with multiple inputs and/or multiple
-   *   outputs. Of the two items in the array, the first is the input feature(s)
-   *   and the second is the output target(s).
+   *   field. The `value` field is expected to be an object of with fields
+   *   `xs` and `ys`, which point to the feature tensor and the target tensor,
+   *   respectively. This case is for models with exactly one input and one output
+   *   (e.g.. a sequential model).
+   *   If the model has multiple inputs, the `xs` field of `value` should
+   *   be an object mapping input names to their respective feature tensors.
+   *   If the model has multiple outputs, the `ys` field of `value` should
+   *   be an object mapping output names to their respective target tensors.
    * @param args A `ModelFitDatasetArgs`, containing optional fields.
    *
    * @return A `History` instance. Its `history` attribute contains all

--- a/src/models.ts
+++ b/src/models.ts
@@ -891,8 +891,8 @@ export class Sequential extends LayersModel {
    *   `next()` call ought to contain a boolean `done` field and a `value`
    *   field. The `value` field is expected to be an object of with fields
    *   `xs` and `ys`, which point to the feature tensor and the target tensor,
-   *   respectively. This case is for models with exactly one input and one output
-   *   (e.g.. a sequential model).
+   *   respectively. This case is for models with exactly one input and one
+   *   output (e.g.. a sequential model).
    *   If the model has multiple inputs, the `xs` field of `value` should
    *   be an object mapping input names to their respective feature tensors.
    *   If the model has multiple outputs, the `ys` field of `value` should


### PR DESCRIPTION
Update the output-of-date array format to the update-to-date
`{xs, ys}` format.

DOC

Fixes: https://github.com/tensorflow/tfjs/issues/1446

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/509)
<!-- Reviewable:end -->
