### PR TITLE
Update test-ci.sh

### DIFF
--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -2,7 +2,7 @@ steps:
 - name: 'node:10'
   entrypoint: 'yarn'
   id: 'yarn'
-  args: ['install']
+  args: ['prep']
 - name: 'node:10'
   entrypoint: 'yarn'
   id: 'test-browser'

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "yalc": "~1.0.0-pre.21"
   },
   "scripts": {
+    "prep": "yarn install && yarn build",
     "build": "tsc",
     "build-npm": "./scripts/build-npm.sh",
     "format": "./tools/clang_format_ts.sh",

--- a/scripts/test-ci.sh
+++ b/scripts/test-ci.sh
@@ -9,19 +9,6 @@
 
 set -e
 
-# If this is nightly, use tfjs-core at master.
-if [ "$NIGHTLY" = true ]
-then
-  echo '########### Testing against tfjs-core@master ###########'
-  yarn run rimraf tfjs-core/
-  # depth is an optimization for faster clone (don't clone all of history).
-  git clone https://github.com/tensorflow/tfjs-core.git --depth=5
-  cd tfjs-core
-  yarn && yarn build && yarn publish-local
-  cd ..
-  yarn link-local '@tensorflow/tfjs-core'
-fi
-
 # Regular testing.
 yarn build
 yarn lint

--- a/scripts/tfjs2keras-js.sh
+++ b/scripts/tfjs2keras-js.sh
@@ -11,7 +11,6 @@ set -e
 
 TEST_DATA="test-data/"
 
-yarn build
 yarn link
 cd integration_tests/tfjs2keras/
 yarn


### PR DESCRIPTION
Remove the nightly logic to avoid double-linking, since the linking happens by the central nightly test: https://github.com/tensorflow/tfjs-core/blob/master/scripts/test-integration.sh#L32

Also remove the duplicate `yarn build` from `tfjs2keras-js` to avoid race condition of typescript compiler which can result in https://github.com/Microsoft/TypeScript/issues/22423

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/530)
<!-- Reviewable:end -->
