### PR TITLE
Remove getScalar().

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -39,7 +39,7 @@ module.exports = function(config) {
     },
     karmaTypescriptConfig,
     reporters: ['progress', 'karma-typescript'],
-    browsers: ['Chrome', 'Firefox'],
+    browsers: ['Chrome'],
     browserStack: {
       username: process.env.BROWSERSTACK_USERNAME,
       accessKey: process.env.BROWSERSTACK_KEY

--- a/src/activations.ts
+++ b/src/activations.ts
@@ -11,7 +11,6 @@
 // Layer activation functions
 import * as tfc from '@tensorflow/tfjs-core';
 import {serialization, Tensor, tidy} from '@tensorflow/tfjs-core';
-import {getScalar} from './backend/state';
 import * as K from './backend/tfjs_backend';
 import {ActivationIdentifier} from './keras_format/activation_config';
 import {deserializeKerasObject} from './utils/generic_utils';
@@ -85,7 +84,7 @@ export class Relu6 extends Activation {
   /** @nocollapse */
   static readonly className = 'relu6';
   apply(x: Tensor): Tensor {
-    return tidy(() => tfc.minimum(getScalar(6.0), tfc.relu(x)));
+    return tidy(() => tfc.minimum(6.0, tfc.relu(x)));
   }
 }
 serialization.registerClass(Relu6);

--- a/src/backend/state.ts
+++ b/src/backend/state.ts
@@ -12,8 +12,6 @@
  * Utilities related to persistent state in the backend.
  */
 
-import {DataType, keep, Scalar, scalar} from '@tensorflow/tfjs-core';
-
 /**
  * An ID to track `tf.SymbolicTensor`s and derived classes.
  * Required in different places in engine/topology.ts to identify unique
@@ -38,34 +36,4 @@ export function getUid(prefix = ''): string {
   }
   _uidPrefixes[prefix] += 1;
   return prefix + _uidPrefixes[prefix].toString();
-}
-
-const scalarCache: {[typeKey: string]: {[key: number]: Scalar}} = {};
-
-const DEFAULT_DTYPE: DataType = 'float32';
-
-/**
- * Get scalar, with caching.
- */
-export function getScalar(value: number, dtype?: DataType): Scalar {
-  if (dtype === undefined) {
-    dtype = DEFAULT_DTYPE;
-  }
-  if (scalarCache[dtype] == null) {
-    scalarCache[dtype] = {};
-  }
-  if (scalarCache[dtype][value] == null) {
-    scalarCache[dtype][value] = scalar(value, dtype);
-    keep(scalarCache[dtype][value]);
-  }
-  return scalarCache[dtype][value];
-}
-
-export function disposeScalarCache() {
-  for (const typeKey in scalarCache) {
-    for (const key in scalarCache[typeKey]) {
-      scalarCache[typeKey][key].dispose();
-      delete scalarCache[typeKey][key];
-    }
-  }
 }

--- a/src/backend/tfjs_backend.ts
+++ b/src/backend/tfjs_backend.ts
@@ -13,8 +13,7 @@
  */
 
 import * as tfc from '@tensorflow/tfjs-core';
-import {onesLike as coreOnesLike, Scalar, scalar, Tensor, Tensor1D, tensor1d, Tensor2D, Tensor3D, Tensor4D, tidy, util, where, zerosLike as coreZerosLike} from '@tensorflow/tfjs-core';
-import {disposeScalarCache} from '../backend/state';
+import {onesLike as coreOnesLike, scalar, Tensor, Tensor1D, tensor1d, Tensor2D, Tensor3D, Tensor4D, tidy, util, where, zerosLike as coreZerosLike} from '@tensorflow/tfjs-core';
 import {checkDataFormat} from '../common';
 import {NotImplementedError, ValueError} from '../errors';
 import {DataFormat, Shape} from '../keras_format/common';
@@ -33,7 +32,6 @@ let backend: 'cpu'|'webgl' = 'webgl';
 export function setBackend(requestedBackend: 'cpu'|'webgl') {
   tfc.setBackend(requestedBackend);
   backend = requestedBackend;
-  disposeScalarCache();
 }
 
 export function getBackend(): 'cpu'|'webgl' {
@@ -667,7 +665,7 @@ export function softsign(x: Tensor): Tensor {
  * @returns Result of the dropout operation.
  */
 export function dropout(
-    x: Tensor, level: Scalar, noiseShape?: number[], seed?: number): Tensor {
+    x: Tensor, level: number, noiseShape?: number[], seed?: number): Tensor {
   return tidy(() => {
     // TODO(cais): Switch to deeplearn.js implementation of dropout when it
     //   becomes avaialable.
@@ -679,10 +677,10 @@ export function dropout(
     if (seed != null) {
       throw new NotImplementedError('seed is not implemented for dropout yet.');
     }
-    let multiplier = tfc.step(tfc.add(
-        tfc.neg(level) as Scalar, tfc.randomUniform(x.shape, 0, 1, 'float32')));
+    let multiplier =
+        tfc.step(tfc.add(-level, tfc.randomUniform(x.shape, 0, 1, 'float32')));
     // Scale the kept elements, so the expected sum is unchanged.
-    multiplier = tfc.mul(tfc.div(1, tfc.sub(1, level)) as Scalar, multiplier);
+    multiplier = tfc.mul(1 / (1 - level), multiplier);
     return tfc.mul(x, multiplier);
   });
 }

--- a/src/backend/tfjs_backend.ts
+++ b/src/backend/tfjs_backend.ts
@@ -14,7 +14,7 @@
 
 import * as tfc from '@tensorflow/tfjs-core';
 import {onesLike as coreOnesLike, Scalar, scalar, Tensor, Tensor1D, tensor1d, Tensor2D, Tensor3D, Tensor4D, tidy, util, where, zerosLike as coreZerosLike} from '@tensorflow/tfjs-core';
-import {disposeScalarCache, getScalar} from '../backend/state';
+import {disposeScalarCache} from '../backend/state';
 import {checkDataFormat} from '../common';
 import {NotImplementedError, ValueError} from '../errors';
 import {DataFormat, Shape} from '../keras_format/common';
@@ -466,7 +466,7 @@ export function sign(x: Tensor): Tensor {
         tfc.equal(x, zerosLikeX), zerosLikeX,
         where(
             tfc.greater(x, coreZerosLike(x)), onesLikeX,
-            tfc.mul(getScalar(-1), onesLikeX)));
+            tfc.mul(-1, onesLikeX)));
   });
 }
 
@@ -653,7 +653,7 @@ export function elu(x: Tensor, alpha = 1): Tensor {
  * @returns Output.
  */
 export function softsign(x: Tensor): Tensor {
-  return tidy(() => tfc.div(x, tfc.add(getScalar(1), tfc.abs(x))));
+  return tidy(() => tfc.div(x, tfc.abs(x).add(1)));
 }
 
 /**
@@ -682,9 +682,7 @@ export function dropout(
     let multiplier = tfc.step(tfc.add(
         tfc.neg(level) as Scalar, tfc.randomUniform(x.shape, 0, 1, 'float32')));
     // Scale the kept elements, so the expected sum is unchanged.
-    multiplier = tfc.mul(
-        tfc.div(getScalar(1), tfc.sub(getScalar(1), level)) as Scalar,
-        multiplier);
+    multiplier = tfc.mul(tfc.div(1, tfc.sub(1, level)) as Scalar, multiplier);
     return tfc.mul(x, multiplier);
   });
 }
@@ -700,7 +698,7 @@ export function dropout(
  */
 export function hardSigmoid(x: Tensor): Tensor {
   return tidy(() => {
-    const y = tfc.add(getScalar(0.5), tfc.mul(getScalar(0.2), x));
+    const y = tfc.add(.5, tfc.mul(.2, x));
     return tfc.clipByValue(y, 0, 1);
   });
 }

--- a/src/backend/tfjs_backend_test.ts
+++ b/src/backend/tfjs_backend_test.ts
@@ -722,7 +722,7 @@ describeMathCPUAndGPU('dropout', () => {
   for (const dropoutLevel of dropoutLevels) {
     it(`Level = ${dropoutLevel}`, () => {
       const x = tensor2d(range(1, 21), [10, 2]);
-      const y = K.dropout(x, scalar(dropoutLevel));
+      const y = K.dropout(x, dropoutLevel);
       expect(y.dtype).toEqual(x.dtype);
       expect(y.shape).toEqual(x.shape);
       const xValue = x.dataSync();

--- a/src/base_callbacks.ts
+++ b/src/base_callbacks.ts
@@ -12,7 +12,6 @@
 
 import {add, div, keep, mul, nextFrame, Scalar, Tensor, tidy, util} from '@tensorflow/tfjs-core';
 
-import {getScalar} from './backend/state';
 import {Container} from './engine/container';
 import {ValueError} from './errors';
 import {Logs, resolveScalarsInLogs, UnresolvedLogs} from './logs';
@@ -363,11 +362,11 @@ export class BaseLogger extends BaseCallback {
         if (key in this.totals) {
           oldTotalsToDispose = this.totals[key] as Scalar;
         } else {
-          this.totals[key] = getScalar(0);
+          this.totals[key] = 0;
         }
         this.totals[key] = tidy(
-            () => add((this.totals[key] as Scalar),
-                      mul(value, getScalar(batchSize))) as Scalar);
+            () => add((this.totals[key] as Scalar), mul(value, batchSize)) as
+                Scalar);
         if (oldTotalsToDispose != null) {
           oldTotalsToDispose.dispose();
         }
@@ -387,7 +386,7 @@ export class BaseLogger extends BaseCallback {
           logs[key] = this.totals[key] as number / this.seen;
         } else {
           tidy(() => {
-            logs[key] = mul(div(getScalar(1), getScalar(this.seen)) as Scalar,
+            logs[key] = mul(div(1, this.seen) as Scalar,
                             this.totals[key] as Scalar) as Scalar;
             (this.totals[key] as Tensor).dispose();
             keep(logs[key] as Scalar);

--- a/src/constraints.ts
+++ b/src/constraints.ts
@@ -12,9 +12,7 @@
 
 import * as tfc from '@tensorflow/tfjs-core';
 import {serialization, Tensor, tidy} from '@tensorflow/tfjs-core';
-
 import {epsilon} from './backend/common';
-import {getScalar} from './backend/state';
 import {deserializeKerasObject, serializeKerasObject} from './utils/generic_utils';
 
 /**
@@ -94,7 +92,7 @@ export class MaxNorm extends Constraint {
     return tidy(() => {
       const norms = calcL2Norms(w, this.axis);
       const desired = tfc.clipByValue(norms, 0, this.maxValue);
-      return tfc.mul(w, tfc.div(desired, tfc.add(getScalar(epsilon()), norms)));
+      return tfc.mul(w, tfc.div(desired, tfc.add(epsilon(), norms)));
     });
   }
 
@@ -137,8 +135,7 @@ export class UnitNorm extends Constraint {
 
   apply(w: Tensor): Tensor {
     return tidy(
-        () => tfc.div(
-            w, tfc.add(getScalar(epsilon()), calcL2Norms(w, this.axis))));
+        () => tfc.div(w, tfc.add(epsilon(), calcL2Norms(w, this.axis))));
   }
 
   getConfig(): serialization.ConfigDict {
@@ -221,10 +218,9 @@ export class MinMaxNorm extends Constraint {
       const norms = calcL2Norms(w, this.axis);
       const desired = tfc.add(
           tfc.mul(
-              getScalar(this.rate),
-              tfc.clipByValue(norms, this.minValue, this.maxValue)),
-          tfc.mul(getScalar(1.0 - this.rate), norms));
-      return tfc.mul(w, tfc.div(desired, tfc.add(getScalar(epsilon()), norms)));
+              this.rate, tfc.clipByValue(norms, this.minValue, this.maxValue)),
+          tfc.mul(1.0 - this.rate, norms));
+      return tfc.mul(w, tfc.div(desired, tfc.add(epsilon(), norms)));
     });
   }
 

--- a/src/engine/container_test.ts
+++ b/src/engine/container_test.ts
@@ -680,7 +680,7 @@ describeMathCPUAndGPU('LayersModel-dispose', () => {
 
     const result = model.dispose();
     expect(result.refCountAfterDispose).toEqual(0);
-    expect(result.numDisposedVariables).toEqual(5);
+    expect(result.numDisposedVariables).toEqual(4);
     // The four weight variables of the two layers should have been disposed.
     // + the rate from the dropout tensor
     expect(memory().numTensors).toEqual(numTensors0);

--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -11,9 +11,7 @@
 /* Original Source: engine/training.py */
 
 import * as tfc from '@tensorflow/tfjs-core';
-import {io, ModelPredictConfig as ModelPredictArgs, NamedTensorMap, Optimizer, Scalar, serialization, Tensor, Tensor1D, tensor1d, util} from '@tensorflow/tfjs-core';
-
-import {getScalar} from '../backend/state';
+import {io, ModelPredictConfig as ModelPredictArgs, NamedTensorMap, Optimizer, Scalar, scalar, serialization, Tensor, Tensor1D, tensor1d, util} from '@tensorflow/tfjs-core';
 import * as K from '../backend/tfjs_backend';
 import {History, ModelLoggingVerbosity} from '../base_callbacks';
 import {nameScope} from '../common';
@@ -1189,20 +1187,18 @@ export class LayersModel extends Container implements tfc.InferenceModel {
           const batchOuts = f(insBatch);
           if (batchIndex === 0) {
             for (let i = 0; i < batchOuts.length; ++i) {
-              outs.push(getScalar(0));
+              outs.push(scalar(0));
             }
           }
           for (let i = 0; i < batchOuts.length; ++i) {
             const batchOut = batchOuts[i];
             outs[i] =
-                tfc.add(
-                    outs[i],
-                    tfc.mul(getScalar(batchEnd - batchStart), batchOut)) as
+                tfc.add(outs[i], tfc.mul(batchEnd - batchStart, batchOut)) as
                 Scalar;
           }
         }
         for (let i = 0; i < outs.length; ++i) {
-          outs[i] = tfc.div(outs[i], getScalar(numSamples)) as Scalar;
+          outs[i] = tfc.div(outs[i], numSamples) as Scalar;
         }
       }
       return outs;

--- a/src/engine/training_dataset.ts
+++ b/src/engine/training_dataset.ts
@@ -503,7 +503,7 @@ export async function evaluateDataset<T>(
   args = args || {};
   const hasBatches = args.batches != null;
   const f = model.testFunction;
-  const outs: tfc.Scalar[] = [];
+  let outs: tfc.Scalar[] = [];
   if (args.verbose > 0) {
     throw new NotImplementedError('Verbose mode is not implemented yet.');
   }
@@ -518,35 +518,42 @@ export async function evaluateDataset<T>(
   // Keeps track of number of examples used in this evaluation.
   let numExamples = 0;
   let batch = 0;
+
   while (hasBatches ? batch < args.batches : true) {
     const iteratorOut = await dataIterator.next();
-    if (iteratorOut.value) {
-      // TODO(cais): Once real dataset is available, use
-      //   `map(x => standardizeDataIteratorOutput(model, x).map(f)`.
-      const xsAndYs = standardizeDataIteratorOutput(model, iteratorOut.value);
-      const batchOuts = tfc.tidy(() => f(xsAndYs));
-      tfc.dispose(xsAndYs);
+    outs = tfc.tidy(() => {
+      if (iteratorOut.value) {
+        // TODO(cais): Once real dataset is available, use
+        //   `map(x => standardizeDataIteratorOutput(model, x).map(f)`.
+        const xsAndYs = standardizeDataIteratorOutput(model, iteratorOut.value);
+        const batchOuts = tfc.tidy(() => f(xsAndYs));
+        tfc.dispose(xsAndYs);
 
-      if (batch === 0) {
+        if (batch === 0) {
+          for (let i = 0; i < batchOuts.length; ++i) {
+            outs.push(scalar(0));
+          }
+        }
+
+        const batchSize = xsAndYs[0].shape[0];
         for (let i = 0; i < batchOuts.length; ++i) {
-          outs.push(scalar(0));
+          const batchOut = batchOuts[i];
+          const oldScalar = outs[i];
+          outs[i] = tfc.tidy(
+              () =>
+                  tfc.add(outs[i], tfc.mul(batchSize, batchOut)) as tfc.Scalar);
+          if (batch > 0) {
+            tfc.dispose(oldScalar);
+          }
         }
-      }
-      const batchSize = xsAndYs[0].shape[0];
-      for (let i = 0; i < batchOuts.length; ++i) {
-        const batchOut = batchOuts[i];
-        const oldScalar = outs[i];
-        outs[i] = tfc.tidy(
-            () => tfc.add(outs[i], tfc.mul(batchSize, batchOut)) as tfc.Scalar);
-        if (batch > 0) {
-          tfc.dispose(oldScalar);
-        }
-      }
-      tfc.dispose(batchOuts);
-      numExamples += batchSize;
+        tfc.dispose(batchOuts);
+        numExamples += batchSize;
 
-      ++batch;
-    }
+        ++batch;
+      }
+      return outs;
+    });
+
     if (iteratorOut.done) {
       if (hasBatches) {
         console.warn(
@@ -560,9 +567,10 @@ export async function evaluateDataset<T>(
       break;
     }
   }
+
   for (let i = 0; i < outs.length; ++i) {
     const oldScalar = outs[i];
-    outs[i] = tfc.tidy(() => tfc.div(outs[i], numExamples) as tfc.Scalar);
+    outs[i] = tfc.div(outs[i], numExamples);
     tfc.dispose(oldScalar);
   }
 

--- a/src/engine/training_dataset.ts
+++ b/src/engine/training_dataset.ts
@@ -13,7 +13,7 @@
  */
 
 import * as tfc from '@tensorflow/tfjs-core';
-
+import {scalar} from '@tensorflow/tfjs-core';
 import {BaseCallback, configureCallbacks, CustomCallbackArgs, History, ModelLoggingVerbosity, standardizeCallbacks, YieldEveryOptions} from '../base_callbacks';
 import {NotImplementedError, ValueError} from '../errors';
 import {disposeTensorsInLogs, UnresolvedLogs} from '../logs';
@@ -529,7 +529,7 @@ export async function evaluateDataset<T>(
 
       if (batch === 0) {
         for (let i = 0; i < batchOuts.length; ++i) {
-          outs.push(0);
+          outs.push(scalar(0));
         }
       }
       const batchSize = xsAndYs[0].shape[0];

--- a/src/engine/training_dataset.ts
+++ b/src/engine/training_dataset.ts
@@ -14,7 +14,6 @@
 
 import * as tfc from '@tensorflow/tfjs-core';
 
-import {getScalar} from '../backend/state';
 import {BaseCallback, configureCallbacks, CustomCallbackArgs, History, ModelLoggingVerbosity, standardizeCallbacks, YieldEveryOptions} from '../base_callbacks';
 import {NotImplementedError, ValueError} from '../errors';
 import {disposeTensorsInLogs, UnresolvedLogs} from '../logs';
@@ -530,7 +529,7 @@ export async function evaluateDataset<T>(
 
       if (batch === 0) {
         for (let i = 0; i < batchOuts.length; ++i) {
-          outs.push(getScalar(0));
+          outs.push(0);
         }
       }
       const batchSize = xsAndYs[0].shape[0];
@@ -538,8 +537,7 @@ export async function evaluateDataset<T>(
         const batchOut = batchOuts[i];
         const oldScalar = outs[i];
         outs[i] = tfc.tidy(
-            () => tfc.add(outs[i], tfc.mul(getScalar(batchSize), batchOut)) as
-                tfc.Scalar);
+            () => tfc.add(outs[i], tfc.mul(batchSize, batchOut)) as tfc.Scalar);
         if (batch > 0) {
           tfc.dispose(oldScalar);
         }
@@ -564,8 +562,7 @@ export async function evaluateDataset<T>(
   }
   for (let i = 0; i < outs.length; ++i) {
     const oldScalar = outs[i];
-    outs[i] =
-        tfc.tidy(() => tfc.div(outs[i], getScalar(numExamples)) as tfc.Scalar);
+    outs[i] = tfc.tidy(() => tfc.div(outs[i], numExamples) as tfc.Scalar);
     tfc.dispose(oldScalar);
   }
 

--- a/src/initializers.ts
+++ b/src/initializers.ts
@@ -8,9 +8,8 @@
  * =============================================================================
  */
 
-import {DataType, eye, linalg, mul, ones, randomUniform, scalar, Scalar, serialization, Tensor, Tensor2D, tidy, truncatedNormal, zeros} from '@tensorflow/tfjs-core';
+import {DataType, eye, linalg, mul, ones, randomUniform, scalar, serialization, Tensor, Tensor2D, tidy, truncatedNormal, zeros} from '@tensorflow/tfjs-core';
 
-import {getScalar} from './backend/state';
 import * as K from './backend/tfjs_backend';
 import {checkDataFormat} from './common';
 import {NotImplementedError, ValueError} from './errors';
@@ -262,10 +261,10 @@ export interface IdentityArgs {
 export class Identity extends Initializer {
   /** @nocollapse */
   static className = 'Identity';
-  private gain: Scalar;
+  private gain: number;
   constructor(args: IdentityArgs) {
     super();
-    this.gain = args.gain != null ? scalar(args.gain) : getScalar(1.0);
+    this.gain = args.gain != null ? args.gain : 1.0;
   }
 
   apply(shape: Shape, dtype?: DataType): Tensor {
@@ -281,7 +280,7 @@ export class Identity extends Initializer {
   }
 
   getConfig(): serialization.ConfigDict {
-    return {gain: this.gain.dataSync()[0]};
+    return {gain: this.gain};
   }
 }
 serialization.registerClass(Identity);
@@ -676,7 +675,7 @@ export class Orthogonal extends Initializer {
       if (shape[0] > shape[1]) {
         q = q.transpose();
       }
-      return mul(getScalar(this.gain), q);
+      return mul(this.gain, q);
     });
   }
 

--- a/src/layers/advanced_activations.ts
+++ b/src/layers/advanced_activations.ts
@@ -15,7 +15,6 @@
 import {clipByValue, elu, leakyRelu, prelu, relu, serialization, Tensor} from '@tensorflow/tfjs-core';
 
 import {Softmax as softmaxActivation} from '../activations';
-import {getScalar} from '../backend/state';
 import {cast} from '../backend/tfjs_backend';
 import {Constraint, getConstraint, serializeConstraint} from '../constraints';
 import {InputSpec, Layer, LayerArgs} from '../engine/topology';
@@ -349,7 +348,6 @@ export class ThresholdedReLU extends Layer {
   /** @nocollapse */
   static className = 'ThresholdedReLU';
   readonly theta: number;
-  private readonly thetaTensor: Tensor;
 
   readonly DEFAULT_THETA = 1.0;
 
@@ -360,12 +358,11 @@ export class ThresholdedReLU extends Layer {
     }
 
     this.theta = args.theta == null ? this.DEFAULT_THETA : args.theta;
-    this.thetaTensor = getScalar(this.theta);
   }
 
   call(inputs: Tensor|Tensor[], kwargs: Kwargs): Tensor|Tensor[] {
     const x = getExactlyOneTensor(inputs);
-    return x.mul(cast(x.greater(this.thetaTensor), 'float32'));
+    return x.mul(cast(x.greater(this.theta), 'float32'));
   }
 
   computeOutputShape(inputShape: Shape|Shape[]): Shape|Shape[] {

--- a/src/layers/merge.ts
+++ b/src/layers/merge.ts
@@ -14,8 +14,6 @@
 
 import * as tfc from '@tensorflow/tfjs-core';
 import {serialization, Tensor, tidy, util} from '@tensorflow/tfjs-core';
-
-import {getScalar} from '../backend/state';
 import * as K from '../backend/tfjs_backend';
 import {Layer, LayerArgs, SymbolicTensor} from '../engine/topology';
 import {NotImplementedError, ValueError} from '../errors';
@@ -477,7 +475,7 @@ export class Average extends Merge {
       for (let i = 1; i < inputs.length; ++i) {
         output = tfc.add(output, inputs[i]);
       }
-      return tfc.mul(getScalar(1 / inputs.length), output);
+      return tfc.mul(1 / inputs.length, output);
     });
   }
 }

--- a/src/layers/normalization.ts
+++ b/src/layers/normalization.ts
@@ -14,8 +14,6 @@
 
 import * as tfc from '@tensorflow/tfjs-core';
 import {serialization, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D, tidy, util} from '@tensorflow/tfjs-core';
-
-import {getScalar} from '../backend/state';
 import {Constraint, ConstraintIdentifier, getConstraint, serializeConstraint} from '../constraints';
 import {InputSpec, Layer, LayerArgs} from '../engine/topology';
 import {NotImplementedError, ValueError} from '../errors';
@@ -397,7 +395,7 @@ export class BatchNormalization extends Layer {
       const doMovingAverage =
           (variable: LayerVariable, value: Tensor, momentum: number): void => {
             tfc.tidy(() => {
-              const decay = getScalar(1.0).sub(getScalar(momentum));
+              const decay = 1 - momentum;
               const origValue = variable.read();
               const updateDelta = origValue.sub(value).mul(decay);
               variable.write(origValue.sub(updateDelta));

--- a/src/layers/recurrent.ts
+++ b/src/layers/recurrent.ts
@@ -16,7 +16,6 @@ import * as tfc from '@tensorflow/tfjs-core';
 import {DataType, serialization, Tensor, tidy, util} from '@tensorflow/tfjs-core';
 
 import {Activation, getActivation, serializeActivation} from '../activations';
-import {getScalar} from '../backend/state';
 import * as K from '../backend/tfjs_backend';
 import {Constraint, ConstraintIdentifier, getConstraint, serializeConstraint} from '../constraints';
 import {InputSpec, SymbolicTensor} from '../engine/topology';
@@ -1650,8 +1649,8 @@ export class GRUCell extends RNNCell {
       const recurrentH = K.dot(tfc.mul(r, hTMinus1), rk2);
       hh = this.activation.apply(tfc.add(xH, recurrentH));
 
-      const h = tfc.add(
-          tfc.mul(z, hTMinus1), tfc.mul(tfc.add(getScalar(1), tfc.neg(z)), hh));
+      const h =
+          tfc.add(tfc.mul(z, hTMinus1), tfc.mul(tfc.add(1, tfc.neg(z)), hh));
       // TODO(cais): Add use_learning_phase flag properly.
       return [h, h];
     });
@@ -2545,7 +2544,7 @@ function generateDropoutMask(
     ones: () => Tensor, rate: number, training: boolean = null,
     count = 1): Tensor|Tensor[] {
   function droppedInputs(): Tensor {
-    return K.dropout(ones(), getScalar(rate));
+    return K.dropout(ones(), rate);
   }
   if (count > 1) {
     const mask: Tensor[] = [];

--- a/src/layers/wrappers.ts
+++ b/src/layers/wrappers.ts
@@ -14,8 +14,6 @@
 
 import * as tfc from '@tensorflow/tfjs-core';
 import {serialization, Tensor, tidy} from '@tensorflow/tfjs-core';
-
-import {getScalar} from '../backend/state';
 import * as K from '../backend/tfjs_backend';
 import {nameScope} from '../common';
 import {InputSpec, Layer, LayerArgs, SymbolicTensor} from '../engine/topology';
@@ -523,7 +521,7 @@ export class Bidirectional extends Wrapper {
       } else if (this.mergeMode === 'sum') {
         output = tfc.add(y as Tensor, yRev as Tensor);
       } else if (this.mergeMode === 'ave') {
-        output = tfc.mul(getScalar(0.5), tfc.add(y as Tensor, yRev as Tensor));
+        output = tfc.mul(.5, tfc.add(y as Tensor, yRev as Tensor));
       } else if (this.mergeMode === 'mul') {
         output = tfc.mul(y as Tensor, yRev as Tensor);
       } else if (this.mergeMode == null) {

--- a/src/regularizers.ts
+++ b/src/regularizers.ts
@@ -12,8 +12,6 @@
 
 import * as tfc from '@tensorflow/tfjs-core';
 import {abs, add, Scalar, serialization, sum, Tensor, tidy, zeros} from '@tensorflow/tfjs-core';
-
-import {getScalar} from './backend/state';
 import * as K from './backend/tfjs_backend';
 import {deserializeKerasObject, serializeKerasObject} from './utils/generic_utils';
 
@@ -52,20 +50,17 @@ export class L1L2 extends Regularizer {
   /** @nocollapse */
   static className = 'L1L2';
 
-  private readonly l1: Scalar;
-  private readonly l2: Scalar;
+  private readonly l1: number;
+  private readonly l2: number;
   private readonly hasL1: boolean;
   private readonly hasL2: boolean;
   constructor(args?: L1L2Args) {
     super();
 
-    const l1 = args == null || args.l1 == null ? 0.01 : args.l1;
-    const l2 = args == null || args.l2 == null ? 0.01 : args.l2;
-    this.hasL1 = l1 !== 0;
-    this.hasL2 = l2 !== 0;
-
-    this.l1 = getScalar(l1);
-    this.l2 = getScalar(l2);
+    this.l1 = args == null || args.l1 == null ? 0.01 : args.l1;
+    this.l2 = args == null || args.l2 == null ? 0.01 : args.l2;
+    this.hasL1 = this.l1 !== 0;
+    this.hasL2 = this.l2 !== 0;
   }
 
   /**
@@ -87,7 +82,7 @@ export class L1L2 extends Regularizer {
   }
 
   getConfig(): serialization.ConfigDict {
-    return {'l1': this.l1.dataSync()[0], 'l2': this.l2.dataSync()[0]};
+    return {'l1': this.l1, 'l2': this.l2};
   }
 
   /** @nocollapse */

--- a/src/utils/test_utils.ts
+++ b/src/utils/test_utils.ts
@@ -14,8 +14,6 @@
 
 import {memory, Tensor, test_util} from '@tensorflow/tfjs-core';
 import {describeWithFlags} from '@tensorflow/tfjs-core/dist/jasmine_util';
-
-import {disposeScalarCache} from '../backend/state';
 import {ValueError} from '../errors';
 
 
@@ -59,9 +57,6 @@ export function expectTensorsValuesInRange(
  */
 export function describeMathCPUAndGPU(testName: string, tests: () => void) {
   describeWithFlags(testName, test_util.ALL_ENVS, () => {
-    beforeEach(() => {
-      disposeScalarCache();
-    });
     tests();
   });
 }
@@ -73,9 +68,6 @@ export function describeMathCPUAndGPU(testName: string, tests: () => void) {
  */
 export function describeMathCPU(testName: string, tests: () => void) {
   describeWithFlags(testName, test_util.CPU_ENVS, () => {
-    beforeEach(() => {
-      disposeScalarCache();
-    });
     tests();
   });
 }
@@ -87,9 +79,6 @@ export function describeMathCPU(testName: string, tests: () => void) {
  */
 export function describeMathGPU(testName: string, tests: () => void) {
   describeWithFlags(testName, test_util.WEBGL_ENVS, () => {
-    beforeEach(() => {
-      disposeScalarCache();
-    });
     tests();
   });
 }


### PR DESCRIPTION
There is no longer any need for this method as we allow passing a number directly to core ops.

Also remove Firefox from local testing (so testing is faster, travis covers ffx).

Fixes https://github.com/tensorflow/tfjs/issues/957

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/513)
<!-- Reviewable:end -->
