### PR TITLE
Fix metrics examples in comments to make them executable in webpage

### DIFF
--- a/src/exports_metrics.ts
+++ b/src/exports_metrics.ts
@@ -16,7 +16,7 @@ import * as metrics from './metrics';
  * @doc {
  *   heading: 'Metrics',
  *   namespace: 'metrics',
- *   useDocsFrom: 'binaryAccuracy'
+ *   useDocsFrom: '_binaryAccuracy'
  * }
  */
 export function binaryAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
@@ -27,7 +27,7 @@ export function binaryAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
  * @doc {
  *   heading: 'Metrics',
  *   namespace: 'metrics',
- *   useDocsFrom: 'binaryCrossentropy'
+ *   useDocsFrom: '_binaryCrossentropy'
  * }
  */
 export function binaryCrossentropy(yTrue: Tensor, yPred: Tensor): Tensor {
@@ -38,7 +38,7 @@ export function binaryCrossentropy(yTrue: Tensor, yPred: Tensor): Tensor {
  * @doc {
  *   heading: 'Metrics',
  *   namespace: 'metrics',
- *   useDocsFrom: 'sparseCategoricalAccuracy'
+ *   useDocsFrom: '_sparseCategoricalAccuracy'
  * }
  */
 export function sparseCategoricalAccuracy(
@@ -50,7 +50,7 @@ export function sparseCategoricalAccuracy(
  * @doc {
  *   heading: 'Metrics',
  *   namespace: 'metrics',
- *   useDocsFrom: 'categoricalAccuracy'
+ *   useDocsFrom: '_categoricalAccuracy'
  * }
  */
 export function categoricalAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
@@ -61,7 +61,7 @@ export function categoricalAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
  * @doc {
  *   heading: 'Metrics',
  *   namespace: 'metrics',
- *   useDocsFrom: 'categoricalCrossentropy'
+ *   useDocsFrom: '_categoricalCrossentropy'
  * }
  */
 export function categoricalCrossentropy(yTrue: Tensor, yPred: Tensor): Tensor {
@@ -72,7 +72,7 @@ export function categoricalCrossentropy(yTrue: Tensor, yPred: Tensor): Tensor {
  * @doc {
  *   heading: 'Metrics',
  *   namespace: 'metrics',
- *   useDocsFrom: 'precision'
+ *   useDocsFrom: '_precision'
  * }
  */
 export function precision(yTrue: Tensor, yPred: Tensor): Tensor {
@@ -83,7 +83,7 @@ export function precision(yTrue: Tensor, yPred: Tensor): Tensor {
  * @doc {
  *   heading: 'Metrics',
  *   namespace: 'metrics',
- *   useDocsFrom: 'recall'
+ *   useDocsFrom: '_recall'
  * }
  */
 export function recall(yTrue: Tensor, yPred: Tensor): Tensor {
@@ -94,7 +94,7 @@ export function recall(yTrue: Tensor, yPred: Tensor): Tensor {
  * @doc {
  *   heading: 'Metrics',
  *   namespace: 'metrics',
- *   useDocsFrom: 'cosineProximity'
+ *   useDocsFrom: '_cosineProximity'
  * }
  */
 export function cosineProximity(yTrue: Tensor, yPred: Tensor): Tensor {
@@ -105,7 +105,7 @@ export function cosineProximity(yTrue: Tensor, yPred: Tensor): Tensor {
  * @doc {
  *   heading: 'Metrics',
  *   namespace: 'metrics',
- *   useDocsFrom: 'meanAbsoluteError'
+ *   useDocsFrom: '_meanAbsoluteError'
  * }
  */
 export function meanAbsoluteError(yTrue: Tensor, yPred: Tensor): Tensor {
@@ -116,7 +116,7 @@ export function meanAbsoluteError(yTrue: Tensor, yPred: Tensor): Tensor {
  * @doc {
  *   heading: 'Metrics',
  *   namespace: 'metrics',
- *   useDocsFrom: 'meanAbsolutePercentageError'
+ *   useDocsFrom: '_meanAbsolutePercentageError'
  * }
  */
 export function meanAbsolutePercentageError(
@@ -136,7 +136,7 @@ export function mape(yTrue: Tensor, yPred: Tensor): Tensor {
  * @doc {
  *   heading: 'Metrics',
  *   namespace: 'metrics',
- *   useDocsFrom: 'meanSquaredError'
+ *   useDocsFrom: '_meanSquaredError'
  * }
  */
 export function meanSquaredError(yTrue: Tensor, yPred: Tensor): Tensor {

--- a/src/exports_metrics.ts
+++ b/src/exports_metrics.ts
@@ -16,7 +16,7 @@ import * as metrics from './metrics';
  * @doc {
  *   heading: 'Metrics',
  *   namespace: 'metrics',
- *   useDocsFrom: '_binaryAccuracy'
+ *   useDocsFrom: 'binaryAccuracy'
  * }
  */
 export function binaryAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
@@ -27,7 +27,7 @@ export function binaryAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
  * @doc {
  *   heading: 'Metrics',
  *   namespace: 'metrics',
- *   useDocsFrom: '_binaryCrossentropy'
+ *   useDocsFrom: 'binaryCrossentropy'
  * }
  */
 export function binaryCrossentropy(yTrue: Tensor, yPred: Tensor): Tensor {
@@ -38,7 +38,7 @@ export function binaryCrossentropy(yTrue: Tensor, yPred: Tensor): Tensor {
  * @doc {
  *   heading: 'Metrics',
  *   namespace: 'metrics',
- *   useDocsFrom: '_sparseCategoricalAccuracy'
+ *   useDocsFrom: 'sparseCategoricalAccuracy'
  * }
  */
 export function sparseCategoricalAccuracy(
@@ -50,7 +50,7 @@ export function sparseCategoricalAccuracy(
  * @doc {
  *   heading: 'Metrics',
  *   namespace: 'metrics',
- *   useDocsFrom: '_categoricalAccuracy'
+ *   useDocsFrom: 'categoricalAccuracy'
  * }
  */
 export function categoricalAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
@@ -61,7 +61,7 @@ export function categoricalAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
  * @doc {
  *   heading: 'Metrics',
  *   namespace: 'metrics',
- *   useDocsFrom: '_categoricalCrossentropy'
+ *   useDocsFrom: 'categoricalCrossentropy'
  * }
  */
 export function categoricalCrossentropy(yTrue: Tensor, yPred: Tensor): Tensor {
@@ -72,7 +72,7 @@ export function categoricalCrossentropy(yTrue: Tensor, yPred: Tensor): Tensor {
  * @doc {
  *   heading: 'Metrics',
  *   namespace: 'metrics',
- *   useDocsFrom: '_precision'
+ *   useDocsFrom: 'precision'
  * }
  */
 export function precision(yTrue: Tensor, yPred: Tensor): Tensor {
@@ -83,7 +83,7 @@ export function precision(yTrue: Tensor, yPred: Tensor): Tensor {
  * @doc {
  *   heading: 'Metrics',
  *   namespace: 'metrics',
- *   useDocsFrom: '_recall'
+ *   useDocsFrom: 'recall'
  * }
  */
 export function recall(yTrue: Tensor, yPred: Tensor): Tensor {
@@ -94,7 +94,7 @@ export function recall(yTrue: Tensor, yPred: Tensor): Tensor {
  * @doc {
  *   heading: 'Metrics',
  *   namespace: 'metrics',
- *   useDocsFrom: '_cosineProximity'
+ *   useDocsFrom: 'cosineProximity'
  * }
  */
 export function cosineProximity(yTrue: Tensor, yPred: Tensor): Tensor {
@@ -105,7 +105,7 @@ export function cosineProximity(yTrue: Tensor, yPred: Tensor): Tensor {
  * @doc {
  *   heading: 'Metrics',
  *   namespace: 'metrics',
- *   useDocsFrom: '_meanAbsoluteError'
+ *   useDocsFrom: 'meanAbsoluteError'
  * }
  */
 export function meanAbsoluteError(yTrue: Tensor, yPred: Tensor): Tensor {
@@ -116,7 +116,7 @@ export function meanAbsoluteError(yTrue: Tensor, yPred: Tensor): Tensor {
  * @doc {
  *   heading: 'Metrics',
  *   namespace: 'metrics',
- *   useDocsFrom: '_meanAbsolutePercentageError'
+ *   useDocsFrom: 'meanAbsolutePercentageError'
  * }
  */
 export function meanAbsolutePercentageError(
@@ -136,7 +136,7 @@ export function mape(yTrue: Tensor, yPred: Tensor): Tensor {
  * @doc {
  *   heading: 'Metrics',
  *   namespace: 'metrics',
- *   useDocsFrom: '_meanSquaredError'
+ *   useDocsFrom: 'meanSquaredError'
  * }
  */
 export function meanSquaredError(yTrue: Tensor, yPred: Tensor): Tensor {

--- a/src/losses.ts
+++ b/src/losses.ts
@@ -51,6 +51,7 @@ export function l2Normalize(x: Tensor, axis?: number): Tensor {
  * @param yPred Prediction Tensor.
  * @return Mean squared error Tensor.
  */
+/** @doc { docsForwardAlias: '_meanSquaredError'} */
 export function meanSquaredError(yTrue: Tensor, yPred: Tensor): Tensor {
   return tidy(() => tfc.mean(K.square(tfc.sub(yPred, yTrue)), -1));
 }
@@ -73,6 +74,7 @@ export function meanSquaredError(yTrue: Tensor, yPred: Tensor): Tensor {
  * @param yPred Prediction Tensor.
  * @return Mean absolute error Tensor.
  */
+/** @doc { docsForwardAlias: '_meanAbsoluteError'} */
 export function meanAbsoluteError(yTrue: Tensor, yPred: Tensor): Tensor {
   return tidy(() => tfc.mean(tfc.abs(tfc.sub(yPred, yTrue)), -1));
 }
@@ -93,6 +95,7 @@ export function meanAbsoluteError(yTrue: Tensor, yPred: Tensor): Tensor {
  * @param yPred Prediction Tensor.
  * @return Mean absolute percentage error Tensor.
  */
+/** @doc { docsForwardAlias: '_meanAbsolutePercentageError'} */
 export function meanAbsolutePercentageError(
     yTrue: Tensor, yPred: Tensor): Tensor {
   return tidy(() => {
@@ -161,12 +164,10 @@ export function logcosh(yTrue: Tensor, yPred: Tensor): Tensor {
 /**
  * Categorical crossentropy between an output tensor and a target tensor.
  *
- * @param target A tensor of the same shape as `output`.
- * @param output A tensor resulting from a softmax (unless `fromLogits` is
- *  `true`, in which case `output` is expected to be the logits).
- * @param fromLogits Boolean, whether `output` is the result of a softmax, or is
- *   a tensor of logits.
+ * @param yTrue A tensor of the same shape as `output`.
+ * @param yPred A tensor resulting from a softmax.
  */
+/** @doc { docsForwardAlias: '_categoricalCrossentropy'} */
 export function categoricalCrossentropy(
     target: Tensor, output: Tensor, fromLogits = false): Tensor {
   return tidy(() => {
@@ -192,6 +193,7 @@ export function categoricalCrossentropy(
  * @param fromLogits Boolean, whether `output` is the result of a softmax, or is
  *   a tensor of logits.
  */
+/** @doc { docsForwardAlias: '_sparseCategoricalCrossentropy'} */
 export function sparseCategoricalCrossentropy(
     target: Tensor, output: Tensor): Tensor {
   return tidy(() => {
@@ -292,6 +294,7 @@ export function poisson(yTrue: Tensor, yPred: Tensor): Tensor {
  * @param yPred Prediction Tensor.
  * @return Cosine proximity Tensor.
  */
+/** @doc { docsForwardAlias: '_cosineProximity'} */
 export function cosineProximity(yTrue: Tensor, yPred: Tensor): Tensor {
   return tidy(() => {
     const trueNormalized = l2Normalize(yTrue, -1);

--- a/src/losses.ts
+++ b/src/losses.ts
@@ -51,7 +51,6 @@ export function l2Normalize(x: Tensor, axis?: number): Tensor {
  * @param yPred Prediction Tensor.
  * @return Mean squared error Tensor.
  */
-/** @doc { docsForwardAlias: '_meanSquaredError'} */
 export function meanSquaredError(yTrue: Tensor, yPred: Tensor): Tensor {
   return tidy(() => tfc.mean(K.square(tfc.sub(yPred, yTrue)), -1));
 }
@@ -74,7 +73,6 @@ export function meanSquaredError(yTrue: Tensor, yPred: Tensor): Tensor {
  * @param yPred Prediction Tensor.
  * @return Mean absolute error Tensor.
  */
-/** @doc { docsForwardAlias: '_meanAbsoluteError'} */
 export function meanAbsoluteError(yTrue: Tensor, yPred: Tensor): Tensor {
   return tidy(() => tfc.mean(tfc.abs(tfc.sub(yPred, yTrue)), -1));
 }
@@ -95,7 +93,6 @@ export function meanAbsoluteError(yTrue: Tensor, yPred: Tensor): Tensor {
  * @param yPred Prediction Tensor.
  * @return Mean absolute percentage error Tensor.
  */
-/** @doc { docsForwardAlias: '_meanAbsolutePercentageError'} */
 export function meanAbsolutePercentageError(
     yTrue: Tensor, yPred: Tensor): Tensor {
   return tidy(() => {
@@ -167,7 +164,6 @@ export function logcosh(yTrue: Tensor, yPred: Tensor): Tensor {
  * @param yTrue A tensor of the same shape as `output`.
  * @param yPred A tensor resulting from a softmax.
  */
-/** @doc { docsForwardAlias: '_categoricalCrossentropy'} */
 export function categoricalCrossentropy(
     target: Tensor, output: Tensor, fromLogits = false): Tensor {
   return tidy(() => {
@@ -193,7 +189,6 @@ export function categoricalCrossentropy(
  * @param fromLogits Boolean, whether `output` is the result of a softmax, or is
  *   a tensor of logits.
  */
-/** @doc { docsForwardAlias: '_sparseCategoricalCrossentropy'} */
 export function sparseCategoricalCrossentropy(
     target: Tensor, output: Tensor): Tensor {
   return tidy(() => {
@@ -294,7 +289,6 @@ export function poisson(yTrue: Tensor, yPred: Tensor): Tensor {
  * @param yPred Prediction Tensor.
  * @return Cosine proximity Tensor.
  */
-/** @doc { docsForwardAlias: '_cosineProximity'} */
 export function cosineProximity(yTrue: Tensor, yPred: Tensor): Tensor {
   return tidy(() => {
     const trueNormalized = l2Normalize(yTrue, -1);

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -47,7 +47,6 @@ import {LossOrMetricFn} from './types';
  * @param yPred Binary Tensor of prediction.
  * @return Accuracy Tensor.
  */
-/** @doc { docsForwardAlias: '_binaryAccuracy'} */
 export function binaryAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
   return tidy(() => {
     const threshold = tfc.mul(.5, tfc.onesLike(yPred));
@@ -72,7 +71,6 @@ export function binaryAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
  *   same categories as in `yTrue`.
  * @return Accuracy Tensor.
  */
-/** @doc { docsForwardAlias: '_categoricalAccuracy'} */
 export function categoricalAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
   return tidy(
       () => K.cast(
@@ -130,7 +128,6 @@ function falsePositives(yTrue: Tensor, yPred: Tensor): Tensor {
  * @param yPred The predicted values. Expected to be contain only 0-1 values.
  * @return Precision Tensor.
  */
-/** @doc { docsForwardAlias: '_precision'} */
 export function precision(yTrue: Tensor, yPred: Tensor): Tensor {
   return tidy(() => {
     const tp = truePositives(yTrue, yPred);
@@ -176,7 +173,6 @@ export function precision(yTrue: Tensor, yPred: Tensor): Tensor {
  * @param yPred The predicted values. Expected to be contain only 0-1 values.
  * @return Recall Tensor.
  */
-/** @doc { docsForwardAlias: '_recall'} */
 export function recall(yTrue: Tensor, yPred: Tensor): Tensor {
   return tidy(() => {
     const tp = truePositives(yTrue, yPred);
@@ -204,7 +200,6 @@ export function recall(yTrue: Tensor, yPred: Tensor): Tensor {
  * @param yPred Binary Tensor of prediction, probabilities for the `1` case.
  * @return Accuracy Tensor.
  */
-/** @doc { docsForwardAlias: '_binaryCrossentropy'} */
 export function binaryCrossentropy(yTrue: Tensor, yPred: Tensor): Tensor {
   return lossBinaryCrossentropy(yTrue, yPred);
 }
@@ -225,7 +220,6 @@ export function binaryCrossentropy(yTrue: Tensor, yPred: Tensor): Tensor {
  * @param yPred Predicted probabilities or logits.
  * @returns Accuracy tensor.
  */
-/** @doc { docsForwardAlias: '_sparseCategoricalAccuracy'} */
 export function sparseCategoricalAccuracy(
     yTrue: Tensor, yPred: Tensor): Tensor {
   if (yTrue.rank === yPred.rank) {

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -25,9 +25,9 @@ import {LossOrMetricFn} from './types';
  *
  * `yTrue` and `yPred` can have 0-1 values. Example:
  * ```js
- * const x = tensor2d([[1, 1, 1, 1], [0, 0, 0, 0]], [2, 4]);
- * const y = tensor2d([[1, 0, 1, 0], [0, 0, 0, 1]], [2, 4]);
- * const accuracy = tfl.metrics.binaryAccuracy(x, y);
+ * const x = tf.tensor2d([[1, 1, 1, 1], [0, 0, 0, 0]], [2, 4]);
+ * const y = tf.tensor2d([[1, 0, 1, 0], [0, 0, 0, 1]], [2, 4]);
+ * const accuracy = tf.metrics.binaryAccuracy(x, y);
  * accuracy.print();
  * ```
  *
@@ -37,8 +37,8 @@ import {LossOrMetricFn} from './types';
  * )
  * Example:
  * ```js
- * const x = tensor1d([1, 1, 1, 1, 0, 0, 0, 0]);
- * const y = tensor1d([0.2, 0.4, 0.6, 0.8, 0.2, 0.3, 0.4, 0.7]);
+ * const x = tf.tensor1d([1, 1, 1, 1, 0, 0, 0, 0]);
+ * const y = tf.tensor1d([0.2, 0.4, 0.6, 0.8, 0.2, 0.3, 0.4, 0.7]);
  * const accuracy = tf.metrics.binaryAccuracy(x, y);
  * accuracy.print();
  * ```
@@ -47,6 +47,7 @@ import {LossOrMetricFn} from './types';
  * @param yPred Binary Tensor of prediction.
  * @return Accuracy Tensor.
  */
+/** @doc { docsForwardAlias: '_binaryAccuracy'} */
 export function binaryAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
   return tidy(() => {
     const threshold = tfc.mul(.5, tfc.onesLike(yPred));
@@ -60,8 +61,8 @@ export function binaryAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
  *
  * Example:
  * ```js
- * const x = tensor2d([[0, 0, 0, 1], [0, 0, 0, 1]]);
- * const y = tensor2d([[0.1, 0.8, 0.05, 0.05], [0.1, 0.05, 0.05, 0.8]]);
+ * const x = tf.tensor2d([[0, 0, 0, 1], [0, 0, 0, 1]]);
+ * const y = tf.tensor2d([[0.1, 0.8, 0.05, 0.05], [0.1, 0.05, 0.05, 0.8]]);
  * const accuracy = tf.metrics.categoricalAccuracy(x, y);
  * accuracy.print();
  * ```
@@ -71,6 +72,7 @@ export function binaryAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
  *   same categories as in `yTrue`.
  * @return Accuracy Tensor.
  */
+/** @doc { docsForwardAlias: '_categoricalAccuracy'} */
 export function categoricalAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
   return tidy(
       () => K.cast(
@@ -100,21 +102,21 @@ function falsePositives(yTrue: Tensor, yPred: Tensor): Tensor {
  *
  * Example:
  * ```js
- * const x = tensor2d(
+ * const x = tf.tensor2d(
  *    [
  *      [0, 0, 0, 1],
  *      [0, 1, 0, 0],
- *      [0, 0, 0, 1].
+ *      [0, 0, 0, 1],
  *      [1, 0, 0, 0],
  *      [0, 0, 1, 0]
  *    ]
  * );
  *
- * const y = tensor2d(
+ * const y = tf.tensor2d(
  *    [
  *      [0, 0, 1, 0],
  *      [0, 1, 0, 0],
- *      [0, 0, 0, 1].
+ *      [0, 0, 0, 1],
  *      [0, 1, 0, 0],
  *      [0, 1, 0, 0]
  *    ]
@@ -128,6 +130,7 @@ function falsePositives(yTrue: Tensor, yPred: Tensor): Tensor {
  * @param yPred The predicted values. Expected to be contain only 0-1 values.
  * @return Precision Tensor.
  */
+/** @doc { docsForwardAlias: '_precision'} */
 export function precision(yTrue: Tensor, yPred: Tensor): Tensor {
   return tidy(() => {
     const tp = truePositives(yTrue, yPred);
@@ -145,21 +148,21 @@ export function precision(yTrue: Tensor, yPred: Tensor): Tensor {
  *
  * Example:
  * ```js
- * const x = tensor2d(
+ * const x = tf.tensor2d(
  *    [
  *      [0, 0, 0, 1],
  *      [0, 1, 0, 0],
- *      [0, 0, 0, 1].
+ *      [0, 0, 0, 1],
  *      [1, 0, 0, 0],
  *      [0, 0, 1, 0]
  *    ]
  * );
  *
- * const y = tensor2d(
+ * const y = tf.tensor2d(
  *    [
  *      [0, 0, 1, 0],
  *      [0, 1, 0, 0],
- *      [0, 0, 0, 1].
+ *      [0, 0, 0, 1],
  *      [0, 1, 0, 0],
  *      [0, 1, 0, 0]
  *    ]
@@ -173,6 +176,7 @@ export function precision(yTrue: Tensor, yPred: Tensor): Tensor {
  * @param yPred The predicted values. Expected to be contain only 0-1 values.
  * @return Recall Tensor.
  */
+/** @doc { docsForwardAlias: '_recall'} */
 export function recall(yTrue: Tensor, yPred: Tensor): Tensor {
   return tidy(() => {
     const tp = truePositives(yTrue, yPred);
@@ -190,8 +194,8 @@ export function recall(yTrue: Tensor, yPred: Tensor): Tensor {
  *
  * Example:
  * ```js
- * const x = tensor2d([[0], [1], [1], [1]]);
- * const y = tensor2d([[0], [0], [0.5], [1]]);
+ * const x = tf.tensor2d([[0], [1], [1], [1]]);
+ * const y = tf.tensor2d([[0], [0], [0.5], [1]]);
  * const crossentropy = tf.metrics.binaryCrossentropy(x, y);
  * crossentropy.print();
  * ```
@@ -200,6 +204,7 @@ export function recall(yTrue: Tensor, yPred: Tensor): Tensor {
  * @param yPred Binary Tensor of prediction, probabilities for the `1` case.
  * @return Accuracy Tensor.
  */
+/** @doc { docsForwardAlias: '_binaryCrossentropy'} */
 export function binaryCrossentropy(yTrue: Tensor, yPred: Tensor): Tensor {
   return lossBinaryCrossentropy(yTrue, yPred);
 }
@@ -207,9 +212,10 @@ export function binaryCrossentropy(yTrue: Tensor, yPred: Tensor): Tensor {
 /**
  * Sparse categorical accuracy metric function.
  *
- * ```Example:
- * const yTrue = tensor1d([1, 1, 2, 2, 0]);
- * const yPred = tensor2d(
+ * Example:
+ * ```js
+ * const yTrue = tf.tensor1d([1, 1, 2, 2, 0]);
+ * const yPred = tf.tensor2d(
  *      [[0, 1, 0], [1, 0, 0], [0, 0.4, 0.6], [0, 0.6, 0.4], [0.7, 0.3, 0]]);
  * const crossentropy = tf.metrics.sparseCategoricalAccuracy(yTrue, yPred);
  * crossentropy.print();
@@ -219,6 +225,7 @@ export function binaryCrossentropy(yTrue: Tensor, yPred: Tensor): Tensor {
  * @param yPred Predicted probabilities or logits.
  * @returns Accuracy tensor.
  */
+/** @doc { docsForwardAlias: '_sparseCategoricalAccuracy'} */
 export function sparseCategoricalAccuracy(
     yTrue: Tensor, yPred: Tensor): Tensor {
   if (yTrue.rank === yPred.rank) {


### PR DESCRIPTION
MISC

### In this PR

* ~~Fix `useDocsFrom` doesn't work for metrics in tfjs-layers, described in [tensorflow/tfjs#710](https://github.com/tensorflow/tfjs/issues/710).~~
* Fix metrics examples in comments to make them executable in webpage.

### Test

To ensure metrics documentation works well with this fix PR, I built a local website and made a screen shot of the metrics section as shown below:

<img width="1233" alt="Screen Shot 2019-05-08 at 2 24 12 PM" src="https://user-images.githubusercontent.com/7977100/57428189-1294db80-71dc-11e9-8c6e-72f911edc0aa.png">

### Note

~~In this PR, use `docsForwardAlias` configuration in jsDoc, relative PR about this feature in [tensorflow/tfjs-website#308](https://github.com/tensorflow/tfjs-website/pull/308)~~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/538)
<!-- Reviewable:end -->
