### PR TITLE
Fix improper template litteral in topology.ts

### DIFF
--- a/src/engine/topology.ts
+++ b/src/engine/topology.ts
@@ -832,7 +832,7 @@ export abstract class Layer extends serialization.Serializable {
               throw new ValueError(
                   `Input ${inputIndex} is incompatible with layer ` +
                   `${this.name}: expected shape=${spec.shape}, ` +
-                  'found shape=${xShape}.');
+                  `found shape=${x.shape}.`);
             }
           }
         }


### PR DESCRIPTION
The current code yields an error message that is less helpful than intended.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/514)
<!-- Reviewable:end -->
