### PR TITLE
Add reverseSequences option to RNN

### DIFF
--- a/src/layers/recurrent_test.ts
+++ b/src/layers/recurrent_test.ts
@@ -56,7 +56,8 @@ describeMathCPUAndGPU('rnn', () => {
         null /* mask */,
         null /* constants */,
         false /* unroll */,
-        true /* needPerStepOutputs */);
+        true /* needPerStepOutputs */,
+        false /* reverseSequences */);
     const lastOutput = rnnOutputs[0];
     const outputs = rnnOutputs[1];
     const newStates = rnnOutputs[2];
@@ -101,7 +102,8 @@ describeMathCPUAndGPU('rnn', () => {
         null /* mask */,
         null /* constants */,
         false /* unroll */,
-        true /* needPerStepOutputs */);
+        true /* needPerStepOutputs */,
+        false /* reverseSequences */);
     const lastOutput = rnnOutputs[0];
     const outputs = rnnOutputs[1];
     const newStates = rnnOutputs[2];
@@ -153,7 +155,8 @@ describeMathCPUAndGPU('rnn', () => {
         null /* mask */,
         null /* constants */,
         false /* unroll */,
-        true /* needPerStepOutputs */);
+        true /* needPerStepOutputs */,
+        false /* reverseSequences */);
     const lastOutput = rnnOutputs[0];
     const outputs = rnnOutputs[1];
     const newStates = rnnOutputs[2];
@@ -236,6 +239,7 @@ describeMathCPU('RNN-Layer', () => {
     const cell = new RNNCellForTest(5);
     const rnn = tfl.layers.rnn({cell}) as RNN;
     expect(rnn.returnSequences).toEqual(false);
+    expect(rnn.reverseSequences).toEqual(false);
     expect(rnn.returnState).toEqual(false);
     expect(rnn.goBackwards).toEqual(false);
   });
@@ -245,10 +249,12 @@ describeMathCPU('RNN-Layer', () => {
     const rnn = tfl.layers.rnn({
       cell,
       returnSequences: true,
+      reverseSequences: true,
       returnState: true,
-      goBackwards: true
+      goBackwards: true,
     }) as RNN;
     expect(rnn.returnSequences).toEqual(true);
+    expect(rnn.reverseSequences).toEqual(true);
     expect(rnn.returnState).toEqual(true);
     expect(rnn.goBackwards).toEqual(true);
   });

--- a/src/layers/wrappers.ts
+++ b/src/layers/wrappers.ts
@@ -245,7 +245,8 @@ export class TimeDistributed extends Wrapper {
       const rnnOutputs =
           rnn(step, inputs, [], false /* goBackwards */, null /* mask */,
               null /* constants */, false /* unroll */,
-              true /* needPerStepOutputs */);
+              true /* needPerStepOutputs */,
+              false /* reverseSequences */);
       const y = rnnOutputs[1];
       // TODO(cais): Add activity regularization.
       // TODO(cais): Add useLearningPhase.


### PR DESCRIPTION
Use case: if you try to make your own bidirectional RNN (forwards rnn1, bacwards rnn2, then forwards rnn3 based on output of rnn1+rnn2) then the order returned for a goBackwards sequence is not the same as the one returned otherwise, making the construction of the third rnn difficult.

Simply allowing to reverse the output sequence of a RNN solves that problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/517)
<!-- Reviewable:end -->
