### PR TITLE
Fix a bug in stateful RNN state memory management

### DIFF
--- a/src/engine/executor.ts
+++ b/src/engine/executor.ts
@@ -316,7 +316,8 @@ export function execute(
       if (!training) {
         recipientCounts[input.name]--;
         if (recipientCounts[input.name] === 0 && !feedDict.hasKey(input) &&
-            outputNames.indexOf(input.name) === -1 && !value.isDisposed) {
+            outputNames.indexOf(input.name) === -1 && !value.isDisposed &&
+            input.sourceLayer.stateful !== true) {
           tensorsToDispose.push(value);
         }
       }


### PR DESCRIPTION
BUG Fix an bug in which the output of a stateful RNN layer was incorrect disposed by the executor.

Fixes https://github.com/tensorflow/tfjs/issues/1503

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/520)
<!-- Reviewable:end -->
