### PR TITLE
Update core dependency to 1.1.2

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,7 +23,6 @@
   "editor.rulers": [80],
   "editor.wrappingIndent": "none",
   "typescript.tsdk": "node_modules/typescript/lib",
-  "typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": false,
   "clang-format.executable": "${workspaceRoot}/node_modules/.bin/clang-format",
   "python.formatting.provider": "yapf"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,29 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "command": "yarn",
+      "label": "lint",
+      "type": "shell",
+      "args": [
+        "lint"
+      ],
+      "problemMatcher": {
+        "base": "$tslint5",
+        "owner": "tslint-type-checked",
+        "fileLocation": "absolute"
+      }
+    },
+    {
+      "command": "yarn",
+      "label": "build",
+      "type": "shell",
+      "args": ["build", "--pretty", "false", "--noEmit"],
+      "problemMatcher": [
+        "$tsc"
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "jsdelivr": "dist/tf-layers.min.js",
   "unpkg": "dist/tf-layers.min.js",
   "devDependencies": {
-    "@tensorflow/tfjs-core": "1.1.0",
+    "@tensorflow/tfjs-core": "1.1.2",
     "@types/jasmine": "~2.5.53",
     "clang-format": "~1.2.2",
     "http-server": "~0.10.0",
@@ -50,6 +50,6 @@
     "lint": "tslint -p . -t verbose"
   },
   "peerDependencies": {
-    "@tensorflow/tfjs-core": "1.1.0"
+    "@tensorflow/tfjs-core": "1.1.2"
   }
 }

--- a/src/backend/tfjs_backend_test.ts
+++ b/src/backend/tfjs_backend_test.ts
@@ -639,7 +639,7 @@ describeMathCPUAndGPU('OneHot', () => {
     const indices = tensor1d([1, 3]);
     expectTensorsClose(
         K.oneHot(indices, numClasses),
-        tensor2d([[0, 1, 0, 0, 0], [0, 0, 0, 1, 0]], [2, 5]));
+        tensor2d([[0, 1, 0, 0, 0], [0, 0, 0, 1, 0]], [2, 5], 'int32'));
   });
 });
 

--- a/src/backend/tfjs_backend_test.ts
+++ b/src/backend/tfjs_backend_test.ts
@@ -638,7 +638,7 @@ describeMathCPUAndGPU('OneHot', () => {
     const numClasses = 5;
     const indices = tensor1d([1, 3]);
     expectTensorsClose(
-        K.oneHot(indices, numClasses),
+        K.oneHot(indices, numClasses).toInt(),
         tensor2d([[0, 1, 0, 0, 0], [0, 0, 0, 1, 0]], [2, 5], 'int32'));
   });
 });

--- a/src/engine/training_dataset_test.ts
+++ b/src/engine/training_dataset_test.ts
@@ -97,8 +97,8 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history.loss.length).toEqual(2);
        expect(history.history.loss[0]).toBeCloseTo(0.923649);
        expect(history.history.loss[1]).toBeCloseTo(0.722993);
-       expectArraysClose(model.getWeights()[0], tfc.tensor2d([[0.108621]]));
-       expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.108621]));
+       expectArraysClose(await model.getWeights()[0].data(), [0.108621]);
+       expectArraysClose(await model.getWeights()[1].data(), [0.108621]);
      });
 
   it('1 input, 1 output, no metric, no validation, no batchesPerEpoch',
@@ -139,8 +139,8 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history.loss.length).toEqual(2);
        expect(history.history.loss[0]).toBeCloseTo(0.923649);
        expect(history.history.loss[1]).toBeCloseTo(0.722993);
-       expectArraysClose(model.getWeights()[0], tfc.tensor2d([[0.108621]]));
-       expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.108621]));
+       expectArraysClose(await model.getWeights()[0].data(), [0.108621]);
+       expectArraysClose(await model.getWeights()[1].data(), [0.108621]);
      });
 
   // Reference Python tf.keras code:
@@ -216,8 +216,8 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history.acc.length).toEqual(2);
        expect(history.history.acc[0]).toBeCloseTo(0);
        expect(history.history.acc[1]).toBeCloseTo(0);
-       expectArraysClose(model.getWeights()[0], tfc.tensor2d([[0.108621]]));
-       expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.108621]));
+       expectArraysClose(await model.getWeights()[0].data(), [0.108621]);
+       expectArraysClose(await model.getWeights()[1].data(), [0.108621]);
      });
 
   it('1 input, 1 output, 1 metric, no validation, no batchesPerEpoch',
@@ -262,8 +262,8 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history.acc.length).toEqual(2);
        expect(history.history.acc[0]).toBeCloseTo(0);
        expect(history.history.acc[1]).toBeCloseTo(0);
-       expectArraysClose(model.getWeights()[0], tfc.tensor2d([[0.108621]]));
-       expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.108621]));
+       expectArraysClose(await model.getWeights()[0].data(), [0.108621]);
+       expectArraysClose(await model.getWeights()[1].data(), [0.108621]);
      });
 
   // Reference Python tf.keras code.
@@ -373,8 +373,8 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history.val_acc.length).toEqual(2);
        expect(history.history.val_acc[0]).toBeCloseTo(1);
        expect(history.history.val_acc[1]).toBeCloseTo(1);
-       expectArraysClose(model.getWeights()[0], tfc.tensor2d([[0.108621]]));
-       expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.108621]));
+       expectArraysClose(await model.getWeights()[0].data(), [0.108621]);
+       expectArraysClose(await model.getWeights()[1].data(), [0.108621]);
 
        expect(epochEndValLosses.length).toEqual(2);
        expect(epochEndValLosses[0]).toBeCloseTo(0.003321);
@@ -449,8 +449,8 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history.val_acc.length).toEqual(2);
        expect(history.history.val_acc[0]).toBeCloseTo(1);
        expect(history.history.val_acc[1]).toBeCloseTo(1);
-       expectArraysClose(model.getWeights()[0], tfc.tensor2d([[0.108621]]));
-       expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.108621]));
+       expectArraysClose(await model.getWeights()[0].data(), [0.108621]);
+       expectArraysClose(await model.getWeights()[1].data(), [0.108621]);
 
        expect(epochEndValLosses.length).toEqual(2);
        expect(epochEndValLosses[0]).toBeCloseTo(0.003321);
@@ -722,8 +722,8 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history.val_acc.length).toEqual(2);
        expect(history.history.val_acc[0]).toBeCloseTo(1);
        expect(history.history.val_acc[1]).toBeCloseTo(1);
-       expectArraysClose(model.getWeights()[0], tfc.tensor2d([[0.108621]]));
-       expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.108621]));
+       expectArraysClose(await model.getWeights()[0].data(), [0.108621]);
+       expectArraysClose(await model.getWeights()[1].data(), [0.108621]);
 
        expect(epochEndValLosses.length).toEqual(2);
        expect(epochEndValLosses[0]).toBeCloseTo(0.003321);
@@ -813,8 +813,8 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history.val_acc.length).toEqual(2);
        expect(history.history.val_acc[0]).toBeCloseTo(1);
        expect(history.history.val_acc[1]).toBeCloseTo(1);
-       expectArraysClose(model.getWeights()[0], tfc.tensor2d([[0.108621]]));
-       expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.108621]));
+       expectArraysClose(await model.getWeights()[0].data(), [0.108621]);
+       expectArraysClose(await model.getWeights()[1].data(), [0.108621]);
 
        expect(epochEndValLosses.length).toEqual(2);
        expect(epochEndValLosses[0]).toBeCloseTo(0.003321);
@@ -1012,8 +1012,8 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history.acc.length).toEqual(2);
        expect(history.history.acc[0]).toBeCloseTo(0);
        expect(history.history.acc[1]).toBeCloseTo(0);
-       expectArraysClose(model.getWeights()[0], tfc.tensor2d([[0.108621]]));
-       expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.108621]));
+       expectArraysClose(await model.getWeights()[0].data(), [0.108621]);
+       expectArraysClose(await model.getWeights()[1].data(), [0.108621]);
 
        expect(onTrainBeginCalls).toEqual(1);
        expect(onTrainEndCalls).toEqual(1);
@@ -1109,8 +1109,8 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history.acc.length).toEqual(2);
        expect(history.history.acc[0]).toBeCloseTo(0);
        expect(history.history.acc[1]).toBeCloseTo(0);
-       expectArraysClose(model.getWeights()[0], tfc.tensor2d([[0.108621]]));
-       expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.108621]));
+       expectArraysClose(await model.getWeights()[0].data(), [0.108621]);
+       expectArraysClose(await model.getWeights()[1].data(), [0.108621]);
 
        expect(onTrainBeginCalls).toEqual(1);
        expect(onTrainEndCalls).toEqual(1);
@@ -1224,8 +1224,8 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history.acc[0]).toBeCloseTo(0);
        expect(history.history.acc[1]).toBeCloseTo(0);
        expectArraysClose(
-           model.getWeights()[0], tfc.tensor2d([[0.103377], [0.103377]]));
-       expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.103377]));
+           await model.getWeights()[0].data(), [0.103377, 0.103377]);
+       expectArraysClose(await model.getWeights()[1].data(), [0.103377]);
      });
 
   it('2 inputs, 1 output, 1 metric, no validation, no batchesPerEpoch',
@@ -1285,8 +1285,8 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history.acc[0]).toBeCloseTo(0);
        expect(history.history.acc[1]).toBeCloseTo(0);
        expectArraysClose(
-           model.getWeights()[0], tfc.tensor2d([[0.103377], [0.103377]]));
-       expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.103377]));
+           await model.getWeights()[0].data(), [0.103377, 0.103377]);
+       expectArraysClose(await model.getWeights()[1].data(), [0.103377]);
      });
 
   // Reference Python tf.keras code:
@@ -1419,8 +1419,8 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history.val_acc[0]).toBeCloseTo(1.0);
        expect(history.history.val_acc[1]).toBeCloseTo(1.0);
        expectArraysClose(
-           model.getWeights()[0], tfc.tensor2d([[0.103377], [0.103377]]));
-       expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.103377]));
+           await model.getWeights()[0].data(), [0.103377, 0.103377]);
+       expectArraysClose(await model.getWeights()[1].data(), [0.103377]);
      });
 
   it('2 inputs, 1 output, 1 metric, tensor array validation, ' +
@@ -1504,8 +1504,8 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history.val_acc[0]).toBeCloseTo(1.0);
        expect(history.history.val_acc[1]).toBeCloseTo(1.0);
        expectArraysClose(
-           model.getWeights()[0], tfc.tensor2d([[0.103377], [0.103377]]));
-       expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.103377]));
+           await model.getWeights()[0].data(), [0.103377, 0.103377]);
+       expectArraysClose(await model.getWeights()[1].data(), [0.103377]);
      });
 
   // Reference Python tf.keras code:
@@ -1641,8 +1641,8 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history.val_acc[0]).toBeCloseTo(1.0);
        expect(history.history.val_acc[1]).toBeCloseTo(1.0);
        expectArraysClose(
-           model.getWeights()[0], tfc.tensor2d([[0.103377], [0.103377]]));
-       expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.103377]));
+           await model.getWeights()[0].data(), [0.103377, 0.103377]);
+       expectArraysClose(await model.getWeights()[1].data(), [0.103377]);
      });
 
   it('2 input, 1 output, 1 metric, tensor array validation, ' +
@@ -1727,8 +1727,8 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history.val_acc[0]).toBeCloseTo(1.0);
        expect(history.history.val_acc[1]).toBeCloseTo(1.0);
        expectArraysClose(
-           model.getWeights()[0], tfc.tensor2d([[0.103377], [0.103377]]));
-       expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.103377]));
+           await model.getWeights()[0].data(), [0.103377, 0.103377]);
+       expectArraysClose(await model.getWeights()[1].data(), [0.103377]);
      });
 
   it('2 input, 1 missing input in dataset, with batchesPerEpoch', async () => {
@@ -1955,10 +1955,10 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history[output2AccName].length).toEqual(2);
        expect(history.history[output2AccName][0]).toBeCloseTo(0);
        expect(history.history[output2AccName][1]).toBeCloseTo(0);
-       expectArraysClose(model.getWeights()[0], tfc.tensor2d([[0.108621]]));
-       expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.108621]));
-       expectArraysClose(model.getWeights()[2], tfc.tensor2d([[0.108621]]));
-       expectArraysClose(model.getWeights()[3], tfc.tensor1d([0.108621]));
+       expectArraysClose(await model.getWeights()[0].data(), [0.108621]);
+       expectArraysClose(await model.getWeights()[1].data(), [0.108621]);
+       expectArraysClose(await model.getWeights()[2].data(), [0.108621]);
+       expectArraysClose(await model.getWeights()[3].data(), [0.108621]);
      });
 
   it('1 input, 2 outputs, 1 metric, no validation, no batchesPerEpoch',
@@ -2045,10 +2045,10 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history[output2AccName].length).toEqual(2);
        expect(history.history[output2AccName][0]).toBeCloseTo(0);
        expect(history.history[output2AccName][1]).toBeCloseTo(0);
-       expectArraysClose(model.getWeights()[0], tfc.tensor2d([[0.108621]]));
-       expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.108621]));
-       expectArraysClose(model.getWeights()[2], tfc.tensor2d([[0.108621]]));
-       expectArraysClose(model.getWeights()[3], tfc.tensor1d([0.108621]));
+       expectArraysClose(await model.getWeights()[0].data(), [0.108621]);
+       expectArraysClose(await model.getWeights()[1].data(), [0.108621]);
+       expectArraysClose(await model.getWeights()[2].data(), [0.108621]);
+       expectArraysClose(await model.getWeights()[3].data(), [0.108621]);
      });
 
   // Reference Python tf.keras code:
@@ -2217,10 +2217,10 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history[valOutput2AccName].length).toEqual(2);
        expect(history.history[valOutput2AccName][0]).toBeCloseTo(1);
        expect(history.history[valOutput2AccName][1]).toBeCloseTo(1);
-       expectArraysClose(model.getWeights()[0], tfc.tensor2d([[0.108621]]));
-       expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.108621]));
-       expectArraysClose(model.getWeights()[2], tfc.tensor2d([[0.108621]]));
-       expectArraysClose(model.getWeights()[3], tfc.tensor1d([0.108621]));
+       expectArraysClose(await model.getWeights()[0].data(), [0.108621]);
+       expectArraysClose(await model.getWeights()[1].data(), [0.108621]);
+       expectArraysClose(await model.getWeights()[2].data(), [0.108621]);
+       expectArraysClose(await model.getWeights()[3].data(), [0.108621]);
      });
 
   it('1 input, 2 outputs, 1 metric, tensor array validation, ' +
@@ -2338,10 +2338,10 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history[valOutput2AccName].length).toEqual(2);
        expect(history.history[valOutput2AccName][0]).toBeCloseTo(1);
        expect(history.history[valOutput2AccName][1]).toBeCloseTo(1);
-       expectArraysClose(model.getWeights()[0], tfc.tensor2d([[0.108621]]));
-       expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.108621]));
-       expectArraysClose(model.getWeights()[2], tfc.tensor2d([[0.108621]]));
-       expectArraysClose(model.getWeights()[3], tfc.tensor1d([0.108621]));
+       expectArraysClose(await model.getWeights()[0].data(), [0.108621]);
+       expectArraysClose(await model.getWeights()[1].data(), [0.108621]);
+       expectArraysClose(await model.getWeights()[2].data(), [0.108621]);
+       expectArraysClose(await model.getWeights()[3].data(), [0.108621]);
      });
 
   it('2 outputs, 1 missing output in dataset, with batchesPerEpoch',
@@ -2610,11 +2610,12 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history[output2AccName][0]).toBeCloseTo(0);
        expect(history.history[output2AccName][1]).toBeCloseTo(0);
        expectArraysClose(
-           model.getWeights()[0], tfc.tensor2d([[0.103376], [0.103376]]));
-       expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.103376]));
+           await model.getWeights()[0].data(), [0.103376, 0.103376]);
+       expectArraysClose(await model.getWeights()[1].data(), [0.103376]);
        expectArraysClose(
-           model.getWeights()[2], tfc.tensor2d([[0.103376], [0.103376]]));
-       expectArraysClose(model.getWeights()[3], tfc.tensor1d([0.103376]));
+           await model.getWeights()[2].data(),
+           [0.103376, 0.103376]);
+       expectArraysClose(await model.getWeights()[3].data(), [0.103376]);
      });
 
   it('2 inputs, 2 outputs, 1 metric, no validation, no batchesPerEpoch',
@@ -2712,11 +2713,11 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history[output2AccName][0]).toBeCloseTo(0);
        expect(history.history[output2AccName][1]).toBeCloseTo(0);
        expectArraysClose(
-           model.getWeights()[0], tfc.tensor2d([[0.103376], [0.103376]]));
-       expectArraysClose(model.getWeights()[1], tfc.tensor1d([0.103376]));
+           await model.getWeights()[0].data(), [0.103376, 0.103376]);
+       expectArraysClose(await model.getWeights()[1].data(), [0.103376]);
        expectArraysClose(
-           model.getWeights()[2], tfc.tensor2d([[0.103376], [0.103376]]));
-       expectArraysClose(model.getWeights()[3], tfc.tensor1d([0.103376]));
+           await model.getWeights()[2].data(), [0.103376, 0.103376]);
+       expectArraysClose(await model.getWeights()[3].data(), [0.103376]);
      });
 
   it('Exhausting iterator with batchesPerEpoch throws warning', async () => {

--- a/src/engine/training_dataset_test.ts
+++ b/src/engine/training_dataset_test.ts
@@ -15,7 +15,6 @@
 
 import * as tfc from '@tensorflow/tfjs-core';
 import {util} from '@tensorflow/tfjs-core';
-import {expectArraysClose} from '@tensorflow/tfjs-core/dist/test_util';
 
 import {CustomCallback, DEFAULT_YIELD_EVERY_MS} from '../base_callbacks';
 import * as tfl from '../index';
@@ -97,8 +96,8 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history.loss.length).toEqual(2);
        expect(history.history.loss[0]).toBeCloseTo(0.923649);
        expect(history.history.loss[1]).toBeCloseTo(0.722993);
-       expectArraysClose(await model.getWeights()[0].data(), [0.108621]);
-       expectArraysClose(await model.getWeights()[1].data(), [0.108621]);
+       expectTensorsClose(model.getWeights()[0], [0.108621]);
+       expectTensorsClose(model.getWeights()[1], [0.108621]);
      });
 
   it('1 input, 1 output, no metric, no validation, no batchesPerEpoch',
@@ -139,8 +138,8 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history.loss.length).toEqual(2);
        expect(history.history.loss[0]).toBeCloseTo(0.923649);
        expect(history.history.loss[1]).toBeCloseTo(0.722993);
-       expectArraysClose(await model.getWeights()[0].data(), [0.108621]);
-       expectArraysClose(await model.getWeights()[1].data(), [0.108621]);
+       expectTensorsClose(model.getWeights()[0], [0.108621]);
+       expectTensorsClose(model.getWeights()[1], [0.108621]);
      });
 
   // Reference Python tf.keras code:
@@ -216,8 +215,8 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history.acc.length).toEqual(2);
        expect(history.history.acc[0]).toBeCloseTo(0);
        expect(history.history.acc[1]).toBeCloseTo(0);
-       expectArraysClose(await model.getWeights()[0].data(), [0.108621]);
-       expectArraysClose(await model.getWeights()[1].data(), [0.108621]);
+       expectTensorsClose(model.getWeights()[0], [0.108621]);
+       expectTensorsClose(model.getWeights()[1], [0.108621]);
      });
 
   it('1 input, 1 output, 1 metric, no validation, no batchesPerEpoch',
@@ -262,8 +261,8 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history.acc.length).toEqual(2);
        expect(history.history.acc[0]).toBeCloseTo(0);
        expect(history.history.acc[1]).toBeCloseTo(0);
-       expectArraysClose(await model.getWeights()[0].data(), [0.108621]);
-       expectArraysClose(await model.getWeights()[1].data(), [0.108621]);
+       expectTensorsClose(model.getWeights()[0], [0.108621]);
+       expectTensorsClose(model.getWeights()[1], [0.108621]);
      });
 
   // Reference Python tf.keras code.
@@ -373,8 +372,8 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history.val_acc.length).toEqual(2);
        expect(history.history.val_acc[0]).toBeCloseTo(1);
        expect(history.history.val_acc[1]).toBeCloseTo(1);
-       expectArraysClose(await model.getWeights()[0].data(), [0.108621]);
-       expectArraysClose(await model.getWeights()[1].data(), [0.108621]);
+       expectTensorsClose(model.getWeights()[0], [0.108621]);
+       expectTensorsClose(model.getWeights()[1], [0.108621]);
 
        expect(epochEndValLosses.length).toEqual(2);
        expect(epochEndValLosses[0]).toBeCloseTo(0.003321);
@@ -449,8 +448,8 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history.val_acc.length).toEqual(2);
        expect(history.history.val_acc[0]).toBeCloseTo(1);
        expect(history.history.val_acc[1]).toBeCloseTo(1);
-       expectArraysClose(await model.getWeights()[0].data(), [0.108621]);
-       expectArraysClose(await model.getWeights()[1].data(), [0.108621]);
+       expectTensorsClose(model.getWeights()[0], [0.108621]);
+       expectTensorsClose(model.getWeights()[1], [0.108621]);
 
        expect(epochEndValLosses.length).toEqual(2);
        expect(epochEndValLosses[0]).toBeCloseTo(0.003321);
@@ -722,8 +721,8 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history.val_acc.length).toEqual(2);
        expect(history.history.val_acc[0]).toBeCloseTo(1);
        expect(history.history.val_acc[1]).toBeCloseTo(1);
-       expectArraysClose(await model.getWeights()[0].data(), [0.108621]);
-       expectArraysClose(await model.getWeights()[1].data(), [0.108621]);
+       expectTensorsClose(model.getWeights()[0], [0.108621]);
+       expectTensorsClose(model.getWeights()[1], [0.108621]);
 
        expect(epochEndValLosses.length).toEqual(2);
        expect(epochEndValLosses[0]).toBeCloseTo(0.003321);
@@ -813,8 +812,8 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history.val_acc.length).toEqual(2);
        expect(history.history.val_acc[0]).toBeCloseTo(1);
        expect(history.history.val_acc[1]).toBeCloseTo(1);
-       expectArraysClose(await model.getWeights()[0].data(), [0.108621]);
-       expectArraysClose(await model.getWeights()[1].data(), [0.108621]);
+       expectTensorsClose(model.getWeights()[0], [0.108621]);
+       expectTensorsClose(model.getWeights()[1], [0.108621]);
 
        expect(epochEndValLosses.length).toEqual(2);
        expect(epochEndValLosses[0]).toBeCloseTo(0.003321);
@@ -1012,8 +1011,8 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history.acc.length).toEqual(2);
        expect(history.history.acc[0]).toBeCloseTo(0);
        expect(history.history.acc[1]).toBeCloseTo(0);
-       expectArraysClose(await model.getWeights()[0].data(), [0.108621]);
-       expectArraysClose(await model.getWeights()[1].data(), [0.108621]);
+       expectTensorsClose(model.getWeights()[0], [0.108621]);
+       expectTensorsClose(model.getWeights()[1], [0.108621]);
 
        expect(onTrainBeginCalls).toEqual(1);
        expect(onTrainEndCalls).toEqual(1);
@@ -1027,7 +1026,7 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(epochEndAccs.length).toEqual(2);
        expect(epochEndAccs[0]).toBeCloseTo(0);
        expect(epochEndAccs[1]).toBeCloseTo(0);
-       expectArraysClose(
+       expectTensorsClose(
            batchEndLosses, [1, 0.9216, 0.849347, 0.782758, 0.721390, 0.664832]);
      });
 
@@ -1109,8 +1108,8 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history.acc.length).toEqual(2);
        expect(history.history.acc[0]).toBeCloseTo(0);
        expect(history.history.acc[1]).toBeCloseTo(0);
-       expectArraysClose(await model.getWeights()[0].data(), [0.108621]);
-       expectArraysClose(await model.getWeights()[1].data(), [0.108621]);
+       expectTensorsClose(model.getWeights()[0], [0.108621]);
+       expectTensorsClose(model.getWeights()[1], [0.108621]);
 
        expect(onTrainBeginCalls).toEqual(1);
        expect(onTrainEndCalls).toEqual(1);
@@ -1124,7 +1123,7 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(epochEndAccs.length).toEqual(2);
        expect(epochEndAccs[0]).toBeCloseTo(0);
        expect(epochEndAccs[1]).toBeCloseTo(0);
-       expectArraysClose(
+       expectTensorsClose(
            batchEndLosses, [1, 0.9216, 0.849347, 0.782758, 0.721390, 0.664832]);
      });
 
@@ -1223,9 +1222,8 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history.acc.length).toEqual(2);
        expect(history.history.acc[0]).toBeCloseTo(0);
        expect(history.history.acc[1]).toBeCloseTo(0);
-       expectArraysClose(
-           await model.getWeights()[0].data(), [0.103377, 0.103377]);
-       expectArraysClose(await model.getWeights()[1].data(), [0.103377]);
+       expectTensorsClose(model.getWeights()[0], [0.103377, 0.103377]);
+       expectTensorsClose(model.getWeights()[1], [0.103377]);
      });
 
   it('2 inputs, 1 output, 1 metric, no validation, no batchesPerEpoch',
@@ -1284,9 +1282,8 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history.acc.length).toEqual(2);
        expect(history.history.acc[0]).toBeCloseTo(0);
        expect(history.history.acc[1]).toBeCloseTo(0);
-       expectArraysClose(
-           await model.getWeights()[0].data(), [0.103377, 0.103377]);
-       expectArraysClose(await model.getWeights()[1].data(), [0.103377]);
+       expectTensorsClose(model.getWeights()[0], [0.103377, 0.103377]);
+       expectTensorsClose(model.getWeights()[1], [0.103377]);
      });
 
   // Reference Python tf.keras code:
@@ -1418,9 +1415,8 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history.val_acc.length).toEqual(2);
        expect(history.history.val_acc[0]).toBeCloseTo(1.0);
        expect(history.history.val_acc[1]).toBeCloseTo(1.0);
-       expectArraysClose(
-           await model.getWeights()[0].data(), [0.103377, 0.103377]);
-       expectArraysClose(await model.getWeights()[1].data(), [0.103377]);
+       expectTensorsClose(model.getWeights()[0], [0.103377, 0.103377]);
+       expectTensorsClose(model.getWeights()[1], [0.103377]);
      });
 
   it('2 inputs, 1 output, 1 metric, tensor array validation, ' +
@@ -1503,9 +1499,8 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history.val_acc.length).toEqual(2);
        expect(history.history.val_acc[0]).toBeCloseTo(1.0);
        expect(history.history.val_acc[1]).toBeCloseTo(1.0);
-       expectArraysClose(
-           await model.getWeights()[0].data(), [0.103377, 0.103377]);
-       expectArraysClose(await model.getWeights()[1].data(), [0.103377]);
+       expectTensorsClose(model.getWeights()[0], [0.103377, 0.103377]);
+       expectTensorsClose(model.getWeights()[1], [0.103377]);
      });
 
   // Reference Python tf.keras code:
@@ -1640,9 +1635,8 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history.val_acc.length).toEqual(2);
        expect(history.history.val_acc[0]).toBeCloseTo(1.0);
        expect(history.history.val_acc[1]).toBeCloseTo(1.0);
-       expectArraysClose(
-           await model.getWeights()[0].data(), [0.103377, 0.103377]);
-       expectArraysClose(await model.getWeights()[1].data(), [0.103377]);
+       expectTensorsClose(model.getWeights()[0], [0.103377, 0.103377]);
+       expectTensorsClose(model.getWeights()[1], [0.103377]);
      });
 
   it('2 input, 1 output, 1 metric, tensor array validation, ' +
@@ -1726,9 +1720,8 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history.val_acc.length).toEqual(2);
        expect(history.history.val_acc[0]).toBeCloseTo(1.0);
        expect(history.history.val_acc[1]).toBeCloseTo(1.0);
-       expectArraysClose(
-           await model.getWeights()[0].data(), [0.103377, 0.103377]);
-       expectArraysClose(await model.getWeights()[1].data(), [0.103377]);
+       expectTensorsClose(model.getWeights()[0], [0.103377, 0.103377]);
+       expectTensorsClose(model.getWeights()[1], [0.103377]);
      });
 
   it('2 input, 1 missing input in dataset, with batchesPerEpoch', async () => {
@@ -1955,10 +1948,10 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history[output2AccName].length).toEqual(2);
        expect(history.history[output2AccName][0]).toBeCloseTo(0);
        expect(history.history[output2AccName][1]).toBeCloseTo(0);
-       expectArraysClose(await model.getWeights()[0].data(), [0.108621]);
-       expectArraysClose(await model.getWeights()[1].data(), [0.108621]);
-       expectArraysClose(await model.getWeights()[2].data(), [0.108621]);
-       expectArraysClose(await model.getWeights()[3].data(), [0.108621]);
+       expectTensorsClose(model.getWeights()[0], [0.108621]);
+       expectTensorsClose(model.getWeights()[1], [0.108621]);
+       expectTensorsClose(model.getWeights()[2], [0.108621]);
+       expectTensorsClose(model.getWeights()[3], [0.108621]);
      });
 
   it('1 input, 2 outputs, 1 metric, no validation, no batchesPerEpoch',
@@ -2045,10 +2038,10 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history[output2AccName].length).toEqual(2);
        expect(history.history[output2AccName][0]).toBeCloseTo(0);
        expect(history.history[output2AccName][1]).toBeCloseTo(0);
-       expectArraysClose(await model.getWeights()[0].data(), [0.108621]);
-       expectArraysClose(await model.getWeights()[1].data(), [0.108621]);
-       expectArraysClose(await model.getWeights()[2].data(), [0.108621]);
-       expectArraysClose(await model.getWeights()[3].data(), [0.108621]);
+       expectTensorsClose(model.getWeights()[0], [0.108621]);
+       expectTensorsClose(model.getWeights()[1], [0.108621]);
+       expectTensorsClose(model.getWeights()[2], [0.108621]);
+       expectTensorsClose(model.getWeights()[3], [0.108621]);
      });
 
   // Reference Python tf.keras code:
@@ -2217,10 +2210,10 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history[valOutput2AccName].length).toEqual(2);
        expect(history.history[valOutput2AccName][0]).toBeCloseTo(1);
        expect(history.history[valOutput2AccName][1]).toBeCloseTo(1);
-       expectArraysClose(await model.getWeights()[0].data(), [0.108621]);
-       expectArraysClose(await model.getWeights()[1].data(), [0.108621]);
-       expectArraysClose(await model.getWeights()[2].data(), [0.108621]);
-       expectArraysClose(await model.getWeights()[3].data(), [0.108621]);
+       expectTensorsClose(model.getWeights()[0], [0.108621]);
+       expectTensorsClose(model.getWeights()[1], [0.108621]);
+       expectTensorsClose(model.getWeights()[2], [0.108621]);
+       expectTensorsClose(model.getWeights()[3], [0.108621]);
      });
 
   it('1 input, 2 outputs, 1 metric, tensor array validation, ' +
@@ -2338,10 +2331,10 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history[valOutput2AccName].length).toEqual(2);
        expect(history.history[valOutput2AccName][0]).toBeCloseTo(1);
        expect(history.history[valOutput2AccName][1]).toBeCloseTo(1);
-       expectArraysClose(await model.getWeights()[0].data(), [0.108621]);
-       expectArraysClose(await model.getWeights()[1].data(), [0.108621]);
-       expectArraysClose(await model.getWeights()[2].data(), [0.108621]);
-       expectArraysClose(await model.getWeights()[3].data(), [0.108621]);
+       expectTensorsClose(model.getWeights()[0], [0.108621]);
+       expectTensorsClose(model.getWeights()[1], [0.108621]);
+       expectTensorsClose(model.getWeights()[2], [0.108621]);
+       expectTensorsClose(model.getWeights()[3], [0.108621]);
      });
 
   it('2 outputs, 1 missing output in dataset, with batchesPerEpoch',
@@ -2609,13 +2602,10 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history[output2AccName].length).toEqual(2);
        expect(history.history[output2AccName][0]).toBeCloseTo(0);
        expect(history.history[output2AccName][1]).toBeCloseTo(0);
-       expectArraysClose(
-           await model.getWeights()[0].data(), [0.103376, 0.103376]);
-       expectArraysClose(await model.getWeights()[1].data(), [0.103376]);
-       expectArraysClose(
-           await model.getWeights()[2].data(),
-           [0.103376, 0.103376]);
-       expectArraysClose(await model.getWeights()[3].data(), [0.103376]);
+       expectTensorsClose(model.getWeights()[0], [0.103376, 0.103376]);
+       expectTensorsClose(model.getWeights()[1], [0.103376]);
+       expectTensorsClose(model.getWeights()[2], [0.103376, 0.103376]);
+       expectTensorsClose(model.getWeights()[3], [0.103376]);
      });
 
   it('2 inputs, 2 outputs, 1 metric, no validation, no batchesPerEpoch',
@@ -2712,12 +2702,10 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(history.history[output2AccName].length).toEqual(2);
        expect(history.history[output2AccName][0]).toBeCloseTo(0);
        expect(history.history[output2AccName][1]).toBeCloseTo(0);
-       expectArraysClose(
-           await model.getWeights()[0].data(), [0.103376, 0.103376]);
-       expectArraysClose(await model.getWeights()[1].data(), [0.103376]);
-       expectArraysClose(
-           await model.getWeights()[2].data(), [0.103376, 0.103376]);
-       expectArraysClose(await model.getWeights()[3].data(), [0.103376]);
+       expectTensorsClose(model.getWeights()[0], [0.103376, 0.103376]);
+       expectTensorsClose(model.getWeights()[1], [0.103376]);
+       expectTensorsClose(model.getWeights()[2], [0.103376, 0.103376]);
+       expectTensorsClose(model.getWeights()[3], [0.103376]);
      });
 
   it('Exhausting iterator with batchesPerEpoch throws warning', async () => {

--- a/src/layers/convolutional.ts
+++ b/src/layers/convolutional.ts
@@ -265,7 +265,7 @@ export function conv3dWithBias(
     y = tfc.conv3d(
         y as Tensor4D | tfc.Tensor<tfc.Rank.R5>,
         kernel as tfc.Tensor<tfc.Rank.R5>, strides as [number, number, number],
-        padding === 'same' ? 'same' : 'valid', 'NHWC', dilationRate);
+        padding === 'same' ? 'same' : 'valid', 'NDHWC', dilationRate);
     if (bias != null) {
       y = K.biasAdd(y, bias as Tensor1D);
     }

--- a/src/layers/pooling_test.ts
+++ b/src/layers/pooling_test.ts
@@ -14,7 +14,6 @@
 
 import * as tfc from '@tensorflow/tfjs-core';
 import {Tensor, tensor2d, Tensor2D, tensor3d, tensor4d, Tensor4D, util} from '@tensorflow/tfjs-core';
-import {expectArraysClose} from '@tensorflow/tfjs-core/dist/test_util';
 
 import {SymbolicTensor} from '../engine/topology';
 import * as tfl from '../index';
@@ -240,7 +239,7 @@ describeMathCPUAndGPU('Pooling Layers 1D: Tensor', () => {
         {poolSize: [2], strides: [2], inputShape: [4, 3]}));
     const xs = tfc.ones([1, 4, 3]);
     const ys = model.predict(xs) as Tensor;
-    expectArraysClose(await ys.data(), [1, 1, 1, 1, 1, 1]);
+    expectTensorsClose(ys, [1, 1, 1, 1, 1, 1]);
     expect(ys.shape).toEqual([1, 2, 3]);
 
     const config = model.layers[0].getConfig();
@@ -432,7 +431,7 @@ describeMathCPUAndGPU('Pooling Layers 2D: Tensor', () => {
         {poolSize: 2, strides: [2, 2], inputShape: [4, 4, 3]}));
     const xs = tfc.ones([1, 4, 4, 3]);
     const ys = model.predict(xs) as Tensor;
-    expectArraysClose(await ys.data(), await tfc.ones([1, 2, 2, 3]).data());
+    expectTensorsClose(ys, tfc.ones([1, 2, 2, 3]));
     expect(ys.shape).toEqual([1, 2, 2, 3]);
     const config = model.layers[0].getConfig();
     expect(config['poolSize']).toEqual([2, 2]);

--- a/src/layers/pooling_test.ts
+++ b/src/layers/pooling_test.ts
@@ -234,13 +234,14 @@ describeMathCPUAndGPU('Pooling Layers 1D: Tensor', () => {
     }
   }
 
-  it('Handles poolSize and strides passed as number arrays', () => {
+  it('Handles poolSize and strides passed as number arrays', async () => {
     const model = tfl.sequential();
     model.add(tfl.layers.maxPool1d(
         {poolSize: [2], strides: [2], inputShape: [4, 3]}));
     const xs = tfc.ones([1, 4, 3]);
     const ys = model.predict(xs) as Tensor;
-    expectArraysClose(ys, tfc.tensor3d([1, 1, 1, 1, 1, 1], [1, 2, 3]));
+    expectArraysClose(await ys.data(), [1, 1, 1, 1, 1, 1]);
+    expect(ys.shape).toEqual([1, 2, 3]);
 
     const config = model.layers[0].getConfig();
     expect(config['poolSize']).toEqual([2]);
@@ -425,13 +426,14 @@ describeMathCPUAndGPU('Pooling Layers 2D: Tensor', () => {
     }
   }
 
-  it('Handles strides passed as number arrays', () => {
+  it('Handles strides passed as number arrays', async () => {
     const model = tfl.sequential();
     model.add(tfl.layers.maxPooling2d(
         {poolSize: 2, strides: [2, 2], inputShape: [4, 4, 3]}));
     const xs = tfc.ones([1, 4, 4, 3]);
     const ys = model.predict(xs) as Tensor;
-    expectArraysClose(ys, tfc.ones([1, 2, 2, 3]));
+    expectArraysClose(await ys.data(), await tfc.ones([1, 2, 2, 3]).data());
+    expect(ys.shape).toEqual([1, 2, 2, 3]);
     const config = model.layers[0].getConfig();
     expect(config['poolSize']).toEqual([2, 2]);
     expect(config['strides']).toEqual([2, 2]);

--- a/src/layers/recurrent.ts
+++ b/src/layers/recurrent.ts
@@ -698,7 +698,7 @@ export class RNN extends Layer {
           this.states_[index] = value;
         }
       }
-      this.states_.forEach(state => tfc.keep(state));
+      this.states_ = this.states_.map(state => tfc.keep(state.clone()));
     });
   }
 
@@ -2551,9 +2551,8 @@ function generateDropoutMask(
     for (let i = 0; i < count; i++) {
       mask.push(K.inTrainPhase(droppedInputs, ones, training));
     }
-    mask.forEach(m => tfc.keep(m));
-    return mask;
+    return mask.map(m => tfc.keep(m.clone()));
   } else {
-    return tfc.keep(K.inTrainPhase(droppedInputs, ones, training));
+    return tfc.keep(K.inTrainPhase(droppedInputs, ones, training).clone());
   }
 }

--- a/src/layers/recurrent_test.ts
+++ b/src/layers/recurrent_test.ts
@@ -765,7 +765,7 @@ describeMathCPUAndGPU('SimpleRNN Tensor', () => {
     // print(model.predict(x))
     // print(model.predict(x))
     // ```
-    it('stateful forward: only RNN layer', () => {
+    it('stateful forward: only RNN layer', async () => {
       const sequenceLength = 3;
       const rnn = tfl.layers.simpleRNN({
         units,
@@ -781,23 +781,38 @@ describeMathCPUAndGPU('SimpleRNN Tensor', () => {
       const x = tfc.ones([batchSize, sequenceLength, inputSize]);
       const scalar1 = tfc.scalar(62);
       const scalar2 = tfc.scalar(7812);
-      let y1: Tensor;
-      let y2: Tensor;
-      tfc.tidy(() => {
-        y1 = model.predict(x) as Tensor;
-        expectArraysClose(y1, tfc.ones([batchSize, units]).mul(scalar1));
-        y2 = model.predict(x) as Tensor;
-        expectArraysClose(y2, tfc.ones([batchSize, units]).mul(scalar2));
-      });
+
+      let y1 = model.predict(x) as Tensor;
+      expect(y1.kept).toBe(false);
+      let y1Expected =
+          tfc.tidy(() => tfc.ones([batchSize, units]).mul(scalar1));
+      expectArraysClose(await y1.array(), await y1Expected.array());
+
+      let y2 = model.predict(x) as Tensor;
+      expect(y2.kept).toBe(false);
+      // Future predicts should not dispose previous outputs.
+      expect(y1.isDisposed).toBe(false);
+      let y2Expected =
+          tfc.tidy(() => tfc.ones([batchSize, units]).mul(scalar2));
+      expectArraysClose(await y2.array(), await y2Expected.array());
+      tfc.dispose([y1, y2, y1Expected, y2Expected]);
+
       model.resetStates();
       const numTensors0 = tfc.memory().numTensors;
 
-      tfc.tidy(() => {
-        y1 = model.predict(x) as Tensor;
-        expectArraysClose(y1, tfc.ones([batchSize, units]).mul(scalar1));
-        y2 = model.predict(x) as Tensor;
-        expectArraysClose(y2, tfc.ones([batchSize, units]).mul(scalar2));
-      });
+      y1 = model.predict(x) as Tensor;
+      expect(y1.kept).toBe(false);
+      y1Expected = tfc.tidy(() => tfc.ones([batchSize, units]).mul(scalar1));
+      expectArraysClose(await y1.array(), await y1Expected.array());
+
+      y2 = model.predict(x) as Tensor;
+      expect(y2.kept).toBe(false);
+      // Future predicts should not dispose previous outputs.
+      expect(y1.isDisposed).toBe(false);
+      y2Expected = tfc.tidy(() => tfc.ones([batchSize, units]).mul(scalar2));
+      expectArraysClose(await y2.array(), await y2Expected.array());
+      tfc.dispose([y1, y2, y1Expected, y2Expected]);
+
       // Assert no memory leak, even without resetStates() being called.
       expect(tfc.memory().numTensors).toEqual(numTensors0);
     });
@@ -1332,7 +1347,7 @@ describeMathCPUAndGPU('GRU Tensor', () => {
   // print(model.predict(x))
   // print(model.predict(x))
   // ```
-  it('stateful forward', () => {
+  it('stateful forward', async () => {
     const sequenceLength = 3;
     const rnn = tfl.layers.gru({
       units,
@@ -1346,25 +1361,36 @@ describeMathCPUAndGPU('GRU Tensor', () => {
     const model = tfl.sequential();
     model.add(rnn);
     const x = tfc.ones([batchSize, sequenceLength, inputSize]);
-    tfc.tidy(() => {
-      const y1 = model.predict(x) as Tensor;
-      expectArraysClose(
-          y1, tfc.ones([batchSize, units]).mul(tfc.scalar(0.542)));
-      const y2 = model.predict(x) as Tensor;
-      expectArraysClose(
-          y2, tfc.ones([batchSize, units]).mul(tfc.scalar(0.9371182)));
-    });
+    const y1 = model.predict(x) as Tensor;
+    expect(y1.kept).toBe(false);
+    const y1Expected =
+        tfc.tidy(() => tfc.ones([batchSize, units]).mul(tfc.scalar(0.542)));
+    expectArraysClose(await y1.array(), await y1Expected.array());
+    const y2 = model.predict(x) as Tensor;
+    expect(y2.kept).toBe(false);
+    // Future predicts should not dispose previous outputs.
+    expect(y1.isDisposed).toBe(false);
+    const y2Expected =
+        tfc.tidy(() => tfc.ones([batchSize, units]).mul(tfc.scalar(0.9371182)));
+    expectArraysClose(await y2.array(), await y2Expected.array());
+
+    tfc.dispose([y1, y2, y1Expected, y2Expected]);
     model.resetStates();
     const numTensors0 = tfc.memory().numTensors;
 
-    tfc.tidy(() => {
-      const y3 = model.predict(x) as Tensor;
-      expectArraysClose(
-          y3, tfc.ones([batchSize, units]).mul(tfc.scalar(0.542)));
-      const y4 = model.predict(x) as Tensor;
-      expectArraysClose(
-          y4, tfc.ones([batchSize, units]).mul(tfc.scalar(0.9371182)));
-    });
+    const y3 = model.predict(x) as Tensor;
+    expect(y3.kept).toBe(false);
+    const y3Expected =
+        tfc.tidy(() => tfc.ones([batchSize, units]).mul(tfc.scalar(0.542)));
+    expectArraysClose(await y3.array(), await y3Expected.array());
+    const y4 = model.predict(x) as Tensor;
+    expect(y4.kept).toBe(false);
+    // Future predicts should not dispose previous outputs.
+    expect(y3.isDisposed).toBe(false);
+    const y4Expected =
+        tfc.tidy(() => tfc.ones([batchSize, units]).mul(tfc.scalar(0.9371182)));
+    expectArraysClose(await y4.array(), await y4Expected.array());
+    tfc.dispose([y3, y3Expected, y4, y4Expected]);
     // Assert no memory leak, even without resetStates() being called.
     expect(tfc.memory().numTensors).toEqual(numTensors0);
   });
@@ -1873,7 +1899,7 @@ describeMathCPUAndGPU('LSTM Tensor', () => {
     // print(model.predict(x))
     // print(model.predict(x))
     // ```
-    it('stateful forward', () => {
+    it('stateful forward', async () => {
       const sequenceLength = 3;
       const rnn = tfl.layers.lstm({
         units,
@@ -1887,25 +1913,36 @@ describeMathCPUAndGPU('LSTM Tensor', () => {
       model.add(rnn);
       const x = tfc.ones([batchSize, sequenceLength, inputSize]);
 
-      tfc.tidy(() => {
-        const y1 = model.predict(x) as Tensor;
-        expectArraysClose(
-            y1, tfc.ones([batchSize, units]).mul(tfc.scalar(0.995)));
-        const y2 = model.predict(x) as Tensor;
-        expectArraysClose(
-            y2, tfc.ones([batchSize, units]).mul(tfc.scalar(0.99998766)));
-      });
+      let y1 = model.predict(x) as Tensor;
+      expect(y1.kept).toBe(false);
+      let y1Expected =
+          tfc.tidy(() => tfc.ones([batchSize, units]).mul(tfc.scalar(0.995)));
+      expectArraysClose(await y1.array(), await y1Expected.array());
+      let y2 = model.predict(x) as Tensor;
+      expect(y2.kept).toBe(false);
+      // Future predicts should not dispose previous outputs.
+      expect(y1.isDisposed).toBe(false);
+      let y2Expected = tfc.tidy(
+          () => tfc.ones([batchSize, units]).mul(tfc.scalar(0.99998766)));
+      expectArraysClose(await y2.array(), await y2Expected.array());
+
+      tfc.dispose([y1, y2, y1Expected, y2Expected]);
       model.resetStates();
       const numTensors0 = tfc.memory().numTensors;
 
-      tfc.tidy(() => {
-        const y1 = model.predict(x) as Tensor;
-        expectArraysClose(
-            y1, tfc.ones([batchSize, units]).mul(tfc.scalar(0.995)));
-        const y2 = model.predict(x) as Tensor;
-        expectArraysClose(
-            y2, tfc.ones([batchSize, units]).mul(tfc.scalar(0.99998766)));
-      });
+      y1 = model.predict(x) as Tensor;
+      expect(y1.kept).toBe(false);
+      y1Expected =
+          tfc.tidy(() => tfc.ones([batchSize, units]).mul(tfc.scalar(0.995)));
+      expectArraysClose(await y1.array(), await y1Expected.array());
+      y2 = model.predict(x) as Tensor;
+      expect(y2.kept).toBe(false);
+      // Future predicts should not dispose previous outputs.
+      expect(y1.isDisposed).toBe(false);
+      y2Expected = tfc.tidy(
+          () => tfc.ones([batchSize, units]).mul(tfc.scalar(0.99998766)));
+      expectArraysClose(await y2.array(), await y2Expected.array());
+      tfc.dispose([y1, y2, y1Expected, y2Expected]);
       // Assert no memory leak, even without resetStates() being called.
       expect(tfc.memory().numTensors).toEqual(numTensors0);
     });

--- a/src/layers/recurrent_test.ts
+++ b/src/layers/recurrent_test.ts
@@ -13,7 +13,7 @@
  */
 
 import * as tfc from '@tensorflow/tfjs-core';
-import {randomNormal, Scalar, scalar, Tensor, tensor1d, tensor2d, tensor3d, tensor4d, test_util} from '@tensorflow/tfjs-core';
+import {randomNormal, Scalar, scalar, Tensor, tensor1d, tensor2d, tensor3d, tensor4d} from '@tensorflow/tfjs-core';
 
 import * as K from '../backend/tfjs_backend';
 import * as tfl from '../index';
@@ -25,8 +25,6 @@ import {describeMathCPU, describeMathCPUAndGPU, describeMathGPU, expectTensorsCl
 
 import {GRU, LSTM, rnn, RNN, RNNCell} from './recurrent';
 import {ActivationIdentifier} from '../keras_format/activation_config';
-
-const expectArraysClose = test_util.expectArraysClose;
 
 /**
  * A simplistic RNN step function for testing.
@@ -786,7 +784,7 @@ describeMathCPUAndGPU('SimpleRNN Tensor', () => {
       expect(y1.kept).toBe(false);
       let y1Expected =
           tfc.tidy(() => tfc.ones([batchSize, units]).mul(scalar1));
-      expectArraysClose(await y1.array(), await y1Expected.array());
+      expectTensorsClose(y1, y1Expected);
 
       let y2 = model.predict(x) as Tensor;
       expect(y2.kept).toBe(false);
@@ -794,7 +792,7 @@ describeMathCPUAndGPU('SimpleRNN Tensor', () => {
       expect(y1.isDisposed).toBe(false);
       let y2Expected =
           tfc.tidy(() => tfc.ones([batchSize, units]).mul(scalar2));
-      expectArraysClose(await y2.array(), await y2Expected.array());
+      expectTensorsClose(y2, y2Expected);
       tfc.dispose([y1, y2, y1Expected, y2Expected]);
 
       model.resetStates();
@@ -803,14 +801,14 @@ describeMathCPUAndGPU('SimpleRNN Tensor', () => {
       y1 = model.predict(x) as Tensor;
       expect(y1.kept).toBe(false);
       y1Expected = tfc.tidy(() => tfc.ones([batchSize, units]).mul(scalar1));
-      expectArraysClose(await y1.array(), await y1Expected.array());
+      expectTensorsClose(y1, y1Expected);
 
       y2 = model.predict(x) as Tensor;
       expect(y2.kept).toBe(false);
       // Future predicts should not dispose previous outputs.
       expect(y1.isDisposed).toBe(false);
       y2Expected = tfc.tidy(() => tfc.ones([batchSize, units]).mul(scalar2));
-      expectArraysClose(await y2.array(), await y2Expected.array());
+      expectTensorsClose(y2, y2Expected);
       tfc.dispose([y1, y2, y1Expected, y2Expected]);
 
       // Assert no memory leak, even without resetStates() being called.
@@ -1365,14 +1363,14 @@ describeMathCPUAndGPU('GRU Tensor', () => {
     expect(y1.kept).toBe(false);
     const y1Expected =
         tfc.tidy(() => tfc.ones([batchSize, units]).mul(tfc.scalar(0.542)));
-    expectArraysClose(await y1.array(), await y1Expected.array());
+    expectTensorsClose(y1, y1Expected);
     const y2 = model.predict(x) as Tensor;
     expect(y2.kept).toBe(false);
     // Future predicts should not dispose previous outputs.
     expect(y1.isDisposed).toBe(false);
     const y2Expected =
         tfc.tidy(() => tfc.ones([batchSize, units]).mul(tfc.scalar(0.9371182)));
-    expectArraysClose(await y2.array(), await y2Expected.array());
+    expectTensorsClose(y2, y2Expected);
 
     tfc.dispose([y1, y2, y1Expected, y2Expected]);
     model.resetStates();
@@ -1382,14 +1380,14 @@ describeMathCPUAndGPU('GRU Tensor', () => {
     expect(y3.kept).toBe(false);
     const y3Expected =
         tfc.tidy(() => tfc.ones([batchSize, units]).mul(tfc.scalar(0.542)));
-    expectArraysClose(await y3.array(), await y3Expected.array());
+    expectTensorsClose(y3, y3Expected);
     const y4 = model.predict(x) as Tensor;
     expect(y4.kept).toBe(false);
     // Future predicts should not dispose previous outputs.
     expect(y3.isDisposed).toBe(false);
     const y4Expected =
         tfc.tidy(() => tfc.ones([batchSize, units]).mul(tfc.scalar(0.9371182)));
-    expectArraysClose(await y4.array(), await y4Expected.array());
+    expectTensorsClose(y4, y4Expected);
     tfc.dispose([y3, y3Expected, y4, y4Expected]);
     // Assert no memory leak, even without resetStates() being called.
     expect(tfc.memory().numTensors).toEqual(numTensors0);
@@ -1917,14 +1915,14 @@ describeMathCPUAndGPU('LSTM Tensor', () => {
       expect(y1.kept).toBe(false);
       let y1Expected =
           tfc.tidy(() => tfc.ones([batchSize, units]).mul(tfc.scalar(0.995)));
-      expectArraysClose(await y1.array(), await y1Expected.array());
+      expectTensorsClose(y1, y1Expected);
       let y2 = model.predict(x) as Tensor;
       expect(y2.kept).toBe(false);
       // Future predicts should not dispose previous outputs.
       expect(y1.isDisposed).toBe(false);
       let y2Expected = tfc.tidy(
           () => tfc.ones([batchSize, units]).mul(tfc.scalar(0.99998766)));
-      expectArraysClose(await y2.array(), await y2Expected.array());
+      expectTensorsClose(y2, y2Expected);
 
       tfc.dispose([y1, y2, y1Expected, y2Expected]);
       model.resetStates();
@@ -1934,14 +1932,14 @@ describeMathCPUAndGPU('LSTM Tensor', () => {
       expect(y1.kept).toBe(false);
       y1Expected =
           tfc.tidy(() => tfc.ones([batchSize, units]).mul(tfc.scalar(0.995)));
-      expectArraysClose(await y1.array(), await y1Expected.array());
+      expectTensorsClose(y1, y1Expected);
       y2 = model.predict(x) as Tensor;
       expect(y2.kept).toBe(false);
       // Future predicts should not dispose previous outputs.
       expect(y1.isDisposed).toBe(false);
       y2Expected = tfc.tidy(
           () => tfc.ones([batchSize, units]).mul(tfc.scalar(0.99998766)));
-      expectArraysClose(await y2.array(), await y2Expected.array());
+      expectTensorsClose(y2, y2Expected);
       tfc.dispose([y1, y2, y1Expected, y2Expected]);
       // Assert no memory leak, even without resetStates() being called.
       expect(tfc.memory().numTensors).toEqual(numTensors0);

--- a/src/metrics_test.ts
+++ b/src/metrics_test.ts
@@ -52,21 +52,21 @@ describeMathCPUAndGPU('sparseCategoricalAccuracy', () => {
     const yPred = tensor2d(
         [[0, 1, 0], [1, 0, 0], [0, 0.4, 0.6], [0, 0.6, 0.4], [0.7, 0.3, 0]]);
     const accuracy = tfl.metrics.sparseCategoricalAccuracy(yTrue, yPred);
-    expectTensorsClose(accuracy, tensor1d([1, 0, 1, 0, 1], 'bool'));
+    expectTensorsClose(accuracy.toBool(), tensor1d([1, 0, 1, 0, 1], 'bool'));
   });
   it('1D int32 yTrue, 2D yPred', () => {
     const yTrue = tensor1d([1, 1, 2, 2, 0], 'int32');
     const yPred = tensor2d(
         [[0, 1, 0], [1, 0, 0], [0, 0.4, 0.6], [0, 0.6, 0.4], [0.7, 0.3, 0]]);
     const accuracy = tfl.metrics.sparseCategoricalAccuracy(yTrue, yPred);
-    expectTensorsClose(accuracy, tensor1d([1, 0, 1, 0, 1], 'bool'));
+    expectTensorsClose(accuracy.toBool(), tensor1d([1, 0, 1, 0, 1], 'bool'));
   });
   it('2D int32 yTrue, 2D yPred', () => {
     const yTrue = tensor2d([1, 1, 2, 2, 0], [5, 1], 'int32');
     const yPred = tensor2d(
         [[0, 1, 0], [1, 0, 0], [0, 0.4, 0.6], [0, 0.6, 0.4], [0.7, 0.3, 0]]);
     const accuracy = tfl.metrics.sparseCategoricalAccuracy(yTrue, yPred);
-    expectTensorsClose(accuracy, tensor1d([1, 0, 1, 0, 1], 'bool'));
+    expectTensorsClose(accuracy.toBool(), tensor1d([1, 0, 1, 0, 1], 'bool'));
   });
 });
 

--- a/src/metrics_test.ts
+++ b/src/metrics_test.ts
@@ -52,21 +52,21 @@ describeMathCPUAndGPU('sparseCategoricalAccuracy', () => {
     const yPred = tensor2d(
         [[0, 1, 0], [1, 0, 0], [0, 0.4, 0.6], [0, 0.6, 0.4], [0.7, 0.3, 0]]);
     const accuracy = tfl.metrics.sparseCategoricalAccuracy(yTrue, yPred);
-    expectTensorsClose(accuracy, tensor1d([1, 0, 1, 0, 1]));
+    expectTensorsClose(accuracy, tensor1d([1, 0, 1, 0, 1], 'bool'));
   });
   it('1D int32 yTrue, 2D yPred', () => {
     const yTrue = tensor1d([1, 1, 2, 2, 0], 'int32');
     const yPred = tensor2d(
         [[0, 1, 0], [1, 0, 0], [0, 0.4, 0.6], [0, 0.6, 0.4], [0.7, 0.3, 0]]);
     const accuracy = tfl.metrics.sparseCategoricalAccuracy(yTrue, yPred);
-    expectTensorsClose(accuracy, tensor1d([1, 0, 1, 0, 1]));
+    expectTensorsClose(accuracy, tensor1d([1, 0, 1, 0, 1], 'bool'));
   });
   it('2D int32 yTrue, 2D yPred', () => {
     const yTrue = tensor2d([1, 1, 2, 2, 0], [5, 1], 'int32');
     const yPred = tensor2d(
         [[0, 1, 0], [1, 0, 0], [0, 0.4, 0.6], [0, 0.6, 0.4], [0.7, 0.3, 0]]);
     const accuracy = tfl.metrics.sparseCategoricalAccuracy(yTrue, yPred);
-    expectTensorsClose(accuracy, tensor1d([1, 0, 1, 0, 1]));
+    expectTensorsClose(accuracy, tensor1d([1, 0, 1, 0, 1], 'bool'));
   });
 });
 

--- a/src/utils/test_utils.ts
+++ b/src/utils/test_utils.ts
@@ -43,7 +43,10 @@ export function expectTensorsClose(
     throw new ValueError(
         'Second argument to expectTensorsClose() is not defined.');
   }
-  test_util.expectArraysClose(actual, expected, epsilon);
+  const actualData = actual instanceof Tensor ? actual.dataSync() : actual;
+  const expectedData =
+      expected instanceof Tensor ? expected.dataSync() : expected;
+  test_util.expectArraysClose(actualData, expectedData, epsilon);
 }
 
 /**

--- a/src/utils/test_utils.ts
+++ b/src/utils/test_utils.ts
@@ -12,7 +12,7 @@
  * Testing utilities.
  */
 
-import {memory, Tensor, test_util} from '@tensorflow/tfjs-core';
+import {memory, Tensor, test_util, util} from '@tensorflow/tfjs-core';
 import {ALL_ENVS, describeWithFlags, registerTestEnv} from '@tensorflow/tfjs-core/dist/jasmine_util';
 import {ValueError} from '../errors';
 
@@ -42,6 +42,13 @@ export function expectTensorsClose(
   if (expected == null) {
     throw new ValueError(
         'Second argument to expectTensorsClose() is not defined.');
+  }
+  if (actual instanceof Tensor && expected instanceof Tensor) {
+    if (!util.arraysEqual(actual.shape, expected.shape)) {
+      throw new Error(
+          `Shapes do not match. Actual: [${actual.shape}]. ` +
+          `Expected: [${expected.shape}].`);
+    }
   }
   const actualData = actual instanceof Tensor ? actual.dataSync() : actual;
   const expectedData =

--- a/src/utils/test_utils.ts
+++ b/src/utils/test_utils.ts
@@ -44,6 +44,11 @@ export function expectTensorsClose(
         'Second argument to expectTensorsClose() is not defined.');
   }
   if (actual instanceof Tensor && expected instanceof Tensor) {
+    if (actual.dtype !== expected.dtype) {
+      throw new Error(
+          `Data types do not match. Actual: '${actual.dtype}'. ` +
+          `Expected: '${expected.dtype}'`);
+    }
     if (!util.arraysEqual(actual.shape, expected.shape)) {
       throw new Error(
           `Shapes do not match. Actual: [${actual.shape}]. ` +

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@tensorflow/tfjs-core@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.1.0.tgz#028c69291e19c328c4c30e18d29b09135c22cb44"
-  integrity sha512-loPpHGVjiyEb+Ixlsj8prQ/r4exekITn7vM4WEyHUouFKx0/CuoB2FQ0m6DSb/6ApvucxTWGGNTRRo4HK4Ma0Q==
+"@tensorflow/tfjs-core@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.1.2.tgz#efb8b3688fbff353e51d41a3d832dde8c1bc321d"
+  integrity sha512-xCAUIAh14OFnHt+IQUUZIH/P/jH/EWvewL0Ty6q6USUx4YZ+HvKwNw1G7h/gKki4A31BJ0avD04ylBKc75laGg==
   dependencies:
     "@types/seedrandom" "2.4.27"
     "@types/webgl-ext" "0.0.30"


### PR DESCRIPTION
Update core dependency to 1.1.2

**Details**
- Fix all the build errors introduced by change in the signature of `expectArraysEqual/Close` where `Tensor` is not a valid entry anymore, and we want to avoid calling `dataSync()` in unit test so we can run unit tests against async-only backends
- Remove `typescript.format.*` rules in `.vscode/settings.json` since it hints to vscode to use the built-in formatter.
- Fix a bug in recurrent cell where the following happened:
```
y1 = model.predict(x)
// y1.kept is true, but should be false
y2 = model.predict(x)
// y1.isDisposed is true, but should be false
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/533)
<!-- Reviewable:end -->
