### PR TITLE
[tfjs2keras test]: Add test against tf.keras

### DIFF
--- a/integration_tests/tfjs2keras/requirements-dev.txt
+++ b/integration_tests/tfjs2keras/requirements-dev.txt
@@ -1,0 +1,3 @@
+keras==2.2.4
+tf-nightly-2.0-preview>=2.0.0.dev20190410
+tensorflowjs>=1.0.0

--- a/integration_tests/tfjs2keras/requirements-stable.txt
+++ b/integration_tests/tfjs2keras/requirements-stable.txt
@@ -1,4 +1,3 @@
 keras==2.2.4
-numpy==1.15.1
 tensorflow==1.13.1
 tensorflowjs==0.8.5

--- a/integration_tests/tfjs2keras/run-test.sh
+++ b/integration_tests/tfjs2keras/run-test.sh
@@ -9,12 +9,53 @@
 
 set -e
 
-if [[ -z "${TRAVIS_BUILD_NUMBER}" ]]; then
-  pip install -r requirements.txt
-else
-  # If in Travis, use the `--user` flag when performing `pip install` of
-  # dependencies.
-  pip install --user -r requirements.txt
+DEV_VERSION=""
+TFJS2KERAS_TEST_USING_TF_KERAS=0
+while [[ ! -z "$1" ]]; do
+  if [[ "$1" == "--stable" ]]; then
+    DEV_VERSION="stable"
+  elif [[ "$1" == "--dev" ]]; then
+    DEV_VERSION="dev"
+  elif [[ "$1" == "--tfkeras" ]]; then
+    TFJS2KERAS_TEST_USING_TF_KERAS=1
+  else
+    echo "ERROR: Unrecognized command-line flag $1"
+    exit 1
+  fi
+  shift
+done
+
+echo "DEV_VERSION: ${DEV_VERSION}"
+echo "TFJS2KERAS_TEST_USING_TF_KERAS: ${TFJS2KERAS_TEST_USING_TF_KERAS}"
+
+if [[ -z "${DEV_VERSION}" ]]; then
+  echo "Must specify one of --stable and --dev."
+  exit 1
 fi
 
+if [[ "${DEV_VERSION}" == "dev" &&
+      "${TFJS2KERAS_TEST_USING_TF_KERAS}" == "0" ]]; then
+  echo "--dev && keras-team/keras is not a valid combination."
+  echo "Use `--dev --tfkeras` together."
+  exit 1
+fi
+
+VENV_DIR="$(mktemp -d)_venv"
+echo "Creating virtualenv at ${VENV_DIR} ..."
+virtualenv "${VENV_DIR}"
+source "${VENV_DIR}/bin/activate"
+
+# If in Travis, use the `--user` flag when performing `pip install` of
+# dependencies.
+if [[ "${DEV_VERSION}" == "stable" ]]; then
+  pip install -r requirements-stable.txt
+else
+  pip install -r requirements-dev.txt
+fi
+
+export TFJS2KERAS_TEST_USING_TF_KERAS="${TFJS2KERAS_TEST_USING_TF_KERAS}"
+
 python tfjs2keras_test.py
+
+# Clean up virtualenv directory.
+rm -rf "${VENV_DIR}"

--- a/integration_tests/tfjs2keras/tfjs2keras_test.py
+++ b/integration_tests/tfjs2keras/tfjs2keras_test.py
@@ -15,10 +15,16 @@ import shutil
 import subprocess
 import tempfile
 
-import keras
 import numpy as np
 import tensorflow as tf
 import tensorflowjs as tfjs
+
+if os.environ['TFJS2KERAS_TEST_USING_TF_KERAS'] == '1':
+  print('Using tensorflow.keras.')
+  from tensorflow import keras
+else:
+  print('Using keras-team/keras.')
+  import keras
 
 
 def _call_command(command):
@@ -85,7 +91,8 @@ class Tfjs2KerasExportTest(tf.test.TestCase):
     if len(ys) == 1:
       ys = ys[0]
 
-    with tf.Graph().as_default(), tf.Session():
+    session = tf.Session() if hasattr(tf, 'Session') else tf.compat.v1.Session()
+    with tf.Graph().as_default(), session:
       model_json_path = os.path.join(self._tmp_dir, model_path, 'model.json')
       print('Loading model from path %s' % model_json_path)
       model = tfjs.converters.load_keras_model(model_json_path)

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "link-local": "yalc link",
     "publish-local": "yarn build-npm && yalc push",
     "test": "karma start",
-    "test-integ": "cd integration_tests/tfjs2keras && ./run-test.sh",
+    "test-integ": "cd integration_tests/tfjs2keras && ./run-test.sh --stable && ./run-test.sh --stable --tfkeras",
     "test-travis": "karma start --browsers='bs_firefox_mac,bs_chrome_mac' --singleRun --reporters='dots,karma-typescript'",
     "lint": "tslint -p . -t verbose"
   },


### PR DESCRIPTION
- Previously only keras-team/keras was tested.
- The --tfkeras flag enables testing against tensorflow.keras

DEV