### PR TITLE
Added convenience to set weights as one tensor for one-weight layers

### DIFF
--- a/src/engine/topology.ts
+++ b/src/engine/topology.ts
@@ -1219,9 +1219,10 @@ export abstract class Layer extends serialization.Serializable {
    *   layer's specifications.
    */
   /** @doc {heading: 'Models', 'subheading': 'Classes'} */
-  setWeights(weights: Tensor[]): void {
+  setWeights(weights: Tensor[]|Tensor): void {
     tidy(() => {
       const params = this.weights;
+      if (weights instanceof Tensor) weights = [weights];
       if (params.length !== weights.length) {
         // TODO(cais): Restore the following and use `providedWeights`, instead
         // of `weights` in the error message, once the deeplearn.js bug is

--- a/src/engine/topology.ts
+++ b/src/engine/topology.ts
@@ -379,7 +379,7 @@ export declare interface LayerArgs {
   /**
    * Initial weight values of the layer.
    */
-  weights?: Tensor[];
+  weights?: Tensor[]|Tensor;
   /** Legacy support. Do not use for new code. */
   inputDType?: DataType;
 }


### PR DESCRIPTION
Maybe that's just me, but that seems more consistent with other places that allow this kind of behavior in the API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/528)
<!-- Reviewable:end -->
