### PR TITLE
Add CI testing of runnable snippets.

### DIFF
--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -24,7 +24,7 @@ steps:
   entrypoint: 'yarn'
   args: ['test-snippets']
   id: 'test-snippets'
-  waitFor: ['yarn']
+  waitFor: ['yarn', 'tfjs2keras-py']
 secrets:
 - kmsKeyName: projects/learnjs-174218/locations/global/keyRings/tfjs/cryptoKeys/enc
   secretEnv:

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -20,11 +20,6 @@ steps:
   id: 'tfjs2keras-py'
   args: ['-c', './scripts/tfjs2keras-py.sh --stable && ./scripts/tfjs2keras-py.sh --stable --tfkeras && ./scripts/tfjs2keras-py.sh --dev --tfkeras']
   waitFor: ['tfjs2keras-js']
-- name: 'node:10'
-  entrypoint: 'yarn'
-  args: ['test-snippets']
-  id: 'test-snippets'
-  waitFor: ['yarn', 'tfjs2keras-py']
 secrets:
 - kmsKeyName: projects/learnjs-174218/locations/global/keyRings/tfjs/cryptoKeys/enc
   secretEnv:

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -20,6 +20,11 @@ steps:
   id: 'tfjs2keras-py'
   args: ['-c', './scripts/tfjs2keras-py.sh --stable && ./scripts/tfjs2keras-py.sh --stable --tfkeras && ./scripts/tfjs2keras-py.sh --dev --tfkeras']
   waitFor: ['tfjs2keras-js']
+- name: 'node:10'
+  entrypoint: 'yarn'
+  args: ['test-snippets']
+  id: 'test-snippets'
+  waitFor: ['yarn']
 secrets:
 - kmsKeyName: projects/learnjs-174218/locations/global/keyRings/tfjs/cryptoKeys/enc
   secretEnv:

--- a/integration_tests/tfjs2keras/package.json
+++ b/integration_tests/tfjs2keras/package.json
@@ -5,9 +5,9 @@
   "private": false,
   "license": "Apache-2.0 AND MIT",
   "devDependencies": {
-    "@tensorflow/tfjs-core": "1.2.0",
-    "@tensorflow/tfjs-layers": "1.0.4",
-    "@tensorflow/tfjs-node": "1.0.2",
+    "@tensorflow/tfjs-core": "1.2.1",
+    "@tensorflow/tfjs-layers": "1.1.2",
+    "@tensorflow/tfjs-node": "1.1.2",
     "clang-format": "~1.2.2"
   },
   "scripts": {

--- a/integration_tests/tfjs2keras/yarn.lock
+++ b/integration_tests/tfjs2keras/yarn.lock
@@ -2,25 +2,15 @@
 # yarn lockfile v1
 
 
-"@tensorflow/tfjs-converter@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-1.0.4.tgz#824f546bf47ceaedf7affbadff3bdd151b530066"
-  integrity sha512-r619cIleJy9btVN12KoFCi0HIgi4qzzgxjxQCDxaVgi7Axas7MwBtAKGTZppR4+eK7eLOVYT1ah95JUDdFNGRw==
+"@tensorflow/tfjs-converter@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-1.1.2.tgz#2400ac77b30f973f1fcb26c912b28271f7f4d605"
+  integrity sha512-KuLIIJYzmRmtJXcjBH3inQVhTHbABj2TNAVS3ss12hzDiEE/RiRb/LZKo8XV2WczuZXTq+gxep84PWXSH/HQXA==
 
-"@tensorflow/tfjs-core@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.0.4.tgz#98365d04d179b3244ec59a270ec5e31e21de3b35"
-  integrity sha512-PpdrCozkvRx3hFyHogZFjbZUmE1t/SB/iiE8yj195aCy3X2D8T66+aLS2iUkdU2tr+1bccyvPkBktwX6/lKtAw==
-  dependencies:
-    "@types/seedrandom" "2.4.27"
-    "@types/webgl-ext" "0.0.30"
-    "@types/webgl2" "0.0.4"
-    seedrandom "2.4.3"
-
-"@tensorflow/tfjs-core@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.2.0.tgz#3c51af02688085a67588a899fe7c847996a761d3"
-  integrity sha512-PF04HsiGiJEllwHpFTSMjoDN4M5RvzoFYwI4QHVyemDY14qz9ngCIzxSLTfCF20JEs/6j7Ep6KQLp0SKa5s61g==
+"@tensorflow/tfjs-core@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.1.2.tgz#efb8b3688fbff353e51d41a3d832dde8c1bc321d"
+  integrity sha512-xCAUIAh14OFnHt+IQUUZIH/P/jH/EWvewL0Ty6q6USUx4YZ+HvKwNw1G7h/gKki4A31BJ0avD04ylBKc75laGg==
   dependencies:
     "@types/seedrandom" "2.4.27"
     "@types/webgl-ext" "0.0.30"
@@ -30,42 +20,54 @@
   optionalDependencies:
     rollup-plugin-visualizer "~1.1.1"
 
-"@tensorflow/tfjs-data@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-data/-/tfjs-data-1.0.4.tgz#1229a3217b529933a97b577004c95dce060a49e7"
-  integrity sha512-Rf7M8ctirYfuKh+hu96pXi6g6yChEEELOvlCa1ta4JWqbQhpsu77DL7SrEtKeWzL+aD/GdCxmwuyofSnRSO7JA==
+"@tensorflow/tfjs-core@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.2.1.tgz#0ff54aa7fd412b8c17e39f6ec5a97bf032e8f530"
+  integrity sha512-cpSHl+tP7cketq0cAyJPbIGxNlPV7mR6lkMLLDvZAmZUTBSyBufCdJg/KwgjHMZksE/KqjL4/RyccOGBAQcb7g==
+  dependencies:
+    "@types/seedrandom" "2.4.27"
+    "@types/webgl-ext" "0.0.30"
+    "@types/webgl2" "0.0.4"
+    node-fetch "~2.1.2"
+    seedrandom "2.4.3"
+  optionalDependencies:
+    rollup-plugin-visualizer "~1.1.1"
+
+"@tensorflow/tfjs-data@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-data/-/tfjs-data-1.1.2.tgz#f37809aa89946a834f3566bd090db852f2c4244e"
+  integrity sha512-K30QdocXd5zn3rpGbRTC4sO42q8tK1SGqDHE2IEkvYzcg0PAU3cEMODGTLjKt0z1Lfy1JKgs0FPcvazqmxpjGA==
   dependencies:
     "@types/node-fetch" "^2.1.2"
     node-fetch "~2.1.2"
 
-"@tensorflow/tfjs-layers@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-1.0.4.tgz#4ebeb3183b3705f7dd00f1cd47a33ff3a0c46213"
-  integrity sha512-X/iH0dh7AODZO1k44cx0YO19kHAItgUc9LEf5ZYH7bWaqrL0O+J4JYONqW5xzjLHunOFkKsvtNvZi9hIyemjGA==
+"@tensorflow/tfjs-layers@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-1.1.2.tgz#29393221446a877962b71084305597295504801e"
+  integrity sha512-iP9mJz/79nK+sXBWdxQkeNIqn9p+O/x3g15ntIXpEaLXOGjQEE12iKtLCWgG3qH+FltOVt5hTbAXkj/yDym1Xg==
 
-"@tensorflow/tfjs-node@1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-node/-/tfjs-node-1.0.2.tgz#ae3f00c4de89db5795ad22a368c21d0d1a2661a3"
-  integrity sha512-p8on3CvtZyOSRsphxaXgu5CR1VXotG+dkNe9qMfLnDG0i9ht7kiPvLwTG/kofQZ1H/QYLuZuE89xY0K9e2KTlQ==
+"@tensorflow/tfjs-node@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-node/-/tfjs-node-1.1.2.tgz#b5979c94fc80351ef2f5fe2a58c58f385cabaaf0"
+  integrity sha512-QBEnptTDccUZXU1z2P++ZXJflZi+qh915uOu8BAHvBYujBmVp/rL3+HyZhJpgHn8GXz88z0dsXMNem5p4zJnvw==
   dependencies:
-    "@tensorflow/tfjs" "~1.0.2"
+    "@tensorflow/tfjs" "~1.1.2"
     adm-zip "^0.4.11"
     bindings "~1.3.0"
     https-proxy-agent "^2.2.1"
-    node-fetch "^2.3.0"
     progress "^2.0.0"
     rimraf "^2.6.2"
     tar "^4.4.6"
 
-"@tensorflow/tfjs@~1.0.2":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-1.0.4.tgz#b571df49419e46753c6aa054d32c10787e83d928"
-  integrity sha512-lTKYfk8VHG/acun7xRWz/A8FFsf2FK6aI0TvKrenmiaW4OZue8BYrFNbhLKdscSaEGvYZ7/RFWaOQkA2nrcI3Q==
+"@tensorflow/tfjs@~1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-1.1.2.tgz#9a1c2bbc4d82f9d18f250ab4a4d7c8ad43e2d432"
+  integrity sha512-b+ekLNEfMzaBszti6uGcS3pJoPNQuv1hxKEoY9Q3ix52fFJzI86nSvM1lwOcvUZy6DjPFDoyB8MO+dJHqecG5w==
   dependencies:
-    "@tensorflow/tfjs-converter" "1.0.4"
-    "@tensorflow/tfjs-core" "1.0.4"
-    "@tensorflow/tfjs-data" "1.0.4"
-    "@tensorflow/tfjs-layers" "1.0.4"
+    "@tensorflow/tfjs-converter" "1.1.2"
+    "@tensorflow/tfjs-core" "1.1.2"
+    "@tensorflow/tfjs-data" "1.1.2"
+    "@tensorflow/tfjs-layers" "1.1.2"
 
 "@types/node-fetch@^2.1.2":
   version "2.1.4"
@@ -255,11 +257,6 @@ ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
-
-node-fetch@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
-  integrity sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==
 
 node-fetch@~2.1.2:
   version "2.1.2"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "jsdelivr": "dist/tf-layers.min.js",
   "unpkg": "dist/tf-layers.min.js",
   "devDependencies": {
-    "@tensorflow/tfjs-core": "1.2.0",
+    "@tensorflow/tfjs-core": "1.2.1",
     "@types/jasmine": "~2.5.53",
     "clang-format": "~1.2.2",
     "http-server": "~0.10.0",
@@ -52,6 +52,6 @@
     "lint": "tslint -p . -t verbose"
   },
   "peerDependencies": {
-    "@tensorflow/tfjs-core": "1.2.0"
+    "@tensorflow/tfjs-core": "1.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "tfjs2keras-js": "./scripts/tfjs2keras-js.sh",
     "tfjs2keras-py": "./scripts/tfjs2keras-py.sh",
     "test-ci": "./scripts/test-ci.sh",
-    "test-snippets": "./node_modules/.bin/ts-node --ignore=false ./scripts/test_snippets.ts",
+    "test-snippets": "ts-node --version && ts-node --ignore=false ./scripts/test_snippets.ts",
     "run-browserstack": "karma start --browsers='bs_firefox_mac,bs_chrome_mac' --singleRun --reporters='dots,karma-typescript'",
     "lint": "tslint -p . -t verbose"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "jsdelivr": "dist/tf-layers.min.js",
   "unpkg": "dist/tf-layers.min.js",
   "devDependencies": {
-    "@tensorflow/tfjs-core": "1.1.2",
+    "@tensorflow/tfjs-core": "1.2.0",
     "@types/jasmine": "~2.5.53",
     "@types/node": "~9.6.0",
     "clang-format": "~1.2.2",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
   "jsdelivr": "dist/tf-layers.min.js",
   "unpkg": "dist/tf-layers.min.js",
   "devDependencies": {
-    "@tensorflow/tfjs-core": "1.2.0",
+    "@tensorflow/tfjs-core": "1.1.2",
     "@types/jasmine": "~2.5.53",
+    "@types/node": "~9.6.0",
     "clang-format": "~1.2.2",
     "http-server": "~0.10.0",
     "jasmine-core": "~3.1.0",
@@ -47,6 +48,7 @@
     "tfjs2keras-js": "./scripts/tfjs2keras-js.sh",
     "tfjs2keras-py": "./scripts/tfjs2keras-py.sh",
     "test-ci": "./scripts/test-ci.sh",
+    "test-snippets": "ts-node --ignore=false ./scripts/test_snippets.ts",
     "run-browserstack": "karma start --browsers='bs_firefox_mac,bs_chrome_mac' --singleRun --reporters='dots,karma-typescript'",
     "lint": "tslint -p . -t verbose"
   },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "rollup-plugin-node-resolve": "3.3.0",
     "rollup-plugin-typescript2": "0.13.0",
     "rollup-plugin-uglify": "~3.0.0",
-    "ts-node": "~7.0.0",
+    "ts-node": "7.0.0",
     "tslint": "~5.11.0",
     "tslint-no-circular-imports": "^0.5.0",
     "typescript": "3.3.3333",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "tfjs2keras-js": "./scripts/tfjs2keras-js.sh",
     "tfjs2keras-py": "./scripts/tfjs2keras-py.sh",
     "test-ci": "./scripts/test-ci.sh",
-    "test-snippets": "ts-node --ignore=false ./scripts/test_snippets.ts",
+    "test-snippets": "./node_modules/.bin/ts-node --ignore=false ./scripts/test_snippets.ts",
     "run-browserstack": "karma start --browsers='bs_firefox_mac,bs_chrome_mac' --singleRun --reporters='dots,karma-typescript'",
     "lint": "tslint -p . -t verbose"
   },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "rollup-plugin-node-resolve": "3.3.0",
     "rollup-plugin-typescript2": "0.13.0",
     "rollup-plugin-uglify": "~3.0.0",
-    "ts-node": "~7.0.0",
+    "ts-node": "7.0.0",
     "tslint": "~5.11.0",
     "tslint-no-circular-imports": "^0.5.0",
     "typescript": "3.3.3333",
@@ -47,7 +47,7 @@
     "tfjs2keras-js": "./scripts/tfjs2keras-js.sh",
     "tfjs2keras-py": "./scripts/tfjs2keras-py.sh",
     "test-ci": "./scripts/test-ci.sh",
-    "test-snippets": "ts-node --ignore=false ./scripts/test_snippets.ts",
+    "test-snippets": "./node_modules/.bin/ts-node --ignore=false ./scripts/test_snippets.ts",
     "run-browserstack": "karma start --browsers='bs_firefox_mac,bs_chrome_mac' --singleRun --reporters='dots,karma-typescript'",
     "lint": "tslint -p . -t verbose"
   },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "tfjs2keras-js": "./scripts/tfjs2keras-js.sh",
     "tfjs2keras-py": "./scripts/tfjs2keras-py.sh",
     "test-ci": "./scripts/test-ci.sh",
-    "test-snippets": "ts-node --ignore=false ./scripts/test_snippets.ts",
+    "test-snippets": "ts-node ./scripts/test_snippets.ts",
     "run-browserstack": "karma start --browsers='bs_firefox_mac,bs_chrome_mac' --singleRun --reporters='dots,karma-typescript'",
     "lint": "tslint -p . -t verbose"
   },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "rollup-plugin-node-resolve": "3.3.0",
     "rollup-plugin-typescript2": "0.13.0",
     "rollup-plugin-uglify": "~3.0.0",
+    "ts-node": "~7.0.0",
     "tslint": "~5.11.0",
     "tslint-no-circular-imports": "^0.5.0",
     "typescript": "3.3.3333",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "rollup-plugin-node-resolve": "3.3.0",
     "rollup-plugin-typescript2": "0.13.0",
     "rollup-plugin-uglify": "~3.0.0",
-    "ts-node": "7.0.0",
+    "ts-node": "~7.0.0",
     "tslint": "~5.11.0",
     "tslint-no-circular-imports": "^0.5.0",
     "typescript": "3.3.3333",
@@ -47,7 +47,7 @@
     "tfjs2keras-js": "./scripts/tfjs2keras-js.sh",
     "tfjs2keras-py": "./scripts/tfjs2keras-py.sh",
     "test-ci": "./scripts/test-ci.sh",
-    "test-snippets": "./node_modules/.bin/ts-node --ignore=false ./scripts/test_snippets.ts",
+    "test-snippets": "ts-node --ignore=false ./scripts/test_snippets.ts",
     "run-browserstack": "karma start --browsers='bs_firefox_mac,bs_chrome_mac' --singleRun --reporters='dots,karma-typescript'",
     "lint": "tslint -p . -t verbose"
   },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "tfjs2keras-js": "./scripts/tfjs2keras-js.sh",
     "tfjs2keras-py": "./scripts/tfjs2keras-py.sh",
     "test-ci": "./scripts/test-ci.sh",
-    "test-snippets": "ts-node --version && ts-node --ignore=false ./scripts/test_snippets.ts",
+    "test-snippets": "ts-node --ignore=false ./scripts/test_snippets.ts",
     "run-browserstack": "karma start --browsers='bs_firefox_mac,bs_chrome_mac' --singleRun --reporters='dots,karma-typescript'",
     "lint": "tslint -p . -t verbose"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "devDependencies": {
     "@tensorflow/tfjs-core": "1.2.0",
     "@types/jasmine": "~2.5.53",
-    "@types/node": "~9.6.0",
     "clang-format": "~1.2.2",
     "http-server": "~0.10.0",
     "jasmine-core": "~3.1.0",

--- a/scripts/test_snippets.ts
+++ b/scripts/test_snippets.ts
@@ -16,14 +16,15 @@
  * =============================================================================
  */
 import * as tfc from '@tensorflow/tfjs-core';
-// import {parseAndEvaluateSnippets} from
-// '@tensorflow/tfjs-core/scripts/test_snippets/util';
+import {parseAndEvaluateSnippets} from '@tensorflow/tfjs-core/scripts/test_snippets/util';
+import * as fs from 'fs';
 
 import * as tfl from '../src/index';
+
+console.log(fs.readFileSync('./node_modules/ts-node/package.json', 'utf8'));
 
 const tf = {
   ...tfl,
   ...tfc
 };
-console.log(tf);
-// parseAndEvaluateSnippets(tf);
+parseAndEvaluateSnippets(tf);

--- a/scripts/test_snippets.ts
+++ b/scripts/test_snippets.ts
@@ -1,4 +1,3 @@
-
 /**
  * @license
  * Copyright 2019 Google LLC. All Rights Reserved.

--- a/scripts/test_snippets.ts
+++ b/scripts/test_snippets.ts
@@ -16,7 +16,8 @@
  * =============================================================================
  */
 import * as tfc from '@tensorflow/tfjs-core';
-import {parseAndEvaluateSnippets} from '@tensorflow/tfjs-core/scripts/test_snippets/util';
+// import {parseAndEvaluateSnippets} from
+// '@tensorflow/tfjs-core/scripts/test_snippets/util';
 
 import * as tfl from '../src/index';
 
@@ -24,5 +25,5 @@ const tf = {
   ...tfl,
   ...tfc
 };
-
-parseAndEvaluateSnippets(tf);
+console.log(tf);
+// parseAndEvaluateSnippets(tf);

--- a/scripts/test_snippets.ts
+++ b/scripts/test_snippets.ts
@@ -16,12 +16,9 @@
  * =============================================================================
  */
 import * as tfc from '@tensorflow/tfjs-core';
-import {parseAndEvaluateSnippets} from '@tensorflow/tfjs-core/scripts/test_snippets/util';
-import * as fs from 'fs';
+import {parseAndEvaluateSnippets} from '@tensorflow/tfjs-core/dist/scripts/test_snippets/util';
 
 import * as tfl from '../src/index';
-
-console.log(fs.readFileSync('./node_modules/ts-node/package.json', 'utf8'));
 
 const tf = {
   ...tfl,

--- a/scripts/test_snippets.ts
+++ b/scripts/test_snippets.ts
@@ -16,7 +16,7 @@
  * =============================================================================
  */
 import * as tfc from '@tensorflow/tfjs-core';
-import {parseAndEvaluatedSnippets} from '@tensorflow/tfjs-core/scripts/test_snippets/util';
+import {parseAndEvaluateSnippets} from '@tensorflow/tfjs-core/scripts/test_snippets/util';
 
 import * as tfl from '../src/index';
 
@@ -25,4 +25,4 @@ const tf = {
   ...tfc
 };
 
-parseAndEvaluatedSnippets(tf);
+parseAndEvaluateSnippets(tf);

--- a/scripts/test_snippets.ts
+++ b/scripts/test_snippets.ts
@@ -1,0 +1,28 @@
+
+/**
+ * @license
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+import * as tfc from '@tensorflow/tfjs-core';
+import {parseAndEvaluatedSnippets} from '@tensorflow/tfjs-core/scripts/test_snippets/util';
+
+import * as tfl from '../src/index';
+
+const tf = {
+  ...tfl,
+  ...tfc
+};
+
+parseAndEvaluatedSnippets(tf);

--- a/src/constraints.ts
+++ b/src/constraints.ts
@@ -62,17 +62,6 @@ export interface MaxNormArgs {
   axis?: number;
 }
 
-/**
- * MaxNorm weight constraint.
- *
- * Constrains the weights incident to each hidden unit
- * to have a norm less than or equal to a desired value.
- *
- * References
- *       - [Dropout: A Simple Way to Prevent Neural Networks from Overfitting
- * Srivastava, Hinton, et al.
- * 2014](http://www.cs.toronto.edu/~rsalakhu/papers/srivastava14a.pdf)
- */
 export class MaxNorm extends Constraint {
   /** @nocollapse */
   static readonly className = 'MaxNorm';
@@ -120,9 +109,6 @@ export interface UnitNormArgs {
   axis?: number;
 }
 
-/**
- * Constrains the weights incident to each hidden unit to have unit norm.
- */
 export class UnitNorm extends Constraint {
   /** @nocollapse */
   static readonly className = 'UnitNorm';
@@ -144,9 +130,6 @@ export class UnitNorm extends Constraint {
 }
 serialization.registerClass(UnitNorm);
 
-/**
- * Constains the weight to be non-negative.
- */
 export class NonNeg extends Constraint {
   /** @nocollapse */
   static readonly className = 'NonNeg';

--- a/src/engine/input_layer.ts
+++ b/src/engine/input_layer.ts
@@ -42,38 +42,6 @@ export declare interface InputLayerArgs {
   name?: string;
 }
 
-/**
- * An input layer is an entry point into a `tf.LayersModel`.
- *
- * `InputLayer` is generated automatically for `tf.Sequential`` models by
- * specifying the `inputshape` or `batchInputShape` for the first layer.  It
- * should not be specified explicitly. However, it can be useful sometimes,
- * e.g., when constructing a sequential model from a subset of another
- * sequential model's layers. Like the code snippet below shows.
- *
- * ```js
- * // Define a model which simply adds two inputs.
- * const model1 = tf.sequential();
- * model1.add(tf.layers.dense({inputShape: [4], units: 3, activation: 'relu'}));
- * model1.add(tf.layers.dense({units: 1, activation: 'sigmoid'}));
- * model1.summary();
- * model1.predict(tf.zeros([1, 4])).print();
- *
- * // Construct another model, reusing the second layer of `model1` while
- * // not using the first layer of `model1`. Note that you cannot add the second
- * // layer of `model` directly as the first layer of the new sequential model,
- * // because doing so will lead to an error related to the fact that the layer
- * // is not an input layer. Instead, you need to create an `inputLayer` and add
- * // it to the new sequential model before adding the reused layer.
- * const model2 = tf.sequential();
- * // Use an inputShape that matches the input shape of `model1`'s second
- * // layer.
- * model2.add(tf.layers.inputLayer({inputShape: [3]}));
- * model2.add(model1.layers[1]);
- * model2.summary();
- * model2.predict(tf.zeros([1, 3])).print();
- * ```
- */
 export class InputLayer extends Layer {
   /** @nocollapse */
   static readonly className = 'InputLayer';
@@ -204,27 +172,6 @@ export interface InputConfig {
   sparse?: boolean;
 }
 
-/**
- * Used to instantiate an input to a model as a `tf.SymbolicTensor`.
- *
- * Users should call the `input` factory function for
- * consistency with other generator functions.
- *
- * Example:
- *
- * ```js
- * // Defines a simple logistic regression model with 32 dimensional input
- * // and 3 dimensional output.
- * const x = tf.input({shape: [32]});
- * const y = tf.layers.dense({units: 3, activation: 'softmax'}).apply(x);
- * const model = tf.model({inputs: x, outputs: y});
- * model.predict(tf.ones([2, 32])).print();
- * ```
- *
- * Note: `input` is only necessary when using `model`. When using
- * `sequential`, specify `inputShape` for the first layer or use `inputLayer`
- * as the first layer.
- */
 export function Input(config: InputConfig): SymbolicTensor {
   if (config.batchShape == null && config.shape == null) {
     throw new Error(

--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -1636,7 +1636,7 @@ export class LayersModel extends Container implements tfc.InferenceModel {
    *   topology and weight values.
    */
   /**
-   * @doc {heading: 'Models', subheading: 'Classes'}
+   * @doc {heading: 'Models', subheading: 'Classes', ignoreCI: true}
    */
   async save(handlerOrURL: io.IOHandler|string, config?: io.SaveConfig):
       Promise<io.SaveResult> {

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -239,12 +239,27 @@ export function loadLayersModel(
 }
 
 /**
- * @doc {
- *   heading: 'Models',
- *   subheading: 'Inputs',
- *   useDocsFrom: 'Input'
- * }
+ * Used to instantiate an input to a model as a `tf.SymbolicTensor`.
+ *
+ * Users should call the `input` factory function for
+ * consistency with other generator functions.
+ *
+ * Example:
+ *
+ * ```js
+ * // Defines a simple logistic regression model with 32 dimensional input
+ * // and 3 dimensional output.
+ * const x = tf.input({shape: [32]});
+ * const y = tf.layers.dense({units: 3, activation: 'softmax'}).apply(x);
+ * const model = tf.model({inputs: x, outputs: y});
+ * model.predict(tf.ones([2, 32])).print();
+ * ```
+ *
+ * Note: `input` is only necessary when using `model`. When using
+ * `sequential`, specify `inputShape` for the first layer or use `inputLayer`
+ * as the first layer.
  */
+/** @doc {heading: 'Models', subheading: 'Inputs'} */
 export function input(config: InputConfig): SymbolicTensor {
   return Input(config);
 }

--- a/src/exports_constraints.ts
+++ b/src/exports_constraints.ts
@@ -10,46 +10,40 @@
 // tslint:disable-next-line:max-line-length
 import {Constraint, MaxNorm, MaxNormArgs, MinMaxNorm, MinMaxNormArgs, NonNeg, UnitNorm, UnitNormArgs} from './constraints';
 
+
 /**
- * @doc {
- *   heading: 'Constraints',
- *   namespace: 'constraints',
- *   useDocsFrom: 'MaxNorm'
- * }
+ * MaxNorm weight constraint.
+ *
+ * Constrains the weights incident to each hidden unit
+ * to have a norm less than or equal to a desired value.
+ *
+ * References
+ *       - [Dropout: A Simple Way to Prevent Neural Networks from Overfitting
+ * Srivastava, Hinton, et al.
+ * 2014](http://www.cs.toronto.edu/~rsalakhu/papers/srivastava14a.pdf)
  */
+/** @doc {heading: 'Constraints',namespace: 'constraints'} */
 export function maxNorm(args: MaxNormArgs): Constraint {
   return new MaxNorm(args);
 }
 
 /**
- * @doc {
- *   heading: 'Constraints',
- *   namespace: 'constraints',
- *   useDocsFrom: 'UnitNorm'
- * }
+ * Constrains the weights incident to each hidden unit to have unit norm.
  */
+/** @doc {heading: 'Constraints', namespace: 'constraints'} */
 export function unitNorm(args: UnitNormArgs): Constraint {
   return new UnitNorm(args);
 }
 
 /**
- * @doc {
- *   heading: 'Constraints',
- *   namespace: 'constraints',
- *   useDocsFrom: 'NonNeg'
- * }
+ * Constains the weight to be non-negative.
  */
+/** @doc {heading: 'Constraints', namespace: 'constraints'} */
 export function nonNeg(): Constraint {
   return new NonNeg();
 }
 
-/**
- * @doc {
- *   heading: 'Constraints',
- *   namespace: 'constraints',
- *   useDocsFrom: 'MinMaxNormConfig'
- * }
- */
+/** @doc {heading: 'Constraints', namespace: 'constraints'} */
 export function minMaxNorm(config: MinMaxNormArgs): Constraint {
   return new MinMaxNorm(config);
 }

--- a/src/exports_initializers.ts
+++ b/src/exports_initializers.ts
@@ -10,168 +10,187 @@
 // tslint:disable-next-line:max-line-length
 import {Constant, ConstantArgs, GlorotNormal, GlorotUniform, HeNormal, HeUniform, Identity, IdentityArgs, Initializer, LeCunNormal, LeCunUniform, Ones, Orthogonal, OrthogonalArgs, RandomNormal, RandomNormalArgs, RandomUniform, RandomUniformArgs, SeedOnlyInitializerArgs, TruncatedNormal, TruncatedNormalArgs, VarianceScaling, VarianceScalingArgs, Zeros} from './initializers';
 
+
 /**
- * @doc {
- *   heading: 'Initializers',
- *   namespace: 'initializers',
- *   useDocsFrom: 'Zeros'
- * }
+ * Initializer that generates tensors initialized to 0.
  */
+/** @doc {heading: 'Initializers', namespace: 'initializers'} */
 export function zeros(): Zeros {
   return new Zeros();
 }
 
 /**
- * @doc {
- *   heading: 'Initializers',
- *   namespace: 'initializers',
- *   useDocsFrom: 'Ones'
- * }
+ * Initializer that generates tensors initialized to 1.
  */
+/** @doc {heading: 'Initializers', namespace: 'initializers'} */
 export function ones(): Initializer {
   return new Ones();
 }
 
 /**
- * @doc {
- *   heading: 'Initializers',
- *   namespace: 'initializers',
- *   useDocsFrom: 'Constant'
- * }
+ * Initializer that generates values initialized to some constant.
  */
+/** @doc {heading: 'Initializers', namespace: 'initializers'} */
 export function constant(args: ConstantArgs): Initializer {
   return new Constant(args);
 }
 
 /**
- * @doc {
- *   heading: 'Initializers',
- *   namespace: 'initializers',
- *   useDocsFrom: 'RandomUniform'
- * }
+ * Initializer that generates random values initialized to a uniform
+ * distribution.
+ *
+ * Values will be distributed uniformly between the configured minval and
+ * maxval.
  */
+/** @doc {heading: 'Initializers', namespace: 'initializers'} */
 export function randomUniform(args: RandomUniformArgs): Initializer {
   return new RandomUniform(args);
 }
 
 /**
- * @doc {
- *   heading: 'Initializers',
- *   namespace: 'initializers',
- *   useDocsFrom: 'RandomNormal'
- * }
+ * Initializer that generates random values initialized to a normal
+ * distribution.
  */
+/** @doc {heading: 'Initializers', namespace: 'initializers'} */
 export function randomNormal(args: RandomNormalArgs): Initializer {
   return new RandomNormal(args);
 }
 
 /**
- * @doc {
- *   heading: 'Initializers',
- *   namespace: 'initializers',
- *   useDocsFrom: 'TruncatedNormal'
- * }
+ * Initializer that generates random values initialized to a truncated normal.
+ * distribution.
+ *
+ * These values are similar to values from a `RandomNormal` except that values
+ * more than two standard deviations from the mean are discarded and re-drawn.
+ * This is the recommended initializer for neural network weights and filters.
  */
+/** @doc {heading: 'Initializers', namespace: 'initializers'} */
 export function truncatedNormal(args: TruncatedNormalArgs): Initializer {
   return new TruncatedNormal(args);
 }
 
 /**
- * @doc {
- *   heading: 'Initializers',
- *   namespace: 'initializers',
- *   useDocsFrom: 'Identity'
- * }
+ * Initializer that generates the identity matrix.
+ * Only use for square 2D matrices.
  */
+/** @doc {heading: 'Initializers', namespace: 'initializers'} */
 export function identity(args: IdentityArgs): Initializer {
   return new Identity(args);
 }
 
 /**
- * @doc {
- *   heading: 'Initializers',
- *   namespace: 'initializers',
- *   useDocsFrom: 'VarianceScaling'
- * }
+ * Initializer capable of adapting its scale to the shape of weights.
+ * With distribution=NORMAL, samples are drawn from a truncated normal
+ * distribution centered on zero, with `stddev = sqrt(scale / n)` where n is:
+ *   - number of input units in the weight tensor, if mode = FAN_IN.
+ *   - number of output units, if mode = FAN_OUT.
+ *   - average of the numbers of input and output units, if mode = FAN_AVG.
+ * With distribution=UNIFORM,
+ * samples are drawn from a uniform distribution
+ * within [-limit, limit], with `limit = sqrt(3 * scale / n)`.
  */
+/** @doc {heading: 'Initializers',namespace: 'initializers'} */
 export function varianceScaling(config: VarianceScalingArgs): Initializer {
   return new VarianceScaling(config);
 }
 
 /**
- * @doc {
- *   heading: 'Initializers',
- *   namespace: 'initializers',
- *   useDocsFrom: 'GlorotUniform'
- * }
+ * Glorot uniform initializer, also called Xavier uniform initializer.
+ * It draws samples from a uniform distribution within [-limit, limit]
+ * where `limit` is `sqrt(6 / (fan_in + fan_out))`
+ * where `fan_in` is the number of input units in the weight tensor
+ * and `fan_out` is the number of output units in the weight tensor
+ *
+ * Reference:
+ *   Glorot & Bengio, AISTATS 2010
+ *       http://jmlr.org/proceedings/papers/v9/glorot10a/glorot10a.pdf.
  */
+/** @doc {heading: 'Initializers', namespace: 'initializers'} */
 export function glorotUniform(args: SeedOnlyInitializerArgs): Initializer {
   return new GlorotUniform(args);
 }
 
 /**
- * @doc {
- *   heading: 'Initializers',
- *   namespace: 'initializers',
- *   useDocsFrom: 'GlorotNormal'
- * }
+ * Glorot normal initializer, also called Xavier normal initializer.
+ * It draws samples from a truncated normal distribution centered on 0
+ * with `stddev = sqrt(2 / (fan_in + fan_out))`
+ * where `fan_in` is the number of input units in the weight tensor
+ * and `fan_out` is the number of output units in the weight tensor.
+ *
+ * Reference:
+ *   Glorot & Bengio, AISTATS 2010
+ *       http://jmlr.org/proceedings/papers/v9/glorot10a/glorot10a.pdf
  */
+/** @doc {heading: 'Initializers', namespace: 'initializers'} */
 export function glorotNormal(args: SeedOnlyInitializerArgs): Initializer {
   return new GlorotNormal(args);
 }
 
 /**
- * @doc {
- *   heading: 'Initializers',
- *   namespace: 'initializers',
- *   useDocsFrom: 'HeNormal'
- * }
+ * He normal initializer.
+ *
+ * It draws samples from a truncated normal distribution centered on 0
+ * with `stddev = sqrt(2 / fanIn)`
+ * where `fanIn` is the number of input units in the weight tensor.
+ *
+ * Reference:
+ *     He et al., http://arxiv.org/abs/1502.01852
  */
+/** @doc {heading: 'Initializers', namespace: 'initializers'} */
 export function heNormal(args: SeedOnlyInitializerArgs): Initializer {
   return new HeNormal(args);
 }
 
 /**
- * @doc {
- *   heading: 'Initializers',
- *   namespace: 'initializers',
- *   useDocsFrom: 'HeUniform'
- * }
+ * He uniform initializer.
+ *
+ * It draws samples from a uniform distribution within [-limit, limit]
+ * where `limit` is `sqrt(6 / fan_in)`
+ * where `fanIn` is the number of input units in the weight tensor.
+ *
+ * Reference:
+ *     He et al., http://arxiv.org/abs/1502.01852
  */
+/** @doc {heading: 'Initializers',namespace: 'initializers'} */
 export function heUniform(args: SeedOnlyInitializerArgs): Initializer {
   return new HeUniform(args);
 }
 
 /**
- * @doc {
- *   heading: 'Initializers',
- *   namespace: 'initializers',
- *   useDocsFrom: 'LeCunNormal'
- * }
+ * LeCun normal initializer.
+ *
+ * It draws samples from a truncated normal distribution centered on 0
+ * with `stddev = sqrt(1 / fanIn)`
+ * where `fanIn` is the number of input units in the weight tensor.
+ *
+ * References:
+ *   [Self-Normalizing Neural Networks](https://arxiv.org/abs/1706.02515)
+ *   [Efficient Backprop](http://yann.lecun.com/exdb/publis/pdf/lecun-98b.pdf)
  */
+/** @doc {heading: 'Initializers', namespace: 'initializers'} */
 export function leCunNormal(args: SeedOnlyInitializerArgs): Initializer {
   return new LeCunNormal(args);
 }
 
 /**
- * @doc {
- *   heading: 'Initializers',
- *   namespace: 'initializers',
- *   useDocsFrom: 'LeCunUniform'
- * }
+ * LeCun uniform initializer.
+ *
+ * It draws samples from a uniform distribution in the interval
+ * `[-limit, limit]` with `limit = sqrt(3 / fanIn)`,
+ * where `fanIn` is the number of input units in the weight tensor.
  */
+/** @doc {heading: 'Initializers', namespace: 'initializers'} */
 export function leCunUniform(args: SeedOnlyInitializerArgs): Initializer {
   return new LeCunUniform(args);
 }
 
-
 /**
- * @doc {
- *   heading: 'Initializers',
- *   namespace: 'initializers',
- *   useDocsFrom: 'Orthogonal'
- * }
+ * Initializer that generates a random orthogonal matrix.
+ *
+ * Reference:
+ * [Saxe et al., http://arxiv.org/abs/1312.6120](http://arxiv.org/abs/1312.6120)
  */
+/** @doc {heading: 'Initializers', namespace: 'initializers'} */
 export function orthogonal(args: OrthogonalArgs): Initializer {
   return new Orthogonal(args);
 }

--- a/src/exports_layers.ts
+++ b/src/exports_layers.ts
@@ -14,15 +14,16 @@ import {input} from './exports';
 import {ELU, ELULayerArgs, LeakyReLU, LeakyReLULayerArgs, PReLU, PReLULayerArgs, ReLU, ReLULayerArgs, Softmax, SoftmaxLayerArgs, ThresholdedReLU, ThresholdedReLULayerArgs} from './layers/advanced_activations';
 import {Conv1D, Conv2D, Conv2DTranspose, Conv3D, ConvLayerArgs, Cropping2D, Cropping2DLayerArgs, SeparableConv2D, SeparableConvLayerArgs, UpSampling2D, UpSampling2DLayerArgs} from './layers/convolutional';
 import {DepthwiseConv2D, DepthwiseConv2DLayerArgs} from './layers/convolutional_depthwise';
-import {Activation, ActivationLayerArgs, Dense, DenseLayerArgs, Dropout, DropoutLayerArgs, Flatten, Permute, PermuteLayerArgs, RepeatVector, RepeatVectorLayerArgs, Reshape, ReshapeLayerArgs, Masking, MaskingArgs} from './layers/core';
+import {Activation, ActivationLayerArgs, Dense, DenseLayerArgs, Dropout, DropoutLayerArgs, Flatten, Masking, MaskingArgs, Permute, PermuteLayerArgs, RepeatVector, RepeatVectorLayerArgs, Reshape, ReshapeLayerArgs} from './layers/core';
 import {Embedding, EmbeddingLayerArgs} from './layers/embeddings';
 import {Add, Average, Concatenate, ConcatenateLayerArgs, Dot, DotLayerArgs, Maximum, Minimum, Multiply} from './layers/merge';
+import {AlphaDropout, AlphaDropoutArgs, GaussianDropout, GaussianDropoutArgs, GaussianNoise, GaussianNoiseArgs} from './layers/noise';
 import {BatchNormalization, BatchNormalizationLayerArgs} from './layers/normalization';
 import {ZeroPadding2D, ZeroPadding2DLayerArgs} from './layers/padding';
 import {AveragePooling1D, AveragePooling2D, GlobalAveragePooling1D, GlobalAveragePooling2D, GlobalMaxPooling1D, GlobalMaxPooling2D, GlobalPooling2DLayerArgs, MaxPooling1D, MaxPooling2D, Pooling1DLayerArgs, Pooling2DLayerArgs} from './layers/pooling';
 import {GRU, GRUCell, GRUCellLayerArgs, GRULayerArgs, LSTM, LSTMCell, LSTMCellLayerArgs, LSTMLayerArgs, RNN, RNNCell, RNNLayerArgs, SimpleRNN, SimpleRNNCell, SimpleRNNCellLayerArgs, SimpleRNNLayerArgs, StackedRNNCells, StackedRNNCellsArgs} from './layers/recurrent';
 import {Bidirectional, BidirectionalLayerArgs, TimeDistributed, WrapperLayerArgs} from './layers/wrappers';
-import {GaussianNoiseArgs, GaussianNoise, GaussianDropoutArgs, GaussianDropout, AlphaDropoutArgs, AlphaDropout} from './layers/noise';
+
 
 // TODO(cais): Add doc string to all the public static functions in this
 //   class; include exectuable JavaScript code snippets where applicable
@@ -30,13 +31,38 @@ import {GaussianNoiseArgs, GaussianNoise, GaussianDropoutArgs, GaussianDropout, 
 
 // Input Layer.
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Inputs',
- *   namespace: 'layers',
- *   useDocsFrom: 'InputLayer'
- * }
+ * An input layer is an entry point into a `tf.LayersModel`.
+ *
+ * `InputLayer` is generated automatically for `tf.Sequential`` models by
+ * specifying the `inputshape` or `batchInputShape` for the first layer.  It
+ * should not be specified explicitly. However, it can be useful sometimes,
+ * e.g., when constructing a sequential model from a subset of another
+ * sequential model's layers. Like the code snippet below shows.
+ *
+ * ```js
+ * // Define a model which simply adds two inputs.
+ * const model1 = tf.sequential();
+ * model1.add(tf.layers.dense({inputShape: [4], units: 3, activation: 'relu'}));
+ * model1.add(tf.layers.dense({units: 1, activation: 'sigmoid'}));
+ * model1.summary();
+ * model1.predict(tf.zeros([1, 4])).print();
+ *
+ * // Construct another model, reusing the second layer of `model1` while
+ * // not using the first layer of `model1`. Note that you cannot add the second
+ * // layer of `model` directly as the first layer of the new sequential model,
+ * // because doing so will lead to an error related to the fact that the layer
+ * // is not an input layer. Instead, you need to create an `inputLayer` and add
+ * // it to the new sequential model before adding the reused layer.
+ * const model2 = tf.sequential();
+ * // Use an inputShape that matches the input shape of `model1`'s second
+ * // layer.
+ * model2.add(tf.layers.inputLayer({inputShape: [3]}));
+ * model2.add(model1.layers[1]);
+ * model2.summary();
+ * model2.predict(tf.zeros([1, 3])).print();
+ * ```
  */
+/** @doc {heading: 'Layers', subheading: 'Inputs', namespace: 'layers'} */
 export function inputLayer(args: InputLayerArgs): Layer {
   return new InputLayer(args);
 }
@@ -44,11 +70,28 @@ export function inputLayer(args: InputLayerArgs): Layer {
 // Advanced Activation Layers.
 
 /**
+ * Exponetial Linear Unit (ELU).
+ *
+ * It follows:
+ * `f(x) =  alpha * (exp(x) - 1.) for x < 0`,
+ * `f(x) = x for x >= 0`.
+ *
+ * Input shape:
+ *   Arbitrary. Use the configuration `inputShape` when using this layer as the
+ *   first layer in a model.
+ *
+ * Output shape:
+ *   Same shape as the input.
+ *
+ * References:
+ *   - [Fast and Accurate Deep Network Learning by Exponential Linear Units
+ * (ELUs)](https://arxiv.org/abs/1511.07289v1)
+ */
+/**
  * @doc {
  *   heading: 'Layers',
  *   subheading: 'Advanced Activation',
- *   namespace: 'layers',
- *   useDocsFrom: 'ELU'
+ *   namespace: 'layers'
  * }
  */
 export function elu(args?: ELULayerArgs): Layer {
@@ -56,11 +99,21 @@ export function elu(args?: ELULayerArgs): Layer {
 }
 
 /**
+ * Rectified Linear Unit activation function.
+ *
+ * Input shape:
+ *   Arbitrary. Use the config field `inputShape` (Array of integers, does
+ *   not include the sample axis) when using this layer as the first layer
+ *   in a model.
+ *
+ * Output shape:
+ *   Same shape as the input.
+ */
+/**
  * @doc {
  *   heading: 'Layers',
  *   subheading: 'Advanced Activation',
- *   namespace: 'layers',
- *   useDocsFrom: 'ReLU'
+ *   namespace: 'layers'
  * }
  */
 export function reLU(args?: ReLULayerArgs): Layer {
@@ -68,11 +121,24 @@ export function reLU(args?: ReLULayerArgs): Layer {
 }
 
 /**
+ * Leaky version of a rectified linear unit.
+ *
+ * It allows a small gradient when the unit is not active:
+ * `f(x) = alpha * x for x < 0.`
+ * `f(x) = x for x >= 0.`
+ *
+ * Input shape:
+ *   Arbitrary. Use the configuration `inputShape` when using this layer as the
+ *   first layer in a model.
+ *
+ * Output shape:
+ *   Same shape as the input.
+ */
+/**
  * @doc {
  *   heading: 'Layers',
  *   subheading: 'Advanced Activation',
- *   namespace: 'layers',
- *   useDocsFrom: 'LeakyReLU'
+ *   namespace: 'layers'
  * }
  */
 export function leakyReLU(args?: LeakyReLULayerArgs): Layer {
@@ -80,11 +146,25 @@ export function leakyReLU(args?: LeakyReLULayerArgs): Layer {
 }
 
 /**
+ * Parameterized version of a leaky rectified linear unit.
+ *
+ * It follows
+ * `f(x) = alpha * x for x < 0.`
+ * `f(x) = x for x >= 0.`
+ * wherein `alpha` is a trainable weight.
+ *
+ * Input shape:
+ *   Arbitrary. Use the configuration `inputShape` when using this layer as the
+ *   first layer in a model.
+ *
+ * Output shape:
+ *   Same shape as the input.
+ */
+/**
  * @doc {
  *   heading: 'Layers',
  *   subheading: 'Advanced Activation',
- *   namespace: 'layers',
- *   useDocsFrom: 'PReLU'
+ *   namespace: 'layers'
  * }
  */
 export function prelu(args?: PReLULayerArgs): Layer {
@@ -92,11 +172,20 @@ export function prelu(args?: PReLULayerArgs): Layer {
 }
 
 /**
+ * Softmax activation layer.
+ *
+ * Input shape:
+ *   Arbitrary. Use the configuration `inputShape` when using this layer as the
+ *   first layer in a model.
+ *
+ * Output shape:
+ *   Same shape as the input.
+ */
+/**
  * @doc {
  *   heading: 'Layers',
  *   subheading: 'Advanced Activation',
- *   namespace: 'layers',
- *   useDocsFrom: 'Softmax'
+ *   namespace: 'layers'
  * }
  */
 export function softmax(args?: SoftmaxLayerArgs): Layer {
@@ -104,11 +193,28 @@ export function softmax(args?: SoftmaxLayerArgs): Layer {
 }
 
 /**
+ * Thresholded Rectified Linear Unit.
+ *
+ * It follows:
+ * `f(x) = x for x > theta`,
+ * `f(x) = 0 otherwise`.
+ *
+ * Input shape:
+ *   Arbitrary. Use the configuration `inputShape` when using this layer as the
+ *   first layer in a model.
+ *
+ * Output shape:
+ *   Same shape as the input.
+ *
+ * References:
+ *   - [Zero-Bias Autoencoders and the Benefits of Co-Adapting
+ * Features](http://arxiv.org/abs/1402.3337)
+ */
+/**
  * @doc {
  *   heading: 'Layers',
  *   subheading: 'Advanced Activation',
- *   namespace: 'layers',
- *   useDocsFrom: 'ThresholdedReLU'
+ *   namespace: 'layers'
  * }
  */
 export function thresholdedReLU(args?: ThresholdedReLULayerArgs): Layer {
@@ -118,84 +224,210 @@ export function thresholdedReLU(args?: ThresholdedReLULayerArgs): Layer {
 // Convolutional Layers.
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Convolutional',
- *   namespace: 'layers',
- *   useDocsFrom: 'Conv1D'
- * }
+ * 1D convolution layer (e.g., temporal convolution).
+ *
+ * This layer creates a convolution kernel that is convolved
+ * with the layer input over a single spatial (or temporal) dimension
+ * to produce a tensor of outputs.
+ *
+ * If `use_bias` is True, a bias vector is created and added to the outputs.
+ *
+ * If `activation` is not `null`, it is applied to the outputs as well.
+ *
+ * When using this layer as the first layer in a model, provide an
+ * `inputShape` argument `Array` or `null`.
+ *
+ * For example, `inputShape` would be:
+ * - `[10, 128]` for sequences of 10 vectors of 128-dimensional vectors
+ * - `[null, 128]` for variable-length sequences of 128-dimensional vectors.
+ */
+/**
+ * @doc {heading: 'Layers', subheading: 'Convolutional',  namespace: 'layers'}
  */
 export function conv1d(args: ConvLayerArgs): Layer {
   return new Conv1D(args);
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Convolutional',
- *   namespace: 'layers',
- *   useDocsFrom: 'Conv2D'
- * }
+ * 2D convolution layer (e.g. spatial convolution over images).
+ *
+ * This layer creates a convolution kernel that is convolved
+ * with the layer input to produce a tensor of outputs.
+ *
+ * If `useBias` is True, a bias vector is created and added to the outputs.
+ *
+ * If `activation` is not `null`, it is applied to the outputs as well.
+ *
+ * When using this layer as the first layer in a model,
+ * provide the keyword argument `inputShape`
+ * (Array of integers, does not include the sample axis),
+ * e.g. `inputShape=[128, 128, 3]` for 128x128 RGB pictures
+ * in `dataFormat='channelsLast'`.
+ */
+/**
+ * @doc {heading: 'Layers', subheading: 'Convolutional', namespace: 'layers'}
  */
 export function conv2d(args: ConvLayerArgs): Layer {
   return new Conv2D(args);
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Convolutional',
- *   namespace: 'layers',
- *   useDocsFrom: 'Conv2DTranspose'
- * }
+ * Transposed convolutional layer (sometimes called Deconvolution).
+ *
+ * The need for transposed convolutions generally arises
+ * from the desire to use a transformation going in the opposite direction of
+ * a normal convolution, i.e., from something that has the shape of the output
+ * of some convolution to something that has the shape of its input while
+ * maintaining a connectivity pattern that is compatible with said
+ * convolution.
+ *
+ * When using this layer as the first layer in a model, provide the
+ * configuration `inputShape` (`Array` of integers, does not include the
+ * sample axis), e.g., `inputShape: [128, 128, 3]` for 128x128 RGB pictures in
+ * `dataFormat: 'channelsLast'`.
+ *
+ * Input shape:
+ *   4D tensor with shape:
+ *   `[batch, channels, rows, cols]` if `dataFormat` is `'channelsFirst'`.
+ *   or 4D tensor with shape
+ *   `[batch, rows, cols, channels]` if `dataFormat` is `'channelsLast`.
+ *
+ * Output shape:
+ *   4D tensor with shape:
+ *   `[batch, filters, newRows, newCols]` if `dataFormat` is
+ * `'channelsFirst'`. or 4D tensor with shape:
+ *   `[batch, newRows, newCols, filters]` if `dataFormat` is `'channelsLast'`.
+ *
+ * References:
+ *   - [A guide to convolution arithmetic for deep
+ * learning](https://arxiv.org/abs/1603.07285v1)
+ *   - [Deconvolutional
+ * Networks](http://www.matthewzeiler.com/pubs/cvpr2010/cvpr2010.pdf)
+ */
+/**
+ * @doc {heading: 'Layers', subheading: 'Convolutional', namespace: 'layers'}
  */
 export function conv2dTranspose(args: ConvLayerArgs): Layer {
   return new Conv2DTranspose(args);
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Convolutional',
- *   namespace: 'layers',
- *   useDocsFrom: 'Conv3D'
- * }
+ * 3D convolution layer (e.g. spatial convolution over volumes).
+ *
+ * This layer creates a convolution kernel that is convolved
+ * with the layer input to produce a tensor of outputs.
+ *
+ * If `useBias` is True, a bias vector is created and added to the outputs.
+ *
+ * If `activation` is not `null`, it is applied to the outputs as well.
+ *
+ * When using this layer as the first layer in a model,
+ * provide the keyword argument `inputShape`
+ * (Array of integers, does not include the sample axis),
+ * e.g. `inputShape=[128, 128, 128, 1]` for 128x128x128 grayscale volumes
+ * in `dataFormat='channelsLast'`.
+ */
+/**
+ * @doc {heading: 'Layers', subheading: 'Convolutional', namespace: 'layers'}
  */
 export function conv3d(args: ConvLayerArgs): Layer {
   return new Conv3D(args);
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Convolutional',
- *   namespace: 'layers',
- *   useDocsFrom: 'SeparableConv2D'
- * }
+ * Depthwise separable 2D convolution.
+ *
+ * Separable convolution consists of first performing
+ * a depthwise spatial convolution
+ * (which acts on each input channel separately)
+ * followed by a pointwise convolution which mixes together the resulting
+ * output channels. The `depthMultiplier` argument controls how many
+ * output channels are generated per input channel in the depthwise step.
+ *
+ * Intuitively, separable convolutions can be understood as
+ * a way to factorize a convolution kernel into two smaller kernels,
+ * or as an extreme version of an Inception block.
+ *
+ * Input shape:
+ *   4D tensor with shape:
+ *     `[batch, channels, rows, cols]` if data_format='channelsFirst'
+ *   or 4D tensor with shape:
+ *     `[batch, rows, cols, channels]` if data_format='channelsLast'.
+ *
+ * Output shape:
+ *   4D tensor with shape:
+ *     `[batch, filters, newRows, newCols]` if data_format='channelsFirst'
+ *   or 4D tensor with shape:
+ *     `[batch, newRows, newCols, filters]` if data_format='channelsLast'.
+ *     `rows` and `cols` values might have changed due to padding.
+ */
+/**
+ * @doc {heading: 'Layers', subheading: 'Convolutional', namespace: 'layers'}
  */
 export function separableConv2d(args: SeparableConvLayerArgs): Layer {
   return new SeparableConv2D(args);
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Convolutional',
- *   namespace: 'layers',
- *   useDocsFrom: 'Cropping2D'
- * }
+ * Cropping layer for 2D input (e.g., image).
+ *
+ * This layer can crop an input
+ * at the top, bottom, left and right side of an image tensor.
+ *
+ * Input shape:
+ *   4D tensor with shape:
+ *   - If `dataFormat` is `"channelsLast"`:
+ *     `[batch, rows, cols, channels]`
+ *   - If `data_format` is `"channels_first"`:
+ *     `[batch, channels, rows, cols]`.
+ *
+ * Output shape:
+ *   4D with shape:
+ *   - If `dataFormat` is `"channelsLast"`:
+ *     `[batch, croppedRows, croppedCols, channels]`
+ *    - If `dataFormat` is `"channelsFirst"`:
+ *     `[batch, channels, croppedRows, croppedCols]`.
+ *
+ * Examples
+ * ```js
+ *
+ * const model = tf.sequential();
+ * model.add(tf.layers.cropping2D({cropping:[[2, 2], [2, 2]],
+ *                                inputShape: [128, 128, 3]}));
+ * //now output shape is [batch, 124, 124, 3]
+ * ```
+ */
+/**
+ * @doc {heading: 'Layers', subheading: 'Convolutional', namespace: 'layers'}
  */
 export function cropping2D(args: Cropping2DLayerArgs): Layer {
   return new Cropping2D(args);
 }
 
 /**
- * @doc{
- *   heading: 'Layers',
- *   subheading: 'Convolutional',
- *   namespace: 'layers',
- *   useDocsFrom: 'UpSampling2D'
- * }
+ * Upsampling layer for 2D inputs.
+ *
+ * Repeats the rows and columns of the data
+ * by size[0] and size[1] respectively.
+ *
+ *
+ * Input shape:
+ *    4D tensor with shape:
+ *     - If `dataFormat` is `"channelsLast"`:
+ *         `[batch, rows, cols, channels]`
+ *     - If `dataFormat` is `"channelsFirst"`:
+ *        `[batch, channels, rows, cols]`
+ *
+ * Output shape:
+ *     4D tensor with shape:
+ *     - If `dataFormat` is `"channelsLast"`:
+ *        `[batch, upsampledRows, upsampledCols, channels]`
+ *     - If `dataFormat` is `"channelsFirst"`:
+ *         `[batch, channels, upsampledRows, upsampledCols]`
+ *
+ */
+/**
+ * @doc {heading: 'Layers', subheading: 'Convolutional', namespace: 'layers'}
  */
 export function upSampling2d(args: UpSampling2DLayerArgs): Layer {
   return new UpSampling2D(args);
@@ -204,14 +436,16 @@ export function upSampling2d(args: UpSampling2DLayerArgs): Layer {
 // Convolutional(depthwise) Layers.
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Convolutional',
- *   namespace: 'layers',
- *   useDocsFrom: 'DepthwiseConv2D'
- * }
+ * Depthwise separable 2D convolution.
+ *
+ * Depthwise Separable convolutions consists in performing just the first step
+ * in a depthwise spatial convolution (which acts on each input channel
+ * separately). The `depthMultplier` argument controls how many output channels
+ * are generated per input channel in the depthwise step.
  */
-
+/**
+ * @doc {heading: 'Layers', subheading: 'Convolutional', namespace: 'layers'}
+ */
 export function depthwiseConv2d(args: DepthwiseConv2DLayerArgs): Layer {
   return new DepthwiseConv2D(args);
 }
@@ -219,97 +453,195 @@ export function depthwiseConv2d(args: DepthwiseConv2DLayerArgs): Layer {
 // Basic Layers.
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Basic',
- *   namespace: 'layers',
- *   useDocsFrom: 'Activation'
- * }
+ * Applies an activation function to an output.
+ *
+ * This layer applies element-wise activation function.  Other layers, notably
+ * `dense` can also apply activation functions.  Use this isolated activation
+ * function to extract the values before and after the
+ * activation. For instance:
+ *
+ * ```js
+ * const input = tf.input({shape: [5]});
+ * const denseLayer = tf.layers.dense({units: 1});
+ * const activationLayer = tf.layers.activation({activation: 'relu6'});
+ *
+ * // Obtain the output symbolic tensors by applying the layers in order.
+ * const denseOutput = denseLayer.apply(input);
+ * const activationOutput = activationLayer.apply(denseOutput);
+ *
+ * // Create the model based on the inputs.
+ * const model = tf.model({
+ *     inputs: input,
+ *     outputs: [denseOutput, activationOutput]
+ * });
+ *
+ * // Collect both outputs and print separately.
+ * const [denseOut, activationOut] = model.predict(tf.randomNormal([6, 5]));
+ * denseOut.print();
+ * activationOut.print();
+ * ```
+ */
+/**
+ * @doc {heading: 'Layers', subheading: 'Basic', namespace: 'layers'}
  */
 export function activation(args: ActivationLayerArgs): Layer {
   return new Activation(args);
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Basic',
- *   namespace: 'layers',
- *   useDocsFrom: 'Dense'
- * }
+ * Creates a dense (fully connected) layer.
+ *
+ * This layer implements the operation:
+ *   `output = activation(dot(input, kernel) + bias)`
+ *
+ * `activation` is the element-wise activation function
+ *   passed as the `activation` argument.
+ *
+ * `kernel` is a weights matrix created by the layer.
+ *
+ * `bias` is a bias vector created by the layer (only applicable if `useBias`
+ * is `true`).
+ *
+ * **Input shape:**
+ *
+ *   nD `tf.Tensor` with shape: `(batchSize, ..., inputDim)`.
+ *
+ *   The most common situation would be
+ *   a 2D input with shape `(batchSize, inputDim)`.
+ *
+ * **Output shape:**
+ *
+ *   nD tensor with shape: `(batchSize, ..., units)`.
+ *
+ *   For instance, for a 2D input with shape `(batchSize, inputDim)`,
+ *   the output would have shape `(batchSize, units)`.
+ *
+ * Note: if the input to the layer has a rank greater than 2, then it is
+ * flattened prior to the initial dot product with the kernel.
  */
+/** @doc {heading: 'Layers', subheading: 'Basic', namespace: 'layers'} */
 export function dense(args: DenseLayerArgs): Layer {
   return new Dense(args);
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Basic',
- *   namespace: 'layers',
- *   useDocsFrom: 'Dropout'
- * }
+ * Applies
+ * [dropout](http://www.cs.toronto.edu/~rsalakhu/papers/srivastava14a.pdf) to
+ * the input.
+ *
+ * Dropout consists in randomly setting a fraction `rate` of input units to 0 at
+ * each update during training time, which helps prevent overfitting.
  */
+/** @doc {heading: 'Layers', subheading: 'Basic', namespace: 'layers'} */
 export function dropout(args: DropoutLayerArgs): Layer {
   return new Dropout(args);
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Basic',
- *   namespace: 'layers',
- *   useDocsFrom: 'Flatten'
- * }
+ * Flattens the input. Does not affect the batch size.
+ *
+ * A `Flatten` layer flattens each batch in its inputs to 1D (making the output
+ * 2D).
+ *
+ * For example:
+ *
+ * ```js
+ * const input = tf.input({shape: [4, 3]});
+ * const flattenLayer = tf.layers.flatten();
+ * // Inspect the inferred output shape of the flatten layer, which
+ * // equals `[null, 12]`. The 2nd dimension is 4 * 3, i.e., the result of the
+ * // flattening. (The 1st dimension is the undermined batch size.)
+ * console.log(JSON.stringify(flattenLayer.apply(input).shape));
+ * ```
  */
+/** @doc {heading: 'Layers', subheading: 'Basic', namespace: 'layers'} */
 export function flatten(args?: LayerArgs): Layer {
   return new Flatten(args);
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Basic',
- *   namespace: 'layers',
- *   useDocsFrom: 'RepeatVector'
- * }
+ * Repeats the input n times in a new dimension.
+ *
+ * ```js
+ *  const model = tf.sequential();
+ *  model.add(tf.layers.repeatVector({n: 4, inputShape: [2]}));
+ *  const x = tf.tensor2d([[10, 20]]);
+ *  // Use the model to do inference on a data point the model hasn't see
+ *  model.predict(x).print();
+ *  // output shape is now [batch, 2, 4]
+ * ```
  */
+/** @doc {heading: 'Layers', subheading: 'Basic', namespace: 'layers'} */
 export function repeatVector(args: RepeatVectorLayerArgs): Layer {
   return new RepeatVector(args);
 }
 
 /**
- * @doc{
- *   heading: 'Layers',
- *   subheading: 'Basic',
- *   namespace: 'layers',
- *   useDocsFrom: 'Reshape'
- * }
+ * Reshapes an input to a certain shape.
+ *
+ * ```js
+ * const input = tf.input({shape: [4, 3]});
+ * const reshapeLayer = tf.layers.reshape({targetShape: [2, 6]});
+ * // Inspect the inferred output shape of the Reshape layer, which
+ * // equals `[null, 2, 6]`. (The 1st dimension is the undermined batch size.)
+ * console.log(JSON.stringify(reshapeLayer.apply(input).shape));
+ * ```
+ *
+ * Input shape:
+ *   Arbitrary: although all dimensions in the input shape must be fixed.
+ *     Use the ReshapeLayerConfig field `input_shape` when using this layer
+ *     as the first layer in a model.
+ *
+ * Output shape:
+ *   [batchSize, targetShape[0], targetShape[1], ...,
+ *    targetShape[targetShape.length - 1]].
  */
+/** @doc {heading: 'Layers', subheading: 'Basic', namespace: 'layers'} */
 export function reshape(args: ReshapeLayerArgs): Layer {
   return new Reshape(args);
 }
 
 /**
- * @doc{
- *   heading: 'Layers',
- *   subheading: 'Basic',
- *   namespace: 'layers',
- *   useDocsFrom: 'Permute'
- * }
+ * Permutes the dimensions of the input according to a given pattern.
+ *
+ * Useful for, e.g., connecting RNNs and convnets together.
+ *
+ * Example:
+ *
+ * ```js
+ * const model = tf.sequential();
+ * model.add(tf.layers.permute({
+ *   dims: [2, 1],
+ *   inputShape: [10, 64]
+ * }));
+ * console.log(model.outputShape);
+ * // Now model's output shape is [null, 64, 10], where null is the
+ * // unpermuted sample (batch) dimension.
+ * ```
+ *
+ * Input shape:
+ *   Arbitrary. Use the configuration field `inputShape` when using this
+ *   layer as othe first layer in a model.
+ *
+ * Output shape:
+ *   Same rank as the input shape, but with the dimensions re-ordered (i.e.,
+ *   permuted) according to the `dims` configuration of this layer.
  */
+/** @doc {heading: 'Layers', subheading: 'Basic', namespace: 'layers'} */
 export function permute(args: PermuteLayerArgs): Layer {
   return new Permute(args);
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Basic',
- *   namespace: 'layers',
- *    useDocsFrom: 'Embedding'
- * }
+ * Maps positive integers (indices) into dense vectors of fixed size.
+ * eg. [[4], [20]] -> [[0.25, 0.1], [0.6, -0.2]]
+ *
+ * **Input shape:** 2D tensor with shape: `[batchSize, sequenceLength]`.
+ *
+ * **Output shape:** 3D tensor with shape: `[batchSize, sequenceLength,
+ * outputDim]`.
  */
+/** @doc {heading: 'Layers', subheading: 'Basic', namespace: 'layers'} */
 export function embedding(args: EmbeddingLayerArgs): Layer {
   return new Embedding(args);
 }
@@ -317,85 +649,157 @@ export function embedding(args: EmbeddingLayerArgs): Layer {
 // Merge Layers.
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Merge',
- *   namespace: 'layers',
- *   useDocsFrom: 'Add'
- * }
+ * Layer that performs element-wise addition on an `Array` of inputs.
+ *
+ * It takes as input a list of tensors, all of the same shape, and returns a
+ * single tensor (also of the same shape). The inputs are specified as an
+ * `Array` when the `apply` method of the `Add` layer instance is called. For
+ * example:
+ *
+ * ```js
+ * const input1 = tf.input({shape: [2, 2]});
+ * const input2 = tf.input({shape: [2, 2]});
+ * const addLayer = tf.layers.add();
+ * const sum = addLayer.apply([input1, input2]);
+ * console.log(JSON.stringify(sum.shape));
+ * // You get [null, 2, 2], with the first dimension as the undetermined batch
+ * // dimension.
+ * ```
  */
+/** @doc {heading: 'Layers', subheading: 'Merge', namespace: 'layers'} */
 export function add(args?: LayerArgs): Layer {
   return new Add(args);
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Merge',
- *   namespace: 'layers',
- *   useDocsFrom: 'Average'
- * }
+ * Layer that performs element-wise averaging on an `Array` of inputs.
+ *
+ * It takes as input a list of tensors, all of the same shape, and returns a
+ * single tensor (also of the same shape). For example:
+ *
+ * ```js
+ * const input1 = tf.input({shape: [2, 2]});
+ * const input2 = tf.input({shape: [2, 2]});
+ * const averageLayer = tf.layers.average();
+ * const average = averageLayer.apply([input1, input2]);
+ * console.log(JSON.stringify(average.shape));
+ * // You get [null, 2, 2], with the first dimension as the undetermined batch
+ * // dimension.
+ * ```
  */
+/** @doc {heading: 'Layers', subheading: 'Merge', namespace: 'layers'} */
 export function average(args?: LayerArgs): Layer {
   return new Average(args);
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Merge',
- *   namespace: 'layers',
- *   useDocsFrom: 'Concatenate'
- * }
+ * Layer that concatenates an `Array` of inputs.
+ *
+ * It takes a list of tensors, all of the same shape except for the
+ * concatenation axis, and returns a single tensor, the concatenation
+ * of all inputs. For example:
+ *
+ * ```js
+ * const input1 = tf.input({shape: [2, 2]});
+ * const input2 = tf.input({shape: [2, 3]});
+ * const concatLayer = tf.layers.concatenate();
+ * const output = concatLayer.apply([input1, input2]);
+ * console.log(JSON.stringify(output.shape));
+ * // You get [null, 2, 5], with the first dimension as the undetermined batch
+ * // dimension. The last dimension (5) is the result of concatenating the
+ * // last dimensions of the inputs (2 and 3).
+ * ```
  */
+/** @doc {heading: 'Layers', subheading: 'Merge', namespace: 'layers'} */
 export function concatenate(args?: ConcatenateLayerArgs): Layer {
   return new Concatenate(args);
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Merge',
- *   namespace: 'layers',
- *   useDocsFrom: 'Maximum'
- * }
+ * Layer that computes the element-wise maximum an `Array` of inputs.
+ *
+ * It takes as input a list of tensors, all of the same shape and returns a
+ * single tensor (also of the same shape). For example:
+ *
+ * ```js
+ * const input1 = tf.input({shape: [2, 2]});
+ * const input2 = tf.input({shape: [2, 2]});
+ * const maxLayer = tf.layers.maximum();
+ * const max = maxLayer.apply([input1, input2]);
+ * console.log(JSON.stringify(max.shape));
+ * // You get [null, 2, 2], with the first dimension as the undetermined batch
+ * // dimension.
+ * ```
  */
+/** @doc {heading: 'Layers', subheading: 'Merge', namespace: 'layers'} */
 export function maximum(args?: LayerArgs): Layer {
   return new Maximum(args);
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Merge',
- *   namespace: 'layers',
- *   useDocsFrom: 'Minimum'
- * }
+ * Layer that computes the element-wise minimum of an `Array` of inputs.
+ *
+ * It takes as input a list of tensors, all of the same shape and returns a
+ * single tensor (also of the same shape). For example:
+ *
+ * ```js
+ * const input1 = tf.input({shape: [2, 2]});
+ * const input2 = tf.input({shape: [2, 2]});
+ * const minLayer = tf.layers.minimum();
+ * const min = minLayer.apply([input1, input2]);
+ * console.log(JSON.stringify(min.shape));
+ * // You get [null, 2, 2], with the first dimension as the undetermined batch
+ * // dimension.
+ * ```
  */
+/** @doc {heading: 'Layers', subheading: 'Merge', namespace: 'layers'} */
 export function minimum(args?: LayerArgs): Layer {
   return new Minimum(args);
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Merge',
- *   namespace: 'layers',
- *   useDocsFrom: 'Multiply'
- * }
+ * Layer that multiplies (element-wise) an `Array` of inputs.
+ *
+ * It takes as input an Array of tensors, all of the same
+ * shape, and returns a single tensor (also of the same shape).
+ * For example:
+ *
+ * ```js
+ * const input1 = tf.input({shape: [2, 2]});
+ * const input2 = tf.input({shape: [2, 2]});
+ * const input3 = tf.input({shape: [2, 2]});
+ * const multiplyLayer = tf.layers.multiply();
+ * const product = multiplyLayer.apply([input1, input2, input3]);
+ * console.log(product.shape);
+ * // You get [null, 2, 2], with the first dimension as the undetermined batch
+ * // dimension.
  */
+/** @doc {heading: 'Layers', subheading: 'Merge', namespace: 'layers'} */
 export function multiply(args?: LayerArgs): Layer {
   return new Multiply(args);
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Merge',
- *   namespace: 'layers',
- *   useDocsFrom: 'Dot'
- * }
+ * Layer that computes a dot product between samples in two tensors.
+ *
+ * E.g., if applied to a list of two tensors `a` and `b` both of shape
+ * `[batchSize, n]`, the output will be a tensor of shape `[batchSize, 1]`,
+ * where each entry at index `[i, 0]` will be the dot product between
+ * `a[i, :]` and `b[i, :]`.
+ *
+ * Example:
+ *
+ * ```js
+ * const dotLayer = tf.layers.dot({axes: -1});
+ * const x1 = tf.tensor2d([[10, 20], [30, 40]]);
+ * const x2 = tf.tensor2d([[-1, -2], [-3, -4]]);
+ *
+ * // Invoke the layer's apply() method in eager (imperative) mode.
+ * const y = dotLayer.apply([x1, x2]);
+ * y.print();
+ * ```
  */
+/** @doc {heading: 'Layers', subheading: 'Merge', namespace: 'layers'} */
 export function dot(args: DotLayerArgs): Layer {
   return new Dot(args);
 }
@@ -403,12 +807,26 @@ export function dot(args: DotLayerArgs): Layer {
 // Normalization Layers.
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Normalization',
- *   namespace: 'layers',
- *   useDocsFrom: 'BatchNormalization'
- * }
+ * Batch normalization layer (Ioffe and Szegedy, 2014).
+ *
+ * Normalize the activations of the previous layer at each batch,
+ * i.e. applies a transformation that maintains the mean activation
+ * close to 0 and the activation standard deviation close to 1.
+ *
+ * Input shape:
+ *   Arbitrary. Use the keyword argument `inputShape` (Array of integers, does
+ *   not include the sample axis) when calling the constructor of this class,
+ *   if this layer is used as a first layer in a model.
+ *
+ * Output shape:
+ *   Same shape as input.
+ *
+ * References:
+ *   - [Batch Normalization: Accelerating Deep Network Training by Reducing
+ * Internal Covariate Shift](https://arxiv.org/abs/1502.03167)
+ */
+/**
+ * @doc {heading: 'Layers', subheading: 'Normalization', namespace: 'layers'}
  */
 export function batchNormalization(args?: BatchNormalizationLayerArgs): Layer {
   return new BatchNormalization(args);
@@ -417,26 +835,42 @@ export function batchNormalization(args?: BatchNormalizationLayerArgs): Layer {
 // Padding Layers.
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Padding',
- *   namespace: 'layers',
- *   useDocsFrom: 'ZeroPadding2D'
- * }
+ * Zero-padding layer for 2D input (e.g., image).
+ *
+ * This layer can add rows and columns of zeros
+ * at the top, bottom, left and right side of an image tensor.
+ *
+ * Input shape:
+ *   4D tensor with shape:
+ *   - If `dataFormat` is `"channelsLast"`:
+ *     `[batch, rows, cols, channels]`
+ *   - If `data_format` is `"channels_first"`:
+ *     `[batch, channels, rows, cols]`.
+ *
+ * Output shape:
+ *   4D with shape:
+ *   - If `dataFormat` is `"channelsLast"`:
+ *     `[batch, paddedRows, paddedCols, channels]`
+ *    - If `dataFormat` is `"channelsFirst"`:
+ *     `[batch, channels, paddedRows, paddedCols]`.
  */
+/** @doc {heading: 'Layers', subheading: 'Padding', namespace: 'layers'} */
 export function zeroPadding2d(args?: ZeroPadding2DLayerArgs): Layer {
   return new ZeroPadding2D(args);
 }
 
 // Pooling Layers.
+
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Pooling',
- *   namespace: 'layers',
- *   useDocsFrom: 'AveragePooling1D'
- * }
+ * Average pooling operation for spatial data.
+ *
+ * Input shape: `[batchSize, inLength, channels]`
+ *
+ * Output shape: `[batchSize, pooledLength, channels]`
+ *
+ * `tf.avgPool1d` is an alias.
  */
+/** @doc {heading: 'Layers', subheading: 'Pooling', namespace: 'layers'} */
 export function averagePooling1d(args: Pooling1DLayerArgs): Layer {
   return new AveragePooling1D(args);
 }
@@ -450,13 +884,27 @@ export function avgPooling1d(args: Pooling1DLayerArgs): Layer {
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Pooling',
- *   namespace: 'layers',
- *   useDocsFrom: 'AveragePooling2D'
- * }
+ * Average pooling operation for spatial data.
+ *
+ * Input shape:
+ *  - If `dataFormat === CHANNEL_LAST`:
+ *      4D tensor with shape:
+ *      `[batchSize, rows, cols, channels]`
+ *  - If `dataFormat === CHANNEL_FIRST`:
+ *      4D tensor with shape:
+ *      `[batchSize, channels, rows, cols]`
+ *
+ * Output shape
+ *  - If `dataFormat === CHANNEL_LAST`:
+ *      4D tensor with shape:
+ *      `[batchSize, pooleRows, pooledCols, channels]`
+ *  - If `dataFormat === CHANNEL_FIRST`:
+ *      4D tensor with shape:
+ *      `[batchSize, channels, pooleRows, pooledCols]`
+ *
+ * `tf.avgPool2d` is an alias.
  */
+/** @doc {heading: 'Layers', subheading: 'Pooling', namespace: 'layers'} */
 export function averagePooling2d(args: Pooling2DLayerArgs): Layer {
   return new AveragePooling2D(args);
 }
@@ -470,73 +918,95 @@ export function avgPooling2d(args: Pooling2DLayerArgs): Layer {
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Pooling',
- *   namespace: 'layers',
- *   useDocsFrom: 'GlobalAveragePooling1D'
- * }
+ * Global average pooling operation for temporal data.
+ *
+ * Input Shape: 3D tensor with shape: `[batchSize, steps, features]`.
+ *
+ * Output Shape:2D tensor with shape: `[batchSize, features]`.
  */
+/** @doc {heading: 'Layers', subheading: 'Pooling', namespace: 'layers'} */
 export function globalAveragePooling1d(args?: LayerArgs): Layer {
   return new GlobalAveragePooling1D(args);
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Pooling',
- *   namespace: 'layers',
- *   useDocsFrom: 'GlobalAveragePooling2D'
- * }
+ * Global average pooling operation for spatial data.
+ *
+ * Input shape:
+ *   - If `dataFormat` is `CHANNEL_LAST`:
+ *       4D tensor with shape: `[batchSize, rows, cols, channels]`.
+ *   - If `dataFormat` is `CHANNEL_FIRST`:
+ *       4D tensor with shape: `[batchSize, channels, rows, cols]`.
+ *
+ * Output shape:
+ *   2D tensor with shape: `[batchSize, channels]`.
  */
+/** @doc {heading: 'Layers', subheading: 'Pooling', namespace: 'layers'} */
 export function globalAveragePooling2d(args: GlobalPooling2DLayerArgs): Layer {
   return new GlobalAveragePooling2D(args);
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Pooling',
- *   namespace: 'layers',
- *   useDocsFrom: 'GlobalMaxPooling1D'
- * }
+ * Global max pooling operation for temporal data.
+ *
+ * Input Shape: 3D tensor with shape: `[batchSize, steps, features]`.
+ *
+ * Output Shape:2D tensor with shape: `[batchSize, features]`.
  */
+/** @doc {heading: 'Layers', subheading: 'Pooling', namespace: 'layers'} */
 export function globalMaxPooling1d(args?: LayerArgs): Layer {
   return new GlobalMaxPooling1D(args);
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Pooling',
- *   namespace: 'layers',
- *   useDocsFrom: 'GlobalMaxPooling2D'
- * }
+ * Global max pooling operation for spatial data.
+ *
+ * Input shape:
+ *   - If `dataFormat` is `CHANNEL_LAST`:
+ *       4D tensor with shape: `[batchSize, rows, cols, channels]`.
+ *   - If `dataFormat` is `CHANNEL_FIRST`:
+ *       4D tensor with shape: `[batchSize, channels, rows, cols]`.
+ *
+ * Output shape:
+ *   2D tensor with shape: `[batchSize, channels]`.
  */
+/** @doc {heading: 'Layers', subheading: 'Pooling', namespace: 'layers'} */
 export function globalMaxPooling2d(args: GlobalPooling2DLayerArgs): Layer {
   return new GlobalMaxPooling2D(args);
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Pooling',
- *   namespace: 'layers',
- *   useDocsFrom: 'MaxPooling1D'
- * }
+ * Max pooling operation for temporal data.
+ *
+ * Input shape:  `[batchSize, inLength, channels]`
+ *
+ * Output shape: `[batchSize, pooledLength, channels]`
  */
+/** @doc {heading: 'Layers', subheading: 'Pooling', namespace: 'layers'} */
 export function maxPooling1d(args: Pooling1DLayerArgs): Layer {
   return new MaxPooling1D(args);
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Pooling',
- *   namespace: 'layers',
- *   useDocsFrom: 'MaxPooling2D'
- * }
+ * Max pooling operation for spatial data.
+ *
+ * Input shape
+ *   - If `dataFormat === CHANNEL_LAST`:
+ *       4D tensor with shape:
+ *       `[batchSize, rows, cols, channels]`
+ *   - If `dataFormat === CHANNEL_FIRST`:
+ *      4D tensor with shape:
+ *       `[batchSize, channels, rows, cols]`
+ *
+ * Output shape
+ *   - If `dataFormat=CHANNEL_LAST`:
+ *       4D tensor with shape:
+ *       `[batchSize, pooleRows, pooledCols, channels]`
+ *   - If `dataFormat=CHANNEL_FIRST`:
+ *       4D tensor with shape:
+ *       `[batchSize, channels, pooleRows, pooledCols]`
  */
+/** @doc {heading: 'Layers', subheading: 'Pooling', namespace: 'layers'} */
 export function maxPooling2d(args: Pooling2DLayerArgs): Layer {
   return new MaxPooling2D(args);
 }
@@ -544,123 +1014,353 @@ export function maxPooling2d(args: Pooling2DLayerArgs): Layer {
 // Recurrent Layers.
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Recurrent',
- *   namespace: 'layers',
- *   useDocsFrom: 'GRU'
- * }
+ * Gated Recurrent Unit - Cho et al. 2014.
+ *
+ * This is an `RNN` layer consisting of one `GRUCell`. However, unlike
+ * the underlying `GRUCell`, the `apply` method of `SimpleRNN` operates
+ * on a sequence of inputs. The shape of the input (not including the first,
+ * batch dimension) needs to be at least 2-D, with the first dimension being
+ * time steps. For example:
+ *
+ * ```js
+ * const rnn = tf.layers.gru({units: 8, returnSequences: true});
+ *
+ * // Create an input with 10 time steps.
+ * const input = tf.input({shape: [10, 20]});
+ * const output = rnn.apply(input);
+ *
+ * console.log(JSON.stringify(output.shape));
+ * // [null, 10, 8]: 1st dimension is unknown batch size; 2nd dimension is the
+ * // same as the sequence length of `input`, due to `returnSequences`: `true`;
+ * // 3rd dimension is the `GRUCell`'s number of units.
  */
+/** @doc {heading: 'Layers', subheading: 'Recurrent', namespace: 'layers'} */
 export function gru(args: GRULayerArgs): Layer {
   return new GRU(args);
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Recurrent',
- *   namespace: 'layers',
- *   useDocsFrom: 'GRUCell'
- * }
+ * Cell class for `GRU`.
+ *
+ * `GRUCell` is distinct from the `RNN` subclass `GRU` in that its
+ * `apply` method takes the input data of only a single time step and returns
+ * the cell's output at the time step, while `GRU` takes the input data
+ * over a number of time steps. For example:
+ *
+ * ```js
+ * const cell = tf.layers.gruCell({units: 2});
+ * const input = tf.input({shape: [10]});
+ * const output = cell.apply(input);
+ *
+ * console.log(JSON.stringify(output.shape));
+ * // [null, 10]: This is the cell's output at a single time step. The 1st
+ * // dimension is the unknown batch size.
+ * ```
+ *
+ * Instance(s) of `GRUCell` can be used to construct `RNN` layers. The
+ * most typical use of this workflow is to combine a number of cells into a
+ * stacked RNN cell (i.e., `StackedRNNCell` internally) and use it to create an
+ * RNN. For example:
+ *
+ * ```js
+ * const cells = [
+ *   tf.layers.gruCell({units: 4}),
+ *   tf.layers.gruCell({units: 8}),
+ * ];
+ * const rnn = tf.layers.rnn({cell: cells, returnSequences: true});
+ *
+ * // Create an input with 10 time steps and a length-20 vector at each step.
+ * const input = tf.input({shape: [10, 20]});
+ * const output = rnn.apply(input);
+ *
+ * console.log(JSON.stringify(output.shape));
+ * // [null, 10, 8]: 1st dimension is unknown batch size; 2nd dimension is the
+ * // same as the sequence length of `input`, due to `returnSequences`: `true`;
+ * // 3rd dimension is the last `gruCell`'s number of units.
+ * ```
+ *
+ * To create an `RNN` consisting of only *one* `GRUCell`, use the
+ * `tf.layers.gru`.
  */
+/** @doc {heading: 'Layers', subheading: 'Recurrent', namespace: 'layers'} */
 export function gruCell(args: GRUCellLayerArgs): RNNCell {
   return new GRUCell(args);
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Recurrent',
- *   namespace: 'layers',
- *   useDocsFrom: 'LSTM'
- * }
+ * Long-Short Term Memory layer - Hochreiter 1997.
+ *
+ * This is an `RNN` layer consisting of one `LSTMCell`. However, unlike
+ * the underlying `LSTMCell`, the `apply` method of `LSTM` operates
+ * on a sequence of inputs. The shape of the input (not including the first,
+ * batch dimension) needs to be at least 2-D, with the first dimension being
+ * time steps. For example:
+ *
+ * ```js
+ * const lstm = tf.layers.lstm({units: 8, returnSequences: true});
+ *
+ * // Create an input with 10 time steps.
+ * const input = tf.input({shape: [10, 20]});
+ * const output = lstm.apply(input);
+ *
+ * console.log(JSON.stringify(output.shape));
+ * // [null, 10, 8]: 1st dimension is unknown batch size; 2nd dimension is the
+ * // same as the sequence length of `input`, due to `returnSequences`: `true`;
+ * // 3rd dimension is the `LSTMCell`'s number of units.
  */
+/** @doc {heading: 'Layers', subheading: 'Recurrent', namespace: 'layers'} */
 export function lstm(args: LSTMLayerArgs): Layer {
   return new LSTM(args);
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Recurrent',
- *   namespace: 'layers',
- *   useDocsFrom: 'LSTMCell'
- * }
+ * Cell class for `LSTM`.
+ *
+ * `LSTMCell` is distinct from the `RNN` subclass `LSTM` in that its
+ * `apply` method takes the input data of only a single time step and returns
+ * the cell's output at the time step, while `LSTM` takes the input data
+ * over a number of time steps. For example:
+ *
+ * ```js
+ * const cell = tf.layers.lstmCell({units: 2});
+ * const input = tf.input({shape: [10]});
+ * const output = cell.apply(input);
+ *
+ * console.log(JSON.stringify(output.shape));
+ * // [null, 10]: This is the cell's output at a single time step. The 1st
+ * // dimension is the unknown batch size.
+ * ```
+ *
+ * Instance(s) of `LSTMCell` can be used to construct `RNN` layers. The
+ * most typical use of this workflow is to combine a number of cells into a
+ * stacked RNN cell (i.e., `StackedRNNCell` internally) and use it to create an
+ * RNN. For example:
+ *
+ * ```js
+ * const cells = [
+ *   tf.layers.lstmCell({units: 4}),
+ *   tf.layers.lstmCell({units: 8}),
+ * ];
+ * const rnn = tf.layers.rnn({cell: cells, returnSequences: true});
+ *
+ * // Create an input with 10 time steps and a length-20 vector at each step.
+ * const input = tf.input({shape: [10, 20]});
+ * const output = rnn.apply(input);
+ *
+ * console.log(JSON.stringify(output.shape));
+ * // [null, 10, 8]: 1st dimension is unknown batch size; 2nd dimension is the
+ * // same as the sequence length of `input`, due to `returnSequences`: `true`;
+ * // 3rd dimension is the last `lstmCell`'s number of units.
+ * ```
+ *
+ * To create an `RNN` consisting of only *one* `LSTMCell`, use the
+ * `tf.layers.lstm`.
  */
+/** @doc {heading: 'Layers', subheading: 'Recurrent', namespace: 'layers'} */
 export function lstmCell(args: LSTMCellLayerArgs): RNNCell {
   return new LSTMCell(args);
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Recurrent',
- *   namespace: 'layers',
- *   useDocsFrom: 'SimpleRNN'
- * }
+ * Fully-connected RNN where the output is to be fed back to input.
+ *
+ * This is an `RNN` layer consisting of one `SimpleRNNCell`. However, unlike
+ * the underlying `SimpleRNNCell`, the `apply` method of `SimpleRNN` operates
+ * on a sequence of inputs. The shape of the input (not including the first,
+ * batch dimension) needs to be at least 2-D, with the first dimension being
+ * time steps. For example:
+ *
+ * ```js
+ * const rnn = tf.layers.simpleRNN({units: 8, returnSequences: true});
+ *
+ * // Create an input with 10 time steps.
+ * const input = tf.input({shape: [10, 20]});
+ * const output = rnn.apply(input);
+ *
+ * console.log(JSON.stringify(output.shape));
+ * // [null, 10, 8]: 1st dimension is unknown batch size; 2nd dimension is the
+ * // same as the sequence length of `input`, due to `returnSequences`: `true`;
+ * // 3rd dimension is the `SimpleRNNCell`'s number of units.
+ * ```
  */
+/** @doc {heading: 'Layers', subheading: 'Recurrent', namespace: 'layers'} */
 export function simpleRNN(args: SimpleRNNLayerArgs): Layer {
   return new SimpleRNN(args);
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Recurrent',
- *   namespace: 'layers',
- *   useDocsFrom: 'SimpleRNNCell'
- * }
+ * Cell class for `SimpleRNN`.
+ *
+ * `SimpleRNNCell` is distinct from the `RNN` subclass `SimpleRNN` in that its
+ * `apply` method takes the input data of only a single time step and returns
+ * the cell's output at the time step, while `SimpleRNN` takes the input data
+ * over a number of time steps. For example:
+ *
+ * ```js
+ * const cell = tf.layers.simpleRNNCell({units: 2});
+ * const input = tf.input({shape: [10]});
+ * const output = cell.apply(input);
+ *
+ * console.log(JSON.stringify(output.shape));
+ * // [null, 10]: This is the cell's output at a single time step. The 1st
+ * // dimension is the unknown batch size.
+ * ```
+ *
+ * Instance(s) of `SimpleRNNCell` can be used to construct `RNN` layers. The
+ * most typical use of this workflow is to combine a number of cells into a
+ * stacked RNN cell (i.e., `StackedRNNCell` internally) and use it to create an
+ * RNN. For example:
+ *
+ * ```js
+ * const cells = [
+ *   tf.layers.simpleRNNCell({units: 4}),
+ *   tf.layers.simpleRNNCell({units: 8}),
+ * ];
+ * const rnn = tf.layers.rnn({cell: cells, returnSequences: true});
+ *
+ * // Create an input with 10 time steps and a length-20 vector at each step.
+ * const input = tf.input({shape: [10, 20]});
+ * const output = rnn.apply(input);
+ *
+ * console.log(JSON.stringify(output.shape));
+ * // [null, 10, 8]: 1st dimension is unknown batch size; 2nd dimension is the
+ * // same as the sequence length of `input`, due to `returnSequences`: `true`;
+ * // 3rd dimension is the last `SimpleRNNCell`'s number of units.
+ * ```
+ *
+ * To create an `RNN` consisting of only *one* `SimpleRNNCell`, use the
+ * `tf.layers.simpleRNN`.
  */
+/** @doc {heading: 'Layers', subheading: 'Recurrent', namespace: 'layers'} */
 export function simpleRNNCell(args: SimpleRNNCellLayerArgs): RNNCell {
   return new SimpleRNNCell(args);
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Recurrent',
- *   namespace: 'layers',
- *   useDocsFrom: 'RNN'
- * }
+ * Base class for recurrent layers.
+ *
+ * Input shape:
+ *   3D tensor with shape `[batchSize, timeSteps, inputDim]`.
+ *
+ * Output shape:
+ *   - if `returnState`, an Array of tensors (i.e., `tf.Tensor`s). The first
+ *     tensor is the output. The remaining tensors are the states at the
+ *     last time step, each with shape `[batchSize, units]`.
+ *   - if `returnSequences`, the output will have shape
+ *     `[batchSize, timeSteps, units]`.
+ *   - else, the output will have shape `[batchSize, units]`.
+ *
+ * Masking:
+ *   This layer supports masking for input data with a variable number
+ *   of timesteps. To introduce masks to your data,
+ *   use an embedding layer with the `mask_zero` parameter
+ *   set to `True`.
+ *
+ * Notes on using statefulness in RNNs:
+ *   You can set RNN layers to be 'stateful', which means that the states
+ *   computed for the samples in one batch will be reused as initial states
+ *   for the samples in the next batch. This assumes a one-to-one mapping
+ *   between samples in different successive batches.
+ *
+ *   To enable statefulness:
+ *     - specify `stateful: true` in the layer constructor.
+ *     - specify a fixed batch size for your model, by passing
+ *       if sequential model:
+ *         `batchInputShape=[...]` to the first layer in your model.
+ *       else for functional model with 1 or more Input layers:
+ *         `batchShape=[...]` to all the first layers in your model.
+ *       This is the expected shape of your inputs *including the batch size*.
+ *       It should be a tuple of integers, e.g. `(32, 10, 100)`.
+ *     - specify `shuffle=False` when calling fit().
+ *
+ *   To reset the states of your model, call `.resetStates()` on either
+ *   a specific layer, or on your entire model.
+ *
+ * Note on specifying the initial state of RNNs
+ *   You can specify the initial state of RNN layers symbolically by
+ *   calling them with the option `initialState`. The value of
+ *   `initialState` should be a tensor or list of tensors representing
+ *   the initial state of the RNN layer.
+ *
+ *   You can specify the initial state of RNN layers numerically by
+ *   calling `resetStates` with the keyword argument `states`. The value of
+ *   `states` should be a numpy array or list of numpy arrays representing
+ *   the initial state of the RNN layer.
+ *
+ * Note on passing external constants to RNNs
+ *   You can pass "external" constants to the cell using the `constants`
+ *   keyword argument of `RNN.call` method. This requires that the `cell.call`
+ *   method accepts the same keyword argument `constants`. Such constants
+ *   can be used to conditon the cell transformation on additional static inputs
+ *   (not changing over time), a.k.a an attention mechanism.
  */
+/** @doc {heading: 'Layers', subheading: 'Recurrent', namespace: 'layers'} */
 export function rnn(args: RNNLayerArgs): Layer {
   return new RNN(args);
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Recurrent',
- *   namespace: 'layers',
- *   useDocsFrom: 'RNN'
- * }
+ * Wrapper allowing a stack of RNN cells to behave as a single cell.
+ *
+ * Used to implement efficient stacked RNNs.
  */
+/** @doc {heading: 'Layers', subheading: 'Recurrent', namespace: 'layers'} */
 export function stackedRNNCells(args: StackedRNNCellsArgs): RNNCell {
   return new StackedRNNCells(args);
 }
 
 // Wrapper Layers.
 
-/**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Wrapper',
- *   namespace: 'layers',
- *   useDocsFrom: 'Bidirectional'
- * }
- */
+/** @doc {heading: 'Layers', subheading: 'Wrapper', namespace: 'layers'} */
 export function bidirectional(args: BidirectionalLayerArgs): Bidirectional {
   return new Bidirectional(args);
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Wrapper',
- *   namespace: 'layers',
- *   useDocsFrom: 'TimeDistributed'
- * }
+ * This wrapper applies a layer to every temporal slice of an input.
+ *
+ * The input should be at least 3D,  and the dimension of the index `1` will be
+ * considered to be the temporal dimension.
+ *
+ * Consider a batch of 32 samples, where each sample is a sequence of 10 vectors
+ * of 16 dimensions. The batch input shape of the layer is then `[32,  10,
+ * 16]`, and the `inputShape`, not including the sample dimension, is
+ * `[10, 16]`.
+ *
+ * You can then use `TimeDistributed` to apply a `Dense` layer to each of the 10
+ * timesteps, independently:
+ *
+ * ```js
+ * const model = tf.sequential();
+ * model.add(tf.layers.timeDistributed({
+ *   layer: tf.layers.dense({units: 8}),
+ *   inputShape: [10, 16],
+ * }));
+ *
+ * // Now model.outputShape = [null, 10, 8].
+ * // The output will then have shape `[32, 10, 8]`.
+ *
+ * // In subsequent layers, there is no need for `inputShape`:
+ * model.add(tf.layers.timeDistributed({layer: tf.layers.dense({units: 32})}));
+ * console.log(JSON.stringify(model.outputs[0].shape));
+ * // Now model.outputShape = [null, 10, 32].
+ * ```
+ *
+ * The output will then have shape `[32, 10, 32]`.
+ *
+ * `TimeDistributed` can be used with arbitrary layers, not just `Dense`, for
+ * instance a `Conv2D` layer.
+ *
+ * ```js
+ * const model = tf.sequential();
+ * model.add(tf.layers.timeDistributed({
+ *   layer: tf.layers.conv2d({filters: 64, kernelSize: [3, 3]}),
+ *   inputShape: [10, 299, 299, 3],
+ * }));
+ * console.log(JSON.stringify(model.outputs[0].shape));
+ * ```
  */
+/** @doc {heading: 'Layers', subheading: 'Wrapper', namespace: 'layers'} */
 export function timeDistributed(args: WrapperLayerArgs): Layer {
   return new TimeDistributed(args);
 }
@@ -674,49 +1374,116 @@ export const maxPool2d = maxPooling2d;
 export {Layer, RNN, RNNCell, input /* alias for tf.input */};
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Noise',
- *   namespace: 'layers',
- *   useDocsFrom: 'GaussianNoise'
- * }
+ * Apply additive zero-centered Gaussian noise.
+ *
+ * As it is a regularization layer, it is only active at training time.
+ *
+ * This is useful to mitigate overfitting
+ * (you could see it as a form of random data augmentation).
+ * Gaussian Noise (GS) is a natural choice as corruption process
+ * for real valued inputs.
+ *
+ * # Arguments
+ *     stddev: float, standard deviation of the noise distribution.
+ *
+ * # Input shape
+ *         Arbitrary. Use the keyword argument `input_shape`
+ *         (tuple of integers, does not include the samples axis)
+ *         when using this layer as the first layer in a model.
+ *
+ * # Output shape
+ *         Same shape as input.
  */
+/** @doc {heading: 'Layers', subheading: 'Noise', namespace: 'layers'} */
 export function gaussianNoise(args: GaussianNoiseArgs): GaussianNoise {
   return new GaussianNoise(args);
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Noise',
- *   namespace: 'layers',
- *   useDocsFrom: 'GaussianDropout'
- * }
+ * Apply multiplicative 1-centered Gaussian noise.
+ *
+ * As it is a regularization layer, it is only active at training time.
+ *
+ * # Arguments
+ *     rate: float, drop probability (as with `Dropout`).
+ *        The multiplicative noise will have
+ *        standard deviation `sqrt(rate / (1 - rate))`.
+ *
+ * # Input shape
+ *     Arbitrary. Use the keyword argument `input_shape`
+ *     (tuple of integers, does not include the samples axis)
+ *     when using this layer as the first layer in a model.
+ *
+ * # Output shape
+ *     Same shape as input.
+ *
+ * # References
+ *     - [Dropout: A Simple Way to Prevent Neural Networks from Overfitting](
+ *        http://www.cs.toronto.edu/~rsalakhu/papers/srivastava14a.pdf)
+ *
  */
+/** @doc {heading: 'Layers', subheading: 'Noise', namespace: 'layers'} */
 export function gaussianDropout(args: GaussianDropoutArgs): GaussianDropout {
   return new GaussianDropout(args);
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Noise',
- *   namespace: 'layers',
- *   useDocsFrom: 'AlphaDropout'
- * }
+ * Applies Alpha Dropout to the input.
+ *
+ * As it is a regularization layer, it is only active at training time.
+ *
+ * Alpha Dropout is a `Dropout` that keeps mean and variance of inputs
+ * to their original values, in order to ensure the self-normalizing property
+ * even after this dropout.
+ * Alpha Dropout fits well to Scaled Exponential Linear Units
+ * by randomly setting activations to the negative saturation value.
+ *
+ * # Arguments
+ *    rate: float, drop probability (as with `Dropout`).
+ *        The multiplicative noise will have
+ *        standard deviation `sqrt(rate / (1 - rate))`.
+ *    noise_shape: A 1-D `Tensor` of type `int32`, representing the
+ *         shape for randomly generated keep/drop flags.
+ *
+ *
+ * # Input shape
+ *         Arbitrary. Use the keyword argument `input_shape`
+ *         (tuple of integers, does not include the samples axis)
+ *         when using this layer as the first layer in a model.
+ *
+ * # Output shape
+ *         Same shape as input.
+ *
+ * # References
+ *     - [Self-Normalizing Neural Networks](https://arxiv.org/abs/1706.02515)
  */
+/** @doc {heading: 'Layers', subheading: 'Noise', namespace: 'layers'} */
 export function alphaDropout(args: AlphaDropoutArgs): AlphaDropout {
   return new AlphaDropout(args);
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Mask',
- *   namespace: 'layers',
- *   useDocsFrom: 'Masking'
- * }
+ * Masks a sequence by using a mask value to skip timesteps.
+ *
+ * If all features for a given sample timestep are equal to `mask_value`,
+ * then the sample timestep will be masked (skipped) in all downstream layers
+ * (as long as they support masking).
+ *
+ * If any downstream layer does not support masking yet receives such
+ * an input mask, an exception will be raised.
+ *
+ * # Arguments
+ *     maskValue: Either None or mask value to skip.
+ *
+ * # Input shape
+ *     Arbitrary. Use the keyword argument `input_shape`
+ *     (tuple of integers, does not include the samples axis)
+ *     when using this layer as the first layer in a model.
+ *
+ * # Output shape
+ *     Same shape as input.
  */
+/** @doc {heading: 'Layers', subheading: 'Mask', namespace: 'layers'} */
 export function masking(args?: MaskingArgs): Layer {
   return new Masking(args);
 }

--- a/src/exports_layers.ts
+++ b/src/exports_layers.ts
@@ -610,7 +610,7 @@ export function reshape(args: ReshapeLayerArgs): Layer {
  * Example:
  *
  * ```js
- * const model = tf.Sequential();
+ * const model = tf.sequential();
  * model.add(tf.layers.permute({
  *   dims: [2, 1],
  *   inputShape: [10, 64]

--- a/src/exports_metrics.ts
+++ b/src/exports_metrics.ts
@@ -13,112 +13,255 @@ import * as losses from './losses';
 import * as metrics from './metrics';
 
 /**
- * @doc {
- *   heading: 'Metrics',
- *   namespace: 'metrics',
- *   useDocsFrom: 'binaryAccuracy'
- * }
+ * Binary accuracy metric function.
+ *
+ * `yTrue` and `yPred` can have 0-1 values. Example:
+ * ```js
+ * const x = tf.tensor2d([[1, 1, 1, 1], [0, 0, 0, 0]], [2, 4]);
+ * const y = tf.tensor2d([[1, 0, 1, 0], [0, 0, 0, 1]], [2, 4]);
+ * const accuracy = tf.metrics.binaryAccuracy(x, y);
+ * accuracy.print();
+ * ```
+ *
+ * `yTrue` and `yPred` can also have floating-number values between 0 and 1, in
+ * which case the values will be thresholded at 0.5 to yield 0-1 values (i.e.,
+ * a value >= 0.5 and <= 1.0 is interpreted as 1.
+ * )
+ * Example:
+ * ```js
+ * const x = tf.tensor1d([1, 1, 1, 1, 0, 0, 0, 0]);
+ * const y = tf.tensor1d([0.2, 0.4, 0.6, 0.8, 0.2, 0.3, 0.4, 0.7]);
+ * const accuracy = tf.metrics.binaryAccuracy(x, y);
+ * accuracy.print();
+ * ```
+ *
+ * @param yTrue Binary Tensor of truth.
+ * @param yPred Binary Tensor of prediction.
+ * @return Accuracy Tensor.
  */
+/** @doc {heading: 'Metrics', namespace: 'metrics'} */
 export function binaryAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
   return metrics.binaryAccuracy(yTrue, yPred);
 }
 
 /**
- * @doc {
- *   heading: 'Metrics',
- *   namespace: 'metrics',
- *   useDocsFrom: 'binaryCrossentropy'
- * }
+ * Binary crossentropy metric function.
+ *
+ * Example:
+ * ```js
+ * const x = tf.tensor2d([[0], [1], [1], [1]]);
+ * const y = tf.tensor2d([[0], [0], [0.5], [1]]);
+ * const crossentropy = tf.metrics.binaryCrossentropy(x, y);
+ * crossentropy.print();
+ * ```
+ *
+ * @param yTrue Binary Tensor of truth.
+ * @param yPred Binary Tensor of prediction, probabilities for the `1` case.
+ * @return Accuracy Tensor.
  */
+/** @doc {heading: 'Metrics', namespace: 'metrics'} */
 export function binaryCrossentropy(yTrue: Tensor, yPred: Tensor): Tensor {
   return metrics.binaryCrossentropy(yTrue, yPred);
 }
 
 /**
- * @doc {
- *   heading: 'Metrics',
- *   namespace: 'metrics',
- *   useDocsFrom: 'sparseCategoricalAccuracy'
- * }
+ * Sparse categorical accuracy metric function.
+ *
+ * Example:
+ * ```js
+ *
+ * const yTrue = tf.tensor1d([1, 1, 2, 2, 0]);
+ * const yPred = tf.tensor2d(
+ *      [[0, 1, 0], [1, 0, 0], [0, 0.4, 0.6], [0, 0.6, 0.4], [0.7, 0.3, 0]]);
+ * const crossentropy = tf.metrics.sparseCategoricalAccuracy(yTrue, yPred);
+ * crossentropy.print();
+ * ```
+ *
+ * @param yTrue True labels: indices.
+ * @param yPred Predicted probabilities or logits.
+ * @returns Accuracy tensor.
  */
+/** @doc {heading: 'Metrics', namespace: 'metrics'} */
 export function sparseCategoricalAccuracy(
     yTrue: Tensor, yPred: Tensor): Tensor {
   return metrics.sparseCategoricalAccuracy(yTrue, yPred);
 }
 
 /**
- * @doc {
- *   heading: 'Metrics',
- *   namespace: 'metrics',
- *   useDocsFrom: 'categoricalAccuracy'
- * }
+ * Categorical accuracy metric function.
+ *
+ * Example:
+ * ```js
+ * const x = tf.tensor2d([[0, 0, 0, 1], [0, 0, 0, 1]]);
+ * const y = tf.tensor2d([[0.1, 0.8, 0.05, 0.05], [0.1, 0.05, 0.05, 0.8]]);
+ * const accuracy = tf.metrics.categoricalAccuracy(x, y);
+ * accuracy.print();
+ * ```
+ *
+ * @param yTrue Binary Tensor of truth: one-hot encoding of categories.
+ * @param yPred Binary Tensor of prediction: probabilities or logits for the
+ *   same categories as in `yTrue`.
+ * @return Accuracy Tensor.
  */
+/** @doc {heading: 'Metrics', namespace: 'metrics'} */
 export function categoricalAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
   return metrics.categoricalAccuracy(yTrue, yPred);
 }
 
 /**
- * @doc {
- *   heading: 'Metrics',
- *   namespace: 'metrics',
- *   useDocsFrom: 'categoricalCrossentropy'
- * }
+ * Categorical crossentropy between an output tensor and a target tensor.
+ *
+ * @param target A tensor of the same shape as `output`.
+ * @param output A tensor resulting from a softmax (unless `fromLogits` is
+ *  `true`, in which case `output` is expected to be the logits).
+ * @param fromLogits Boolean, whether `output` is the result of a softmax, or is
+ *   a tensor of logits.
  */
+/** @doc {heading: 'Metrics', namespace: 'metrics'} */
 export function categoricalCrossentropy(yTrue: Tensor, yPred: Tensor): Tensor {
   return metrics.categoricalCrossentropy(yTrue, yPred);
 }
 
 /**
- * @doc {
- *   heading: 'Metrics',
- *   namespace: 'metrics',
- *   useDocsFrom: 'precision'
- * }
+ * Computes the precision of the predictions with respect to the labels.
+ *
+ * Example:
+ * ```js
+ * const x = tf.tensor2d(
+ *    [
+ *      [0, 0, 0, 1],
+ *      [0, 1, 0, 0],
+ *      [0, 0, 0, 1],
+ *      [1, 0, 0, 0],
+ *      [0, 0, 1, 0]
+ *    ]
+ * );
+ *
+ * const y = tf.tensor2d(
+ *    [
+ *      [0, 0, 1, 0],
+ *      [0, 1, 0, 0],
+ *      [0, 0, 0, 1],
+ *      [0, 1, 0, 0],
+ *      [0, 1, 0, 0]
+ *    ]
+ * );
+ *
+ * const precision = tf.metrics.precision(x, y);
+ * precision.print();
+ * ```
+ *
+ * @param yTrue The ground truth values. Expected to be contain only 0-1 values.
+ * @param yPred The predicted values. Expected to be contain only 0-1 values.
+ * @return Precision Tensor.
  */
+/** @doc {heading: 'Metrics', namespace: 'metrics'} */
 export function precision(yTrue: Tensor, yPred: Tensor): Tensor {
   return metrics.precision(yTrue, yPred);
 }
 
 /**
- * @doc {
- *   heading: 'Metrics',
- *   namespace: 'metrics',
- *   useDocsFrom: 'recall'
- * }
+ * Computes the recall of the predictions with respect to the labels.
+ *
+ * Example:
+ * ```js
+ * const x = tf.tensor2d(
+ *    [
+ *      [0, 0, 0, 1],
+ *      [0, 1, 0, 0],
+ *      [0, 0, 0, 1],
+ *      [1, 0, 0, 0],
+ *      [0, 0, 1, 0]
+ *    ]
+ * );
+ *
+ * const y = tf.tensor2d(
+ *    [
+ *      [0, 0, 1, 0],
+ *      [0, 1, 0, 0],
+ *      [0, 0, 0, 1],
+ *      [0, 1, 0, 0],
+ *      [0, 1, 0, 0]
+ *    ]
+ * );
+ *
+ * const recall = tf.metrics.recall(x, y);
+ * recall.print();
+ * ```
+ *
+ * @param yTrue The ground truth values. Expected to be contain only 0-1 values.
+ * @param yPred The predicted values. Expected to be contain only 0-1 values.
+ * @return Recall Tensor.
  */
+/** @doc {heading: 'Metrics', namespace: 'metrics'} */
 export function recall(yTrue: Tensor, yPred: Tensor): Tensor {
   return metrics.recall(yTrue, yPred);
 }
 
 /**
- * @doc {
- *   heading: 'Metrics',
- *   namespace: 'metrics',
- *   useDocsFrom: 'cosineProximity'
- * }
+ * Loss or metric function: Cosine proximity.
+ *
+ * Mathematically, cosine proximity is defined as:
+ *   `-sum(l2Normalize(yTrue) * l2Normalize(yPred))`,
+ * wherein `l2Normalize()` normalizes the L2 norm of the input to 1 and `*`
+ * represents element-wise multiplication.
+ *
+ * ```js
+ * const yTrue = tf.tensor2d([[1, 0], [1, 0]]);
+ * const yPred = tf.tensor2d([[1 / Math.sqrt(2), 1 / Math.sqrt(2)], [0, 1]]);
+ * const proximity = tf.metrics.cosineProximity(yTrue, yPred);
+ * proximity.print();
+ * ```
+ *
+ * @param yTrue Truth Tensor.
+ * @param yPred Prediction Tensor.
+ * @return Cosine proximity Tensor.
  */
+/** @doc {heading: 'Metrics', namespace: 'metrics'} */
 export function cosineProximity(yTrue: Tensor, yPred: Tensor): Tensor {
   return losses.cosineProximity(yTrue, yPred);
 }
 
 /**
- * @doc {
- *   heading: 'Metrics',
- *   namespace: 'metrics',
- *   useDocsFrom: 'meanAbsoluteError'
- * }
+ * Loss or metric function: Mean absolute error.
+ *
+ * Mathematically, mean absolute error is defined as:
+ *   `mean(abs(yPred - yTrue))`,
+ * wherein the `mean` is applied over feature dimensions.
+ *
+ * ```js
+ * const yTrue = tf.tensor2d([[0, 1], [0, 0], [2, 3]]);
+ * const yPred = tf.tensor2d([[0, 1], [0, 1], [-2, -3]]);
+ * const mse = tf.metrics.meanAbsoluteError(yTrue, yPred);
+ * mse.print();
+ * ```
+ *
+ * @param yTrue Truth Tensor.
+ * @param yPred Prediction Tensor.
+ * @return Mean absolute error Tensor.
  */
+/** @doc {heading: 'Metrics', namespace: 'metrics'} */
 export function meanAbsoluteError(yTrue: Tensor, yPred: Tensor): Tensor {
   return losses.meanAbsoluteError(yTrue, yPred);
 }
 
 /**
- * @doc {
- *   heading: 'Metrics',
- *   namespace: 'metrics',
- *   useDocsFrom: 'meanAbsolutePercentageError'
- * }
+ * Loss or metric function: Mean absolute percentage error.
+ *
+ * ```js
+ * const yTrue = tf.tensor2d([[0, 1], [10, 20]]);
+ * const yPred = tf.tensor2d([[0, 1], [11, 24]]);
+ * const mse = tf.metrics.meanAbsolutePercentageError(yTrue, yPred);
+ * mse.print();
+ * ```
+ *
+ * Aliases: `tf.metrics.MAPE`, `tf.metrics.mape`.
+ *
+ * @param yTrue Truth Tensor.
+ * @param yPred Prediction Tensor.
+ * @return Mean absolute percentage error Tensor.
  */
+/** @doc {heading: 'Metrics', namespace: 'metrics'} */
 export function meanAbsolutePercentageError(
     yTrue: Tensor, yPred: Tensor): Tensor {
   return losses.meanAbsolutePercentageError(yTrue, yPred);
@@ -133,12 +276,22 @@ export function mape(yTrue: Tensor, yPred: Tensor): Tensor {
 }
 
 /**
- * @doc {
- *   heading: 'Metrics',
- *   namespace: 'metrics',
- *   useDocsFrom: 'meanSquaredError'
- * }
+ * Loss or metric function: Mean squared error.
+ *
+ * ```js
+ * const yTrue = tf.tensor2d([[0, 1], [3, 4]]);
+ * const yPred = tf.tensor2d([[0, 1], [-3, -4]]);
+ * const mse = tf.metrics.meanSquaredError(yTrue, yPred);
+ * mse.print();
+ * ```
+ *
+ * Aliases: `tf.metrics.MSE`, `tf.metrics.mse`.
+ *
+ * @param yTrue Truth Tensor.
+ * @param yPred Prediction Tensor.
+ * @return Mean squared error Tensor.
  */
+/** @doc {heading: 'Metrics', namespace: 'metrics'} */
 export function meanSquaredError(yTrue: Tensor, yPred: Tensor): Tensor {
   return losses.meanSquaredError(yTrue, yPred);
 }

--- a/src/exports_regularizers.ts
+++ b/src/exports_regularizers.ts
@@ -12,34 +12,36 @@ import * as regularizers from './regularizers';
 import {L1Args, L1L2, L1L2Args, L2Args, Regularizer} from './regularizers';
 
 /**
- * @doc {
- *   heading: 'Regularizers',
- *   namespace: 'regularizers',
- *   useDocsFrom: 'L1L2'
- * }
+ * Regularizer for L1 and L2 regularization.
+ *
+ * Adds a term to the loss to penalize large weights:
+ * loss += sum(l1 * abs(x)) + sum(l2 * x^2)
  */
+/** @doc {heading: 'Regularizers', namespace: 'regularizers'} */
 export function l1l2(config?: L1L2Args): Regularizer {
   return new L1L2(config);
 }
 
 /**
- * @doc {
- *   heading: 'Regularizers',
- *   namespace: 'regularizers',
- *   useDocsFrom: 'L1L2'
- * }
+ * Regularizer for L1 regularization.
+ *
+ * Adds a term to the loss to penalize large weights:
+ * loss += sum(l1 * abs(x))
+ * @param args l1 config.
  */
+/** @doc {heading: 'Regularizers', namespace: 'regularizers'} */
 export function l1(config?: L1Args): Regularizer {
   return regularizers.l1(config);
 }
 
 /**
- * @doc {
- *   heading: 'Regularizers',
- *   namespace: 'regularizers',
- *   useDocsFrom: 'L1L2'
- * }
+ * Regularizer for L2 regularization.
+ *
+ * Adds a term to the loss to penalize large weights:
+ * loss += sum(l2 * x^2)
+ * @param args l2 config.
  */
+/** @doc {heading: 'Regularizers', namespace: 'regularizers'} */
 export function l2(config?: L2Args): Regularizer {
   return regularizers.l2(config);
 }

--- a/src/initializers.ts
+++ b/src/initializers.ts
@@ -49,9 +49,6 @@ export abstract class Initializer extends serialization.Serializable {
   }
 }
 
-/**
- * Initializer that generates tensors initialized to 0.
- */
 export class Zeros extends Initializer {
   /** @nocollapse */
   static className = 'Zeros';
@@ -62,9 +59,6 @@ export class Zeros extends Initializer {
 }
 serialization.registerClass(Zeros);
 
-/**
- * Initializer that generates tensors initialized to 1.
- */
 export class Ones extends Initializer {
   /** @nocollapse */
   static className = 'Ones';
@@ -80,9 +74,6 @@ export interface ConstantArgs {
   value: number;
 }
 
-/**
- * Initializer that generates values initialized to some constant.
- */
 export class Constant extends Initializer {
   /** @nocollapse */
   static className = 'Constant';
@@ -120,13 +111,6 @@ export interface RandomUniformArgs {
   seed?: number;
 }
 
-/**
- * Initializer that generates random values initialized to a uniform
- * distribution.
- *
- * Values will be distributed uniformly between the configured minval and
- * maxval.
- */
 export class RandomUniform extends Initializer {
   /** @nocollapse */
   static className = 'RandomUniform';
@@ -162,10 +146,6 @@ export interface RandomNormalArgs {
   seed?: number;
 }
 
-/**
- * Initializer that generates random values initialized to a normal
- * distribution.
- */
 export class RandomNormal extends Initializer {
   /** @nocollapse */
   static className = 'RandomNormal';
@@ -207,14 +187,6 @@ export interface TruncatedNormalArgs {
   seed?: number;
 }
 
-/**
- * Initializer that generates random values initialized to a truncated normal.
- * distribution.
- *
- * These values are similar to values from a `RandomNormal` except that values
- * more than two standard deviations from the mean are discarded and re-drawn.
- * This is the recommended initializer for neural network weights and filters.
- */
 export class TruncatedNormal extends Initializer {
   /** @nocollapse */
   static className = 'TruncatedNormal';
@@ -254,10 +226,6 @@ export interface IdentityArgs {
   gain?: number;
 }
 
-/**
- * Initializer that generates the identity matrix.
- * Only use for square 2D matrices.
- */
 export class Identity extends Initializer {
   /** @nocollapse */
   static className = 'Identity';
@@ -334,18 +302,6 @@ export interface VarianceScalingArgs {
   seed?: number;
 }
 
-
-/**
- * Initializer capable of adapting its scale to the shape of weights.
- * With distribution=NORMAL, samples are drawn from a truncated normal
- * distribution centered on zero, with `stddev = sqrt(scale / n)` where n is:
- *   - number of input units in the weight tensor, if mode = FAN_IN.
- *   - number of output units, if mode = FAN_OUT.
- *   - average of the numbers of input and output units, if mode = FAN_AVG.
- * With distribution=UNIFORM,
- * samples are drawn from a uniform distribution
- * within [-limit, limit], with `limit = sqrt(3 * scale / n)`.
- */
 export class VarianceScaling extends Initializer {
   /** @nocollapse */
   static className = 'VarianceScaling';
@@ -416,17 +372,6 @@ export interface SeedOnlyInitializerArgs {
   seed?: number;
 }
 
-/**
- * Glorot uniform initializer, also called Xavier uniform initializer.
- * It draws samples from a uniform distribution within [-limit, limit]
- * where `limit` is `sqrt(6 / (fan_in + fan_out))`
- * where `fan_in` is the number of input units in the weight tensor
- * and `fan_out` is the number of output units in the weight tensor
- *
- * Reference:
- *   Glorot & Bengio, AISTATS 2010
- *       http://jmlr.org/proceedings/papers/v9/glorot10a/glorot10a.pdf.
- */
 export class GlorotUniform extends VarianceScaling {
   /** @nocollapse */
   static className = 'GlorotUniform';
@@ -456,17 +401,6 @@ export class GlorotUniform extends VarianceScaling {
 }
 serialization.registerClass(GlorotUniform);
 
-/**
- * Glorot normal initializer, also called Xavier normal initializer.
- * It draws samples from a truncated normal distribution centered on 0
- * with `stddev = sqrt(2 / (fan_in + fan_out))`
- * where `fan_in` is the number of input units in the weight tensor
- * and `fan_out` is the number of output units in the weight tensor.
- *
- * Reference:
- *   Glorot & Bengio, AISTATS 2010
- *       http://jmlr.org/proceedings/papers/v9/glorot10a/glorot10a.pdf
- */
 export class GlorotNormal extends VarianceScaling {
   /** @nocollapse */
   static className = 'GlorotNormal';
@@ -496,16 +430,6 @@ export class GlorotNormal extends VarianceScaling {
 }
 serialization.registerClass(GlorotNormal);
 
-/**
- * He normal initializer.
- *
- * It draws samples from a truncated normal distribution centered on 0
- * with `stddev = sqrt(2 / fanIn)`
- * where `fanIn` is the number of input units in the weight tensor.
- *
- * Reference:
- *     He et al., http://arxiv.org/abs/1502.01852
- */
 export class HeNormal extends VarianceScaling {
   /** @nocollapse */
   static className = 'HeNormal';
@@ -528,16 +452,6 @@ export class HeNormal extends VarianceScaling {
 }
 serialization.registerClass(HeNormal);
 
-/**
- * He uniform initializer.
- *
- * It draws samples from a uniform distribution within [-limit, limit]
- * where `limit` is `sqrt(6 / fan_in)`
- * where `fanIn` is the number of input units in the weight tensor.
- *
- * Reference:
- *     He et al., http://arxiv.org/abs/1502.01852
- */
 export class HeUniform extends VarianceScaling {
   /** @nocollapse */
   static className = 'HeUniform';
@@ -560,18 +474,6 @@ export class HeUniform extends VarianceScaling {
 }
 serialization.registerClass(HeUniform);
 
-
-/**
- * LeCun normal initializer.
- *
- * It draws samples from a truncated normal distribution centered on 0
- * with `stddev = sqrt(1 / fanIn)`
- * where `fanIn` is the number of input units in the weight tensor.
- *
- * References:
- *   [Self-Normalizing Neural Networks](https://arxiv.org/abs/1706.02515)
- *   [Efficient Backprop](http://yann.lecun.com/exdb/publis/pdf/lecun-98b.pdf)
- */
 export class LeCunNormal extends VarianceScaling {
   /** @nocollapse */
   static className = 'LeCunNormal';
@@ -594,13 +496,6 @@ export class LeCunNormal extends VarianceScaling {
 }
 serialization.registerClass(LeCunNormal);
 
-/**
- * LeCun uniform initializer.
- *
- * It draws samples from a uniform distribution in the interval
- * `[-limit, limit]` with `limit = sqrt(3 / fanIn)`,
- * where `fanIn` is the number of input units in the weight tensor.
- */
 export class LeCunUniform extends VarianceScaling {
   /** @nocollapse */
   static className = 'LeCunNormal';
@@ -630,12 +525,6 @@ export interface OrthogonalArgs extends SeedOnlyInitializerArgs {
   gain?: number;
 }
 
-/**
- * Initializer that generates a random orthogonal matrix.
- *
- * Reference:
- * [Saxe et al., http://arxiv.org/abs/1312.6120](http://arxiv.org/abs/1312.6120)
- */
 export class Orthogonal extends Initializer {
   /** @nocollapse */
   static className = 'Orthogonal';

--- a/src/layers/advanced_activations.ts
+++ b/src/layers/advanced_activations.ts
@@ -33,17 +33,6 @@ export declare interface ReLULayerArgs extends LayerArgs {
   maxValue?: number;
 }
 
-/**
- * Rectified Linear Unit activation function.
- *
- * Input shape:
- *   Arbitrary. Use the config field `inputShape` (Array of integers, does
- *   not include the sample axis) when using this layer as the first layer
- *   in a model.
- *
- * Output shape:
- *   Same shape as the input.
- */
 export class ReLU extends Layer {
   /** @nocollapse */
   static className = 'ReLU';
@@ -86,20 +75,6 @@ export declare interface LeakyReLULayerArgs extends LayerArgs {
   alpha?: number;
 }
 
-/**
- * Leaky version of a rectified linear unit.
- *
- * It allows a small gradient when the unit is not active:
- * `f(x) = alpha * x for x < 0.`
- * `f(x) = x for x >= 0.`
- *
- * Input shape:
- *   Arbitrary. Use the configuration `inputShape` when using this layer as the
- *   first layer in a model.
- *
- * Output shape:
- *   Same shape as the input.
- */
 export class LeakyReLU extends Layer {
   /** @nocollapse */
   static className = 'LeakyReLU';
@@ -160,21 +135,6 @@ export declare interface PReLULayerArgs extends LayerArgs {
   sharedAxes?: number|number[];
 }
 
-/**
- * Parameterized version of a leaky rectified linear unit.
- *
- * It follows
- * `f(x) = alpha * x for x < 0.`
- * `f(x) = x for x >= 0.`
- * wherein `alpha` is a trainable weight.
- *
- * Input shape:
- *   Arbitrary. Use the configuration `inputShape` when using this layer as the
- *   first layer in a model.
- *
- * Output shape:
- *   Same shape as the input.
- */
 export class PReLU extends Layer {
   /** @nocollapse */
   static className = 'PReLU';
@@ -261,24 +221,6 @@ export declare interface ELULayerArgs extends LayerArgs {
   alpha?: number;
 }
 
-/**
- * Exponetial Linear Unit (ELU).
- *
- * It follows:
- * `f(x) =  alpha * (exp(x) - 1.) for x < 0`,
- * `f(x) = x for x >= 0`.
- *
- * Input shape:
- *   Arbitrary. Use the configuration `inputShape` when using this layer as the
- *   first layer in a model.
- *
- * Output shape:
- *   Same shape as the input.
- *
- * References:
- *   - [Fast and Accurate Deep Network Learning by Exponential Linear Units
- * (ELUs)](https://arxiv.org/abs/1511.07289v1)
- */
 export class ELU extends Layer {
   /** @nocollapse */
   static className = 'ELU';
@@ -326,24 +268,6 @@ export declare interface ThresholdedReLULayerArgs extends LayerArgs {
   theta?: number;
 }
 
-/**
- * Thresholded Rectified Linear Unit.
- *
- * It follows:
- * `f(x) = x for x > theta`,
- * `f(x) = 0 otherwise`.
- *
- * Input shape:
- *   Arbitrary. Use the configuration `inputShape` when using this layer as the
- *   first layer in a model.
- *
- * Output shape:
- *   Same shape as the input.
- *
- * References:
- *   - [Zero-Bias Autoencoders and the Benefits of Co-Adapting
- * Features](http://arxiv.org/abs/1402.3337)
- */
 export class ThresholdedReLU extends Layer {
   /** @nocollapse */
   static className = 'ThresholdedReLU';
@@ -386,16 +310,6 @@ export declare interface SoftmaxLayerArgs extends LayerArgs {
   axis?: number;
 }
 
-/**
- * Softmax activation layer.
- *
- * Input shape:
- *   Arbitrary. Use the configuration `inputShape` when using this layer as the
- *   first layer in a model.
- *
- * Output shape:
- *   Same shape as the input.
- */
 export class Softmax extends Layer {
   /** @nocollapse */
   static className = 'Softmax';

--- a/src/layers/convolutional.ts
+++ b/src/layers/convolutional.ts
@@ -634,23 +634,6 @@ export abstract class Conv extends BaseConv {
   }
 }
 
-
-/**
- * 2D convolution layer (e.g. spatial convolution over images).
- *
- * This layer creates a convolution kernel that is convolved
- * with the layer input to produce a tensor of outputs.
- *
- * If `useBias` is True, a bias vector is created and added to the outputs.
- *
- * If `activation` is not `null`, it is applied to the outputs as well.
- *
- * When using this layer as the first layer in a model,
- * provide the keyword argument `inputShape`
- * (Array of integers, does not include the sample axis),
- * e.g. `inputShape=[128, 128, 3]` for 128x128 RGB pictures
- * in `dataFormat='channelsLast'`.
- */
 export class Conv2D extends Conv {
   /** @nocollapse */
   static className = 'Conv2D';
@@ -676,22 +659,6 @@ export class Conv2D extends Conv {
 }
 serialization.registerClass(Conv2D);
 
-/**
- * 3D convolution layer (e.g. spatial convolution over volumes).
- *
- * This layer creates a convolution kernel that is convolved
- * with the layer input to produce a tensor of outputs.
- *
- * If `useBias` is True, a bias vector is created and added to the outputs.
- *
- * If `activation` is not `null`, it is applied to the outputs as well.
- *
- * When using this layer as the first layer in a model,
- * provide the keyword argument `inputShape`
- * (Array of integers, does not include the sample axis),
- * e.g. `inputShape=[128, 128, 128, 1]` for 128x128x128 grayscale volumes
- * in `dataFormat='channelsLast'`.
- */
 export class Conv3D extends Conv {
   /** @nocollapse */
   static className = 'Conv3D';
@@ -720,39 +687,6 @@ export class Conv3D extends Conv {
 }
 serialization.registerClass(Conv3D);
 
-/**
- * Transposed convolutional layer (sometimes called Deconvolution).
- *
- * The need for transposed convolutions generally arises
- * from the desire to use a transformation going in the opposite direction of
- * a normal convolution, i.e., from something that has the shape of the output
- * of some convolution to something that has the shape of its input while
- * maintaining a connectivity pattern that is compatible with said
- * convolution.
- *
- * When using this layer as the first layer in a model, provide the
- * configuration `inputShape` (`Array` of integers, does not include the
- * sample axis), e.g., `inputShape: [128, 128, 3]` for 128x128 RGB pictures in
- * `dataFormat: 'channelsLast'`.
- *
- * Input shape:
- *   4D tensor with shape:
- *   `[batch, channels, rows, cols]` if `dataFormat` is `'channelsFirst'`.
- *   or 4D tensor with shape
- *   `[batch, rows, cols, channels]` if `dataFormat` is `'channelsLast`.
- *
- * Output shape:
- *   4D tensor with shape:
- *   `[batch, filters, newRows, newCols]` if `dataFormat` is
- * `'channelsFirst'`. or 4D tensor with shape:
- *   `[batch, newRows, newCols, filters]` if `dataFormat` is `'channelsLast'`.
- *
- * References:
- *   - [A guide to convolution arithmetic for deep
- * learning](https://arxiv.org/abs/1603.07285v1)
- *   - [Deconvolutional
- * Networks](http://www.matthewzeiler.com/pubs/cvpr2010/cvpr2010.pdf)
- */
 export class Conv2DTranspose extends Conv2D {
   /** @nocollapse */
   static className = 'Conv2DTranspose';
@@ -1102,33 +1036,6 @@ export class SeparableConv extends Conv {
   }
 }
 
-/**
- * Depthwise separable 2D convolution.
- *
- * Separable convolution consists of first performing
- * a depthwise spatial convolution
- * (which acts on each input channel separately)
- * followed by a pointwise convolution which mixes together the resulting
- * output channels. The `depthMultiplier` argument controls how many
- * output channels are generated per input channel in the depthwise step.
- *
- * Intuitively, separable convolutions can be understood as
- * a way to factorize a convolution kernel into two smaller kernels,
- * or as an extreme version of an Inception block.
- *
- * Input shape:
- *   4D tensor with shape:
- *     `[batch, channels, rows, cols]` if data_format='channelsFirst'
- *   or 4D tensor with shape:
- *     `[batch, rows, cols, channels]` if data_format='channelsLast'.
- *
- * Output shape:
- *   4D tensor with shape:
- *     `[batch, filters, newRows, newCols]` if data_format='channelsFirst'
- *   or 4D tensor with shape:
- *     `[batch, newRows, newCols, filters]` if data_format='channelsLast'.
- *     `rows` and `cols` values might have changed due to padding.
- */
 export class SeparableConv2D extends SeparableConv {
   /** @nocollapse */
   static className = 'SeparableConv2D';
@@ -1138,24 +1045,6 @@ export class SeparableConv2D extends SeparableConv {
 }
 serialization.registerClass(SeparableConv2D);
 
-/**
- * 1D convolution layer (e.g., temporal convolution).
- *
- * This layer creates a convolution kernel that is convolved
- * with the layer input over a single spatial (or temporal) dimension
- * to produce a tensor of outputs.
- *
- * If `use_bias` is True, a bias vector is created and added to the outputs.
- *
- * If `activation` is not `null`, it is applied to the outputs as well.
- *
- * When using this layer as the first layer in a model, provide an
- * `inputShape` argument `Array` or `null`.
- *
- * For example, `inputShape` would be:
- * - `[10, 128]` for sequences of 10 vectors of 128-dimensional vectors
- * - `[null, 128]` for variable-length sequences of 128-dimensional vectors.
- */
 export class Conv1D extends Conv {
   /** @nocollapse */
   static className = 'Conv1D';
@@ -1213,35 +1102,6 @@ export declare interface Cropping2DLayerArgs extends LayerArgs {
   dataFormat?: DataFormat;
 }
 
-/**
- * Cropping layer for 2D input (e.g., image).
- *
- * This layer can crop an input
- * at the top, bottom, left and right side of an image tensor.
- *
- * Input shape:
- *   4D tensor with shape:
- *   - If `dataFormat` is `"channelsLast"`:
- *     `[batch, rows, cols, channels]`
- *   - If `data_format` is `"channels_first"`:
- *     `[batch, channels, rows, cols]`.
- *
- * Output shape:
- *   4D with shape:
- *   - If `dataFormat` is `"channelsLast"`:
- *     `[batch, croppedRows, croppedCols, channels]`
- *    - If `dataFormat` is `"channelsFirst"`:
- *     `[batch, channels, croppedRows, croppedCols]`.
- *
- * Examples
- * ```js
- *
- * const model = tf.sequential();
- * model.add(tf.layers.cropping2D({cropping:[[2, 2], [2, 2]],
- *                                inputShape: [128, 128, 3]}));
- * //now output shape is [batch, 124, 124, 3]
- * ```
- */
 export class Cropping2D extends Layer {
   /** @nocollapse */
   static className = 'Cropping2D';
@@ -1333,28 +1193,6 @@ export declare interface UpSampling2DLayerArgs extends LayerArgs {
   dataFormat?: DataFormat;
 }
 
-/**
- * Upsampling layer for 2D inputs.
- *
- * Repeats the rows and columns of the data
- * by size[0] and size[1] respectively.
- *
- *
- * Input shape:
- *    4D tensor with shape:
- *     - If `dataFormat` is `"channelsLast"`:
- *         `[batch, rows, cols, channels]`
- *     - If `dataFormat` is `"channelsFirst"`:
- *        `[batch, channels, rows, cols]`
- *
- * Output shape:
- *     4D tensor with shape:
- *     - If `dataFormat` is `"channelsLast"`:
- *        `[batch, upsampledRows, upsampledCols, channels]`
- *     - If `dataFormat` is `"channelsFirst"`:
- *         `[batch, channels, upsampledRows, upsampledCols]`
- *
- */
 export class UpSampling2D extends Layer {
   /** @nocollapse */
   static className = 'UpSampling2D';

--- a/src/layers/convolutional_depthwise.ts
+++ b/src/layers/convolutional_depthwise.ts
@@ -107,14 +107,6 @@ export declare interface DepthwiseConv2DLayerArgs extends BaseConvLayerArgs {
   depthwiseRegularizer?: RegularizerIdentifier|Regularizer;
 }
 
-/**
- * Depthwise separable 2D convolution.
- *
- * Depthwise Separable convolutions consists in performing just the first step
- * in a depthwise spatial convolution (which acts on each input channel
- * separately). The `depthMultplier` argument controls how many output channels
- * are generated per input channel in the depthwise step.
- */
 export class DepthwiseConv2D extends BaseConv {
   /** @nocollapse */
   static className = 'DepthwiseConv2D';

--- a/src/layers/core.ts
+++ b/src/layers/core.ts
@@ -12,7 +12,7 @@
  * TensorFlow.js Layers: Basic Layers.
  */
 
-import {fused, serialization, Tensor, tidy, transpose, util, notEqual, any} from '@tensorflow/tfjs-core';
+import {any, fused, notEqual, serialization, Tensor, tidy, transpose, util} from '@tensorflow/tfjs-core';
 
 import {Activation as ActivationFn, getActivation, serializeActivation} from '../activations';
 import * as K from '../backend/tfjs_backend';
@@ -56,14 +56,6 @@ export declare interface DropoutLayerArgs extends LayerArgs {
   seed?: number;
 }
 
-/**
- * Applies
- * [dropout](http://www.cs.toronto.edu/~rsalakhu/papers/srivastava14a.pdf) to
- * the input.
- *
- * Dropout consists in randomly setting a fraction `rate` of input units to 0 at
- * each update during training time, which helps prevent overfitting.
- */
 export class Dropout extends Layer {
   /** @nocollapse */
   static className = 'Dropout';
@@ -79,8 +71,8 @@ export class Dropout extends Layer {
     this.seed = args.seed;
     if (this.seed != null) {
       throw new NotImplementedError(
-        'Non-default seed is not implemented in Dropout layer yet: ' +
-        this.seed);
+          'Non-default seed is not implemented in Dropout layer yet: ' +
+          this.seed);
     }
     this.supportsMasking = true;
   }
@@ -93,29 +85,29 @@ export class Dropout extends Layer {
     const noiseShape: Shape = [];
     for (let i = 0; i < this.noiseShape.length; ++i) {
       noiseShape.push(
-        this.noiseShape[i] == null ? inputShape[i] : this.noiseShape[i]);
+          this.noiseShape[i] == null ? inputShape[i] : this.noiseShape[i]);
     }
     return noiseShape;
   }
 
-  call(inputs: Tensor | Tensor[], kwargs: Kwargs): Tensor | Tensor[] {
+  call(inputs: Tensor|Tensor[], kwargs: Kwargs): Tensor|Tensor[] {
     return tidy(() => {
       this.invokeCallHook(inputs, kwargs);
       const input = getExactlyOneTensor(inputs);
       if (this.noiseShape != null &&
-        !util.arraysEqual(input.shape, this.noiseShape)) {
+          !util.arraysEqual(input.shape, this.noiseShape)) {
         throw new NotImplementedError(
-          'Non-default noise shape is not implemented in Dropout ' +
-          'layer yet: ' + JSON.stringify(this.noiseShape));
+            'Non-default noise shape is not implemented in Dropout ' +
+            'layer yet: ' + JSON.stringify(this.noiseShape));
       }
       if (0 < this.rate && this.rate < 1) {
         const training =
-          kwargs['training'] == null ? false : kwargs['training'];
+            kwargs['training'] == null ? false : kwargs['training'];
         const noiseShape = this.getNoiseShape(input);
         const output =
-          K.inTrainPhase(
-            () => K.dropout(input, this.rate, noiseShape, this.seed),
-            () => input, training) as Tensor;
+            K.inTrainPhase(
+                () => K.dropout(input, this.rate, noiseShape, this.seed),
+                () => input, training) as Tensor;
         return output;
       }
       return inputs;
@@ -153,11 +145,11 @@ export declare interface DenseLayerArgs extends LayerArgs {
   /**
    * Initializer for the dense kernel weights matrix.
    */
-  kernelInitializer?: InitializerIdentifier | Initializer;
+  kernelInitializer?: InitializerIdentifier|Initializer;
   /**
    * Initializer for the bias vector.
    */
-  biasInitializer?: InitializerIdentifier | Initializer;
+  biasInitializer?: InitializerIdentifier|Initializer;
   /**
    * If specified, defines inputShape as `[inputDim]`.
    */
@@ -166,60 +158,29 @@ export declare interface DenseLayerArgs extends LayerArgs {
   /**
    * Constraint for the kernel weights.
    */
-  kernelConstraint?: ConstraintIdentifier | Constraint;
+  kernelConstraint?: ConstraintIdentifier|Constraint;
 
   /**
    * Constraint for the bias vector.
    */
-  biasConstraint?: ConstraintIdentifier | Constraint;
+  biasConstraint?: ConstraintIdentifier|Constraint;
 
   /**
    * Regularizer function applied to the dense kernel weights matrix.
    */
-  kernelRegularizer?: RegularizerIdentifier | Regularizer;
+  kernelRegularizer?: RegularizerIdentifier|Regularizer;
 
   /**
    * Regularizer function applied to the bias vector.
    */
-  biasRegularizer?: RegularizerIdentifier | Regularizer;
+  biasRegularizer?: RegularizerIdentifier|Regularizer;
 
   /**
    * Regularizer function applied to the activation.
    */
-  activityRegularizer?: RegularizerIdentifier | Regularizer;
+  activityRegularizer?: RegularizerIdentifier|Regularizer;
 }
 
-/**
- * Creates a dense (fully connected) layer.
- *
- * This layer implements the operation:
- *   `output = activation(dot(input, kernel) + bias)`
- *
- * `activation` is the element-wise activation function
- *   passed as the `activation` argument.
- *
- * `kernel` is a weights matrix created by the layer.
- *
- * `bias` is a bias vector created by the layer (only applicable if `useBias`
- * is `true`).
- *
- * **Input shape:**
- *
- *   nD `tf.Tensor` with shape: `(batchSize, ..., inputDim)`.
- *
- *   The most common situation would be
- *   a 2D input with shape `(batchSize, inputDim)`.
- *
- * **Output shape:**
- *
- *   nD tensor with shape: `(batchSize, ..., units)`.
- *
- *   For instance, for a 2D input with shape `(batchSize, inputDim)`,
- *   the output would have shape `(batchSize, units)`.
- *
- * Note: if the input to the layer has a rank greater than 2, then it is
- * flattened prior to the initial dot product with the kernel.
- */
 export class Dense extends Layer {
   /** @nocollapse */
   static className = 'Dense';
@@ -242,7 +203,7 @@ export class Dense extends Layer {
   constructor(args: DenseLayerArgs) {
     super(args);
     if (args.batchInputShape == null && args.inputShape == null &&
-      args.inputDim != null) {
+        args.inputDim != null) {
       // This logic is copied from Layer's constructor, since we can't
       // do exactly what the Python constructor does for Dense().
       let batchSize: number = null;
@@ -259,9 +220,9 @@ export class Dense extends Layer {
       this.useBias = args.useBias;
     }
     this.kernelInitializer = getInitializer(
-      args.kernelInitializer || this.DEFAULT_KERNEL_INITIALIZER);
+        args.kernelInitializer || this.DEFAULT_KERNEL_INITIALIZER);
     this.biasInitializer =
-      getInitializer(args.biasInitializer || this.DEFAULT_BIAS_INITIALIZER);
+        getInitializer(args.biasInitializer || this.DEFAULT_BIAS_INITIALIZER);
     this.kernelConstraint = getConstraint(args.kernelConstraint);
     this.biasConstraint = getConstraint(args.biasConstraint);
     this.kernelRegularizer = getRegularizer(args.kernelRegularizer);
@@ -272,17 +233,17 @@ export class Dense extends Layer {
     this.inputSpec = [{minNDim: 2}];
   }
 
-  public build(inputShape: Shape | Shape[]): void {
+  public build(inputShape: Shape|Shape[]): void {
     inputShape = getExactlyOneShape(inputShape);
     const inputLastDim = inputShape[inputShape.length - 1];
     if (this.kernel == null) {
       this.kernel = this.addWeight(
-        'kernel', [inputLastDim, this.units], null, this.kernelInitializer,
-        this.kernelRegularizer, true, this.kernelConstraint);
+          'kernel', [inputLastDim, this.units], null, this.kernelInitializer,
+          this.kernelRegularizer, true, this.kernelConstraint);
       if (this.useBias) {
         this.bias = this.addWeight(
-          'bias', [this.units], null, this.biasInitializer,
-          this.biasRegularizer, true, this.biasConstraint);
+            'bias', [this.units], null, this.biasInitializer,
+            this.biasRegularizer, true, this.biasConstraint);
       }
     }
 
@@ -290,26 +251,26 @@ export class Dense extends Layer {
     this.built = true;
   }
 
-  computeOutputShape(inputShape: Shape | Shape[]): Shape | Shape[] {
+  computeOutputShape(inputShape: Shape|Shape[]): Shape|Shape[] {
     inputShape = getExactlyOneShape(inputShape);
     const outputShape = inputShape.slice();
     outputShape[outputShape.length - 1] = this.units;
     return outputShape;
   }
 
-  call(inputs: Tensor | Tensor[], kwargs: Kwargs): Tensor | Tensor[] {
+  call(inputs: Tensor|Tensor[], kwargs: Kwargs): Tensor|Tensor[] {
     return tidy(() => {
       this.invokeCallHook(inputs, kwargs);
       // Dense layer accepts only a single input.
       const input = getExactlyOneTensor(inputs);
       const fusedActivationName =
-        mapActivationToFusedKernel(this.activation.getClassName());
+          mapActivationToFusedKernel(this.activation.getClassName());
       let output: Tensor;
 
       if (fusedActivationName != null) {
         output = K.dot(
-          input, this.kernel.read(), fusedActivationName,
-          this.bias ? this.bias.read() : null);
+            input, this.kernel.read(), fusedActivationName,
+            this.bias ? this.bias.read() : null);
       } else {
         output = K.dot(input, this.kernel.read());
         if (this.bias != null) {
@@ -344,23 +305,6 @@ export class Dense extends Layer {
 }
 serialization.registerClass(Dense);
 
-/**
- * Flattens the input. Does not affect the batch size.
- *
- * A `Flatten` layer flattens each batch in its inputs to 1D (making the output
- * 2D).
- *
- * For example:
- *
- * ```js
- * const input = tf.input({shape: [4, 3]});
- * const flattenLayer = tf.layers.flatten();
- * // Inspect the inferred output shape of the flatten layer, which
- * // equals `[null, 12]`. The 2nd dimension is 4 * 3, i.e., the result of the
- * // flattening. (The 1st dimension is the undermined batch size.)
- * console.log(JSON.stringify(flattenLayer.apply(input).shape));
- * ```
- */
 export class Flatten extends Layer {
   /** @nocollapse */
   static className = 'Flatten';
@@ -369,21 +313,21 @@ export class Flatten extends Layer {
     this.inputSpec = [{minNDim: 3}];
   }
 
-  computeOutputShape(inputShape: Shape | Shape[]): Shape | Shape[] {
+  computeOutputShape(inputShape: Shape|Shape[]): Shape|Shape[] {
     inputShape = getExactlyOneShape(inputShape);
     for (const dim of inputShape.slice(1)) {
       if (dim == null) {
         throw new ValueError(
-          `The shape of the input to "Flatten" is not fully defined ` +
-          `(got ${inputShape.slice(1)}). Make sure to pass a complete ` +
-          `"input_shape" or "batch_input_shape" argument to the first ` +
-          `layer in your model.`);
+            `The shape of the input to "Flatten" is not fully defined ` +
+            `(got ${inputShape.slice(1)}). Make sure to pass a complete ` +
+            `"input_shape" or "batch_input_shape" argument to the first ` +
+            `layer in your model.`);
       }
     }
     return [inputShape[0], arrayProd(inputShape, 1)];
   }
 
-  call(inputs: Tensor | Tensor[], kwargs: Kwargs): Tensor | Tensor[] {
+  call(inputs: Tensor|Tensor[], kwargs: Kwargs): Tensor|Tensor[] {
     return tidy(() => {
       this.invokeCallHook(inputs, kwargs);
       return K.batchFlatten(getExactlyOneTensor(inputs));
@@ -399,36 +343,6 @@ export declare interface ActivationLayerArgs extends LayerArgs {
   activation: ActivationIdentifier;
 }
 
-/**
- * Applies an activation function to an output.
- *
- * This layer applies element-wise activation function.  Other layers, notably
- * `dense` can also apply activation functions.  Use this isolated activation
- * function to extract the values before and after the
- * activation. For instance:
- *
- * ```js
- * const input = tf.input({shape: [5]});
- * const denseLayer = tf.layers.dense({units: 1});
- * const activationLayer = tf.layers.activation({activation: 'relu6'});
- *
- * // Obtain the output symbolic tensors by applying the layers in order.
- * const denseOutput = denseLayer.apply(input);
- * const activationOutput = activationLayer.apply(denseOutput);
- *
- * // Create the model based on the inputs.
- * const model = tf.LayersModel({
- *     inputs: input,
- *     outputs: [denseOutput, activationOutput]
- * });
- *
- * // Collect both outputs and print separately.
- * const [denseOut, activationOut] = model.predict(tf.randomNormal([6, 5]));
- * denseOut.print();
- * activationOut.print();
- * ```
- *
- */
 export class Activation extends Layer {
   /** @nocollapse */
   static className = 'Activation';
@@ -440,7 +354,7 @@ export class Activation extends Layer {
     this.activation = getActivation(args.activation);
   }
 
-  call(inputs: Tensor | Tensor[], kwargs: Kwargs): Tensor | Tensor[] {
+  call(inputs: Tensor|Tensor[], kwargs: Kwargs): Tensor|Tensor[] {
     return tidy(() => {
       this.invokeCallHook(inputs, kwargs);
       const input = getExactlyOneTensor(inputs);
@@ -469,18 +383,6 @@ export declare interface RepeatVectorLayerArgs extends LayerArgs {
   n: number;
 }
 
-/**
- * Repeats the input n times in a new dimension.
- *
- * ```js
- *  const model = tf.sequential();
- *  model.add(tf.layers.repeatVector({n: 4, inputShape: [2]}));
- *  const x = tf.tensor2d([[10, 20]]);
- *  // Use the model to do inference on a data point the model hasn't see
- *  model.predict(x).print();
- *  // output shape is now [batch, 2, 4]
- * ```
- */
 export class RepeatVector extends Layer {
   /** @nocollapse */
   static className = 'RepeatVector';
@@ -496,7 +398,7 @@ export class RepeatVector extends Layer {
     return [inputShape[0], this.n, inputShape[1]];
   }
 
-  call(inputs: Tensor | Tensor[], kwargs: Kwargs): Tensor | Tensor[] {
+  call(inputs: Tensor|Tensor[], kwargs: Kwargs): Tensor|Tensor[] {
     return tidy(() => {
       inputs = getExactlyOneTensor(inputs);
       return K.repeat(inputs, this.n);
@@ -514,26 +416,6 @@ export class RepeatVector extends Layer {
 }
 serialization.registerClass(RepeatVector);
 
-/**
- * Reshapes an input to a certain shape.
- *
- * ```js
- * const input = tf.input({shape: [4, 3]});
- * const reshapeLayer = tf.layers.reshape({targetShape: [2, 6]});
- * // Inspect the inferred output shape of the Reshape layer, which
- * // equals `[null, 2, 6]`. (The 1st dimension is the undermined batch size.)
- * console.log(JSON.stringify(reshapeLayer.apply(input).shape));
- * ```
- *
- * Input shape:
- *   Arbitrary: although all dimensions in the input shape must be fixed.
- *     Use the ReshapeLayerConfig field `input_shape` when using this layer
- *     as the first layer in a model.
- *
- * Output shape:
- *   [batchSize, targetShape[0], targetShape[1], ...,
- *    targetShape[targetShape.length - 1]].
- */
 export class Reshape extends Layer {
   /** @nocollapse */
   static className = 'Reshape';
@@ -613,17 +495,17 @@ export class Reshape extends Layer {
       return inputShape.slice(0, 1).concat(this.targetShape);
     } else {
       return inputShape.slice(0, 1).concat(
-        this.fixUnknownDimension(inputShape.slice(1), this.targetShape));
+          this.fixUnknownDimension(inputShape.slice(1), this.targetShape));
     }
   }
 
-  call(inputs: Tensor | Tensor[], kwargs: Kwargs): Tensor | Tensor[] {
+  call(inputs: Tensor|Tensor[], kwargs: Kwargs): Tensor|Tensor[] {
     return tidy(() => {
       this.invokeCallHook(inputs, kwargs);
       const input = getExactlyOneTensor(inputs);
       const inputShape = input.shape;
       const outputShape = inputShape.slice(0, 1).concat(
-        this.fixUnknownDimension(inputShape.slice(1), this.targetShape));
+          this.fixUnknownDimension(inputShape.slice(1), this.targetShape));
       return input.reshape(outputShape);
     });
   }
@@ -649,32 +531,6 @@ export declare interface PermuteLayerArgs extends LayerArgs {
   dims: number[];
 }
 
-/**
- * Permutes the dimensions of the input according to a given pattern.
- *
- * Useful for, e.g., connecting RNNs and convnets together.
- *
- * Example:
- *
- * ```js
- * const model = tf.Sequential();
- * model.add(tf.layers.permute({
- *   dims: [2, 1],
- *   inputShape: [10, 64]
- * }));
- * console.log(model.outputShape);
- * // Now model's output shape is [null, 64, 10], where null is the
- * // unpermuted sample (batch) dimension.
- * ```
- *
- * Input shape:
- *   Arbitrary. Use the configuration field `inputShape` when using this
- *   layer as othe first layer in a model.
- *
- * Output shape:
- *   Same rank as the input shape, but with the dimensions re-ordered (i.e.,
- *   permuted) according to the `dims` configuration of this layer.
- */
 export class Permute extends Layer {
   /** @nocollapse */
   static className = 'Permute';
@@ -685,21 +541,21 @@ export class Permute extends Layer {
     super(args);
     if (args.dims == null) {
       throw new Error(
-        'Required configuration field `dims` is missing during Permute ' +
-        'constructor call.');
+          'Required configuration field `dims` is missing during Permute ' +
+          'constructor call.');
     }
     if (!Array.isArray(args.dims)) {
       throw new Error(
-        'Permute constructor requires `dims` to be an Array, but received ' +
-        `${args.dims} instead.`);
+          'Permute constructor requires `dims` to be an Array, but received ' +
+          `${args.dims} instead.`);
     }
 
     // Check the validity of the permutation indices.
     const expectedSortedIndices = range(1, args.dims.length + 1);
     if (!util.arraysEqual(args.dims.slice().sort(), expectedSortedIndices)) {
       throw new Error(
-        'Invalid permutation `dims`: ' + JSON.stringify(args.dims) +
-        ' `dims` must contain consecutive integers starting from 1.');
+          'Invalid permutation `dims`: ' + JSON.stringify(args.dims) +
+          ' `dims` must contain consecutive integers starting from 1.');
     }
 
     this.dims = args.dims;
@@ -707,7 +563,7 @@ export class Permute extends Layer {
     this.inputSpec = [new InputSpec({ndim: this.dims.length + 1})];
   }
 
-  computeOutputShape(inputShape: Shape | Shape[]): Shape | Shape[] {
+  computeOutputShape(inputShape: Shape|Shape[]): Shape|Shape[] {
     inputShape = getExactlyOneShape(inputShape);
     const outputShape = inputShape.slice();
     this.dims.forEach((dim: number, i: number) => {
@@ -716,7 +572,7 @@ export class Permute extends Layer {
     return outputShape;
   }
 
-  call(inputs: Tensor | Tensor[], kwargs: Kwargs): Tensor | Tensor[] {
+  call(inputs: Tensor|Tensor[], kwargs: Kwargs): Tensor|Tensor[] {
     return transpose(getExactlyOneTensor(inputs), this.dimsIncludingBatch);
   }
 
@@ -738,29 +594,7 @@ export declare interface MaskingArgs extends LayerArgs {
   maskValue?: number;
 }
 
-/**
- * Masks a sequence by using a mask value to skip timesteps.
- *
- * If all features for a given sample timestep are equal to `mask_value`,
- * then the sample timestep will be masked (skipped) in all downstream layers
- * (as long as they support masking).
- *
- * If any downstream layer does not support masking yet receives such
- * an input mask, an exception will be raised.
- *
- * # Arguments
- *     maskValue: Either None or mask value to skip.
- *
- * # Input shape
- *     Arbitrary. Use the keyword argument `input_shape`
- *     (tuple of integers, does not include the samples axis)
- *     when using this layer as the first layer in a model.
- *
- * # Output shape
- *     Same shape as input.
- */
 export class Masking extends Layer {
-
   static className = 'Masking';
   maskValue: number;
 
@@ -774,7 +608,7 @@ export class Masking extends Layer {
     }
   }
 
-  computeOutputShape(inputShape: Shape | Shape[]): Shape | Shape[] {
+  computeOutputShape(inputShape: Shape|Shape[]): Shape|Shape[] {
     return inputShape;
   }
 
@@ -791,7 +625,7 @@ export class Masking extends Layer {
     return any(notEqual(input, this.maskValue), axis);
   }
 
-  call(inputs: Tensor | Tensor[], kwargs: Kwargs): Tensor | Tensor[] {
+  call(inputs: Tensor|Tensor[], kwargs: Kwargs): Tensor|Tensor[] {
     return tidy(() => {
       this.invokeCallHook(inputs, kwargs);
       const input = getExactlyOneTensor(inputs);

--- a/src/layers/embeddings.ts
+++ b/src/layers/embeddings.ts
@@ -74,15 +74,6 @@ export declare interface EmbeddingLayerArgs extends LayerArgs {
   inputLength?: number|number[];
 }
 
-/**
- * Maps positive integers (indices) into dense vectors of fixed size.
- * eg. [[4], [20]] -> [[0.25, 0.1], [0.6, -0.2]]
- *
- * **Input shape:** 2D tensor with shape: `[batchSize, sequenceLength]`.
- *
- * **Output shape:** 3D tensor with shape: `[batchSize, sequenceLength,
- * outputDim]`.
- */
 export class Embedding extends Layer {
   /** @nocollapse */
   static className = 'Embedding';

--- a/src/layers/merge.ts
+++ b/src/layers/merge.ts
@@ -257,24 +257,6 @@ export abstract class Merge extends Layer {
   }
 }
 
-/**
- * Layer that performs element-wise addition on an `Array` of inputs.
- *
- * It takes as input a list of tensors, all of the same shape, and returns a
- * single tensor (also of the same shape). The inputs are specified as an
- * `Array` when the `apply` method of the `Add` layer instance is called. For
- * example:
- *
- * ```js
- * const input1 = tf.input({shape: [2, 2]});
- * const input2 = tf.input({shape: [2, 2]});
- * const addLayer = tf.layers.add();
- * const sum = addLayer.apply([input1, input2]);
- * console.log(JSON.stringify(sum.shape));
- * // You get [null, 2, 2], with the first dimension as the undetermined batch
- * // dimension.
- * ```
- */
 export class Add extends Merge {
   /** @nocollapse */
   static className = 'Add';
@@ -352,23 +334,6 @@ export function add(config?: SymbolicTensor[]|Tensor[]|LayerArgs): Layer|
   }
 }
 
-/**
- * Layer that multiplies (element-wise) an `Array` of inputs.
- *
- * It takes as input an Array of tensors, all of the same
- * shape, and returns a single tensor (also of the same shape).
- * For example:
- *
- * ```js
- * const input1 = tf.input({shape: [2, 2]});
- * const input2 = tf.input({shape: [2, 2]});
- * const input3 = tf.input({shape: [2, 2]});
- * const multiplyLayer = tf.layers.multiply();
- * const product = multiplyLayer.apply([input1, input2, input3]);
- * console.log(product.shape);
- * // You get [null, 2, 2], with the first dimension as the undetermined batch
- * // dimension.
- */
 export class Multiply extends Merge {
   /** @nocollapse */
   static className = 'Multiply';
@@ -446,22 +411,6 @@ export function multiply(config?: SymbolicTensor[]|Tensor[]|LayerArgs): Layer|
   }
 }
 
-/**
- * Layer that performs element-wise averaging on an `Array` of inputs.
- *
- * It takes as input a list of tensors, all of the same shape, and returns a
- * single tensor (also of the same shape). For example:
- *
- * ```js
- * const input1 = tf.input({shape: [2, 2]});
- * const input2 = tf.input({shape: [2, 2]});
- * const averageLayer = tf.layers.average();
- * const average = averageLayer.apply([input1, input2]);
- * console.log(JSON.stringify(average.shape));
- * // You get [null, 2, 2], with the first dimension as the undetermined batch
- * // dimension.
- * ```
- */
 export class Average extends Merge {
   /** @nocollapse */
   static className = 'Average';
@@ -540,22 +489,6 @@ export function average(config?: SymbolicTensor[]|Tensor[]|LayerArgs): Layer|
   }
 }
 
-/**
- * Layer that computes the element-wise maximum an `Array` of inputs.
- *
- * It takes as input a list of tensors, all of the same shape and returns a
- * single tensor (also of the same shape). For example:
- *
- * ```js
- * const input1 = tf.input({shape: [2, 2]});
- * const input2 = tf.input({shape: [2, 2]});
- * const maxLayer = tf.layers.maximum();
- * const max = maxLayer.apply([input1, input2]);
- * console.log(JSON.stringify(max.shape));
- * // You get [null, 2, 2], with the first dimension as the undetermined batch
- * // dimension.
- * ```
- */
 export class Maximum extends Merge {
   /** @nocollapse */
   static className = 'Maximum';
@@ -633,22 +566,6 @@ export function maximum(config?: SymbolicTensor[]|Tensor[]|LayerArgs): Layer|
   }
 }
 
-/**
- * Layer that computes the element-wise minimum of an `Array` of inputs.
- *
- * It takes as input a list of tensors, all of the same shape and returns a
- * single tensor (also of the same shape). For example:
- *
- * ```js
- * const input1 = tf.input({shape: [2, 2]});
- * const input2 = tf.input({shape: [2, 2]});
- * const minLayer = tf.layers.minimum();
- * const min = minLayer.apply([input1, input2]);
- * console.log(JSON.stringify(min.shape));
- * // You get [null, 2, 2], with the first dimension as the undetermined batch
- * // dimension.
- * ```
- */
 export class Minimum extends Merge {
   /** @nocollapse */
   static className = 'Minimum';
@@ -733,24 +650,6 @@ export declare interface ConcatenateLayerArgs extends LayerArgs {
   axis?: number;
 }
 
-/**
- * Layer that concatenates an `Array` of inputs.
- *
- * It takes a list of tensors, all of the same shape except for the
- * concatenation axis, and returns a single tensor, the concatenation
- * of all inputs. For example:
- *
- * ```js
- * const input1 = tf.input({shape: [2, 2]});
- * const input2 = tf.input({shape: [2, 3]});
- * const concatLayer = tf.layers.concatenate();
- * const output = concatLayer.apply([input1, input2]);
- * console.log(JSON.stringify(output.shape));
- * // You get [null, 2, 5], with the first dimension as the undetermined batch
- * // dimension. The last dimension (5) is the result of concatenating the
- * // last dimensions of the inputs (2 and 3).
- * ```
- */
 export class Concatenate extends Merge {
   /** @nocollapse */
   static className = 'Concatenate';
@@ -1069,26 +968,6 @@ function batchDot(x: Tensor, y: Tensor, axes: number|[number, number]): Tensor {
   });
 }
 
-/**
- * Layer that computes a dot product between samples in two tensors.
- *
- * E.g., if applied to a list of two tensors `a` and `b` both of shape
- * `[batchSize, n]`, the output will be a tensor of shape `[batchSize, 1]`,
- * where each entry at index `[i, 0]` will be the dot product between
- * `a[i, :]` and `b[i, :]`.
- *
- * Example:
- *
- * ```js
- * const dotLayer = tf.layers.dot({axes: -1});
- * const x1 = tf.tensor2d([[10, 20], [30, 40]]);
- * const x2 = tf.tensor2d([[-1, -2], [-3, -4]]);
- *
- * // Invoke the layer's apply() method in eager (imperative) mode.
- * const y = dotLayer.apply([x1, x2]);
- * y.print();
- * ```
- */
 export class Dot extends Merge {
   /** @nocollapse */
   static className = 'Dot';

--- a/src/layers/noise.ts
+++ b/src/layers/noise.ts
@@ -26,27 +26,6 @@ export declare interface GaussianNoiseArgs extends LayerArgs {
   stddev: number;
 }
 
-/**
- * Apply additive zero-centered Gaussian noise.
- *
- * As it is a regularization layer, it is only active at training time.
- *
- * This is useful to mitigate overfitting
- * (you could see it as a form of random data augmentation).
- * Gaussian Noise (GS) is a natural choice as corruption process
- * for real valued inputs.
- *
- * # Arguments
- *     stddev: float, standard deviation of the noise distribution.
- *
- * # Input shape
- *         Arbitrary. Use the keyword argument `input_shape`
- *         (tuple of integers, does not include the samples axis)
- *         when using this layer as the first layer in a model.
- *
- * # Output shape
- *         Same shape as input.
- */
 export class GaussianNoise extends Layer {
   static className = 'GaussianNoise';
   readonly stddev: number;
@@ -88,29 +67,6 @@ export declare interface GaussianDropoutArgs extends LayerArgs {
   rate: number;
 }
 
-/**
- * Apply multiplicative 1-centered Gaussian noise.
- *
- * As it is a regularization layer, it is only active at training time.
- *
- * # Arguments
- *     rate: float, drop probability (as with `Dropout`).
- *        The multiplicative noise will have
- *        standard deviation `sqrt(rate / (1 - rate))`.
- *
- * # Input shape
- *     Arbitrary. Use the keyword argument `input_shape`
- *     (tuple of integers, does not include the samples axis)
- *     when using this layer as the first layer in a model.
- *
- * # Output shape
- *     Same shape as input.
- *
- * # References
- *     - [Dropout: A Simple Way to Prevent Neural Networks from Overfitting](
- *        http://www.cs.toronto.edu/~rsalakhu/papers/srivastava14a.pdf)
- *
- */
 export class GaussianDropout extends Layer {
   static className = 'GaussianDropout';
   readonly rate: number;
@@ -159,36 +115,6 @@ export declare interface AlphaDropoutArgs extends LayerArgs {
   noiseShape?: Shape;
 }
 
-/**
- * Applies Alpha Dropout to the input.
- *
- * As it is a regularization layer, it is only active at training time.
- *
- * Alpha Dropout is a `Dropout` that keeps mean and variance of inputs
- * to their original values, in order to ensure the self-normalizing property
- * even after this dropout.
- * Alpha Dropout fits well to Scaled Exponential Linear Units
- * by randomly setting activations to the negative saturation value.
- *
- * # Arguments
- *    rate: float, drop probability (as with `Dropout`).
- *        The multiplicative noise will have
- *        standard deviation `sqrt(rate / (1 - rate))`.
- *    noise_shape: A 1-D `Tensor` of type `int32`, representing the
- *         shape for randomly generated keep/drop flags.
- *
- *
- * # Input shape
- *         Arbitrary. Use the keyword argument `input_shape`
- *         (tuple of integers, does not include the samples axis)
- *         when using this layer as the first layer in a model.
- *
- * # Output shape
- *         Same shape as input.
- *
- * # References
- *     - [Self-Normalizing Neural Networks](https://arxiv.org/abs/1706.02515)
- */
 export class AlphaDropout extends Layer {
   static className = 'AlphaDropout';
   readonly rate: number;

--- a/src/layers/noise.ts
+++ b/src/layers/noise.ts
@@ -26,31 +26,8 @@ export declare interface GaussianNoiseArgs extends LayerArgs {
   stddev: number;
 }
 
-<<<<<<< HEAD
-== == ===
-    /**
-     * Apply additive zero-centered Gaussian noise.
-     *
-     * As it is a regularization layer, it is only active at training time.
-     *
-     * This is useful to mitigate overfitting
-     * (you could see it as a form of random data augmentation).
-     * Gaussian Noise (GS) is a natural choice as corruption process
-     * for real valued inputs.
-     *
-     * Arguments:
-     *   - `stddev`: float, standard deviation of the noise distribution.
-     *
-     * Input shape:
-     *   Arbitrary. Use the keyword argument `inputShape`
-     *   (tuple of integers, does not include the samples axis)
-     *   when using this layer as the first layer in a model.
-     *
-     * Output shape:
-     *   Same shape as input.
-     */
->>>>>>> origin
-    export class GaussianNoise extends Layer {
+
+export class GaussianNoise extends Layer {
   static className = 'GaussianNoise';
   readonly stddev: number;
 

--- a/src/layers/normalization.ts
+++ b/src/layers/normalization.ts
@@ -250,26 +250,6 @@ export declare interface BatchNormalizationLayerArgs extends LayerArgs {
   gammaRegularizer?: RegularizerIdentifier|Regularizer;
 }
 
-
-/**
- * Batch normalization layer (Ioffe and Szegedy, 2014).
- *
- * Normalize the activations of the previous layer at each batch,
- * i.e. applies a transformation that maintains the mean activation
- * close to 0 and the activation standard deviation close to 1.
- *
- * Input shape:
- *   Arbitrary. Use the keyword argument `inputShape` (Array of integers, does
- *   not include the sample axis) when calling the constructor of this class,
- *   if this layer is used as a first layer in a model.
- *
- * Output shape:
- *   Same shape as input.
- *
- * References:
- *   - [Batch Normalization: Accelerating Deep Network Training by Reducing
- * Internal Covariate Shift](https://arxiv.org/abs/1502.03167)
- */
 export class BatchNormalization extends Layer {
   /** @nocollapse */
   static className = 'BatchNormalization';

--- a/src/layers/padding.ts
+++ b/src/layers/padding.ts
@@ -131,26 +131,6 @@ export declare interface ZeroPadding2DLayerArgs extends LayerArgs {
   dataFormat?: DataFormat;
 }
 
-/**
- * Zero-padding layer for 2D input (e.g., image).
- *
- * This layer can add rows and columns of zeros
- * at the top, bottom, left and right side of an image tensor.
- *
- * Input shape:
- *   4D tensor with shape:
- *   - If `dataFormat` is `"channelsLast"`:
- *     `[batch, rows, cols, channels]`
- *   - If `data_format` is `"channels_first"`:
- *     `[batch, channels, rows, cols]`.
- *
- * Output shape:
- *   4D with shape:
- *   - If `dataFormat` is `"channelsLast"`:
- *     `[batch, paddedRows, paddedCols, channels]`
- *    - If `dataFormat` is `"channelsFirst"`:
- *     `[batch, channels, paddedRows, paddedCols]`.
- */
 export class ZeroPadding2D extends Layer {
   /** @nocollapse */
   static className = 'ZeroPadding2D';

--- a/src/layers/pooling.ts
+++ b/src/layers/pooling.ts
@@ -191,13 +191,6 @@ export abstract class Pooling1D extends Layer {
   }
 }
 
-/**
- * Max pooling operation for temporal data.
- *
- * Input shape:  `[batchSize, inLength, channels]`
- *
- * Output shape: `[batchSize, pooledLength, channels]`
- */
 export class MaxPooling1D extends Pooling1D {
   /** @nocollapse */
   static className = 'MaxPooling1D';
@@ -215,15 +208,6 @@ export class MaxPooling1D extends Pooling1D {
 }
 serialization.registerClass(MaxPooling1D);
 
-/**
- * Average pooling operation for spatial data.
- *
- * Input shape: `[batchSize, inLength, channels]`
- *
- * Output shape: `[batchSize, pooledLength, channels]`
- *
- * `tf.avgPool1d` is an alias.
- */
 export class AveragePooling1D extends Pooling1D {
   /** @nocollapse */
   static className = 'AveragePooling1D';
@@ -352,25 +336,6 @@ export abstract class Pooling2D extends Layer {
   }
 }
 
-/**
- * Max pooling operation for spatial data.
- *
- * Input shape
- *   - If `dataFormat === CHANNEL_LAST`:
- *       4D tensor with shape:
- *       `[batchSize, rows, cols, channels]`
- *   - If `dataFormat === CHANNEL_FIRST`:
- *      4D tensor with shape:
- *       `[batchSize, channels, rows, cols]`
- *
- * Output shape
- *   - If `dataFormat=CHANNEL_LAST`:
- *       4D tensor with shape:
- *       `[batchSize, pooleRows, pooledCols, channels]`
- *   - If `dataFormat=CHANNEL_FIRST`:
- *       4D tensor with shape:
- *       `[batchSize, channels, pooleRows, pooledCols]`
- */
 export class MaxPooling2D extends Pooling2D {
   /** @nocollapse */
   static className = 'MaxPooling2D';
@@ -388,27 +353,6 @@ export class MaxPooling2D extends Pooling2D {
 }
 serialization.registerClass(MaxPooling2D);
 
-/**
- * Average pooling operation for spatial data.
- *
- * Input shape:
- *  - If `dataFormat === CHANNEL_LAST`:
- *      4D tensor with shape:
- *      `[batchSize, rows, cols, channels]`
- *  - If `dataFormat === CHANNEL_FIRST`:
- *      4D tensor with shape:
- *      `[batchSize, channels, rows, cols]`
- *
- * Output shape
- *  - If `dataFormat === CHANNEL_LAST`:
- *      4D tensor with shape:
- *      `[batchSize, pooleRows, pooledCols, channels]`
- *  - If `dataFormat === CHANNEL_FIRST`:
- *      4D tensor with shape:
- *      `[batchSize, channels, pooleRows, pooledCols]`
- *
- * `tf.avgPool2d` is an alias.
- */
 export class AveragePooling2D extends Pooling2D {
   /** @nocollapse */
   static className = 'AveragePooling2D';
@@ -444,13 +388,6 @@ export abstract class GlobalPooling1D extends Layer {
   }
 }
 
-/**
- * Global average pooling operation for temporal data.
- *
- * Input Shape: 3D tensor with shape: `[batchSize, steps, features]`.
- *
- * Output Shape:2D tensor with shape: `[batchSize, features]`.
- */
 export class GlobalAveragePooling1D extends GlobalPooling1D {
   /** @nocollapse */
   static className = 'GlobalAveragePooling1D';
@@ -467,13 +404,6 @@ export class GlobalAveragePooling1D extends GlobalPooling1D {
 }
 serialization.registerClass(GlobalAveragePooling1D);
 
-/**
- * Global max pooling operation for temporal data.
- *
- * Input Shape: 3D tensor with shape: `[batchSize, steps, features]`.
- *
- * Output Shape:2D tensor with shape: `[batchSize, features]`.
- */
 export class GlobalMaxPooling1D extends GlobalPooling1D {
   /** @nocollapse */
   static className = 'GlobalMaxPooling1D';
@@ -536,18 +466,6 @@ export abstract class GlobalPooling2D extends Layer {
   }
 }
 
-/**
- * Global average pooling operation for spatial data.
- *
- * Input shape:
- *   - If `dataFormat` is `CHANNEL_LAST`:
- *       4D tensor with shape: `[batchSize, rows, cols, channels]`.
- *   - If `dataFormat` is `CHANNEL_FIRST`:
- *       4D tensor with shape: `[batchSize, channels, rows, cols]`.
- *
- * Output shape:
- *   2D tensor with shape: `[batchSize, channels]`.
- */
 export class GlobalAveragePooling2D extends GlobalPooling2D {
   /** @nocollapse */
   static className = 'GlobalAveragePooling2D';
@@ -565,18 +483,6 @@ export class GlobalAveragePooling2D extends GlobalPooling2D {
 }
 serialization.registerClass(GlobalAveragePooling2D);
 
-/**
- * Global max pooling operation for spatial data.
- *
- * Input shape:
- *   - If `dataFormat` is `CHANNEL_LAST`:
- *       4D tensor with shape: `[batchSize, rows, cols, channels]`.
- *   - If `dataFormat` is `CHANNEL_FIRST`:
- *       4D tensor with shape: `[batchSize, channels, rows, cols]`.
- *
- * Output shape:
- *   2D tensor with shape: `[batchSize, channels]`.
- */
 export class GlobalMaxPooling2D extends GlobalPooling2D {
   /** @nocollapse */
   static className = 'GlobalMaxPooling2D';

--- a/src/layers/recurrent.ts
+++ b/src/layers/recurrent.ts
@@ -339,73 +339,6 @@ export declare interface BaseRNNLayerArgs extends LayerArgs {
   inputLength?: number;
 }
 
-/**
- * RNNLayerConfig is identical to BaseRNNLayerConfig, except it makes the
- * `cell` property required. This interface is to be used with constructors
- * of concrete RNN layer subtypes.
- */
-export declare interface RNNLayerArgs extends BaseRNNLayerArgs {
-  cell: RNNCell|RNNCell[];
-}
-
-/**
- * Base class for recurrent layers.
- *
- * Input shape:
- *   3D tensor with shape `[batchSize, timeSteps, inputDim]`.
- *
- * Output shape:
- *   - if `returnState`, an Array of tensors (i.e., `tf.Tensor`s). The first
- *     tensor is the output. The remaining tensors are the states at the
- *     last time step, each with shape `[batchSize, units]`.
- *   - if `returnSequences`, the output will have shape
- *     `[batchSize, timeSteps, units]`.
- *   - else, the output will have shape `[batchSize, units]`.
- *
- * Masking:
- *   This layer supports masking for input data with a variable number
- *   of timesteps. To introduce masks to your data,
- *   use an embedding layer with the `mask_zero` parameter
- *   set to `True`.
- *
- * Notes on using statefulness in RNNs:
- *   You can set RNN layers to be 'stateful', which means that the states
- *   computed for the samples in one batch will be reused as initial states
- *   for the samples in the next batch. This assumes a one-to-one mapping
- *   between samples in different successive batches.
- *
- *   To enable statefulness:
- *     - specify `stateful: true` in the layer constructor.
- *     - specify a fixed batch size for your model, by passing
- *       if sequential model:
- *         `batchInputShape=[...]` to the first layer in your model.
- *       else for functional model with 1 or more Input layers:
- *         `batchShape=[...]` to all the first layers in your model.
- *       This is the expected shape of your inputs *including the batch size*.
- *       It should be a tuple of integers, e.g. `(32, 10, 100)`.
- *     - specify `shuffle=False` when calling fit().
- *
- *   To reset the states of your model, call `.resetStates()` on either
- *   a specific layer, or on your entire model.
- *
- * Note on specifying the initial state of RNNs
- *   You can specify the initial state of RNN layers symbolically by
- *   calling them with the option `initialState`. The value of
- *   `initialState` should be a tensor or list of tensors representing
- *   the initial state of the RNN layer.
- *
- *   You can specify the initial state of RNN layers numerically by
- *   calling `resetStates` with the keyword argument `states`. The value of
- *   `states` should be a numpy array or list of numpy arrays representing
- *   the initial state of the RNN layer.
- *
- * Note on passing external constants to RNNs
- *   You can pass "external" constants to the cell using the `constants`
- *   keyword argument of `RNN.call` method. This requires that the `cell.call`
- *   method accepts the same keyword argument `constants`. Such constants
- *   can be used to conditon the cell transformation on additional static inputs
- *   (not changing over time), a.k.a an attention mechanism.
- */
 export class RNN extends Layer {
   /** @nocollapse */
   static className = 'RNN';
@@ -992,49 +925,6 @@ export declare interface SimpleRNNCellLayerArgs extends LayerArgs {
   recurrentDropout?: number;
 }
 
-/**
- * Cell class for `SimpleRNN`.
- *
- * `SimpleRNNCell` is distinct from the `RNN` subclass `SimpleRNN` in that its
- * `apply` method takes the input data of only a single time step and returns
- * the cell's output at the time step, while `SimpleRNN` takes the input data
- * over a number of time steps. For example:
- *
- * ```js
- * const cell = tf.layers.simpleRNNCell({units: 2});
- * const input = tf.input({shape: [10]});
- * const output = cell.apply(input);
- *
- * console.log(JSON.stringify(output.shape));
- * // [null, 10]: This is the cell's output at a single time step. The 1st
- * // dimension is the unknown batch size.
- * ```
- *
- * Instance(s) of `SimpleRNNCell` can be used to construct `RNN` layers. The
- * most typical use of this workflow is to combine a number of cells into a
- * stacked RNN cell (i.e., `StackedRNNCell` internally) and use it to create an
- * RNN. For example:
- *
- * ```js
- * const cells = [
- *   tf.layers.simpleRNNCell({units: 4}),
- *   tf.layers.simpleRNNCell({units: 8}),
- * ];
- * const rnn = tf.layers.rnn({cell: cells, returnSequences: true});
- *
- * // Create an input with 10 time steps and a length-20 vector at each step.
- * const input = tf.input({shape: [10, 20]});
- * const output = rnn.apply(input);
- *
- * console.log(JSON.stringify(output.shape));
- * // [null, 10, 8]: 1st dimension is unknown batch size; 2nd dimension is the
- * // same as the sequence length of `input`, due to `returnSequences`: `true`;
- * // 3rd dimension is the last `SimpleRNNCell`'s number of units.
- * ```
- *
- * To create an `RNN` consisting of only *one* `SimpleRNNCell`, use the
- * `tf.layers.simpleRNN`.
- */
 export class SimpleRNNCell extends RNNCell {
   /** @nocollapse */
   static className = 'SimpleRNNCell';
@@ -1284,27 +1174,14 @@ export declare interface SimpleRNNLayerArgs extends BaseRNNLayerArgs {
 }
 
 /**
- * Fully-connected RNN where the output is to be fed back to input.
- *
- * This is an `RNN` layer consisting of one `SimpleRNNCell`. However, unlike
- * the underlying `SimpleRNNCell`, the `apply` method of `SimpleRNN` operates
- * on a sequence of inputs. The shape of the input (not including the first,
- * batch dimension) needs to be at least 2-D, with the first dimension being
- * time steps. For example:
- *
- * ```js
- * const rnn = tf.layers.simpleRNN({units: 8, returnSequences: true});
- *
- * // Create an input with 10 time steps.
- * const input = tf.input({shape: [10, 20]});
- * const output = rnn.apply(input);
- *
- * console.log(JSON.stringify(output.shape));
- * // [null, 10, 8]: 1st dimension is unknown batch size; 2nd dimension is the
- * // same as the sequence length of `input`, due to `returnSequences`: `true`;
- * // 3rd dimension is the `SimpleRNNCell`'s number of units.
- * ```
+ * RNNLayerConfig is identical to BaseRNNLayerConfig, except it makes the
+ * `cell` property required. This interface is to be used with constructors
+ * of concrete RNN layer subtypes.
  */
+export declare interface RNNLayerArgs extends BaseRNNLayerArgs {
+  cell: RNNCell|RNNCell[];
+}
+
 export class SimpleRNN extends RNN {
   /** @nocollapse */
   static className = 'SimpleRNN';
@@ -1444,49 +1321,6 @@ export declare interface GRUCellLayerArgs extends SimpleRNNCellLayerArgs {
   implementation?: number;
 }
 
-/**
- * Cell class for `GRU`.
- *
- * `GRUCell` is distinct from the `RNN` subclass `GRU` in that its
- * `apply` method takes the input data of only a single time step and returns
- * the cell's output at the time step, while `GRU` takes the input data
- * over a number of time steps. For example:
- *
- * ```js
- * const cell = tf.layers.gruCell({units: 2});
- * const input = tf.input({shape: [10]});
- * const output = cell.apply(input);
- *
- * console.log(JSON.stringify(output.shape));
- * // [null, 10]: This is the cell's output at a single time step. The 1st
- * // dimension is the unknown batch size.
- * ```
- *
- * Instance(s) of `GRUCell` can be used to construct `RNN` layers. The
- * most typical use of this workflow is to combine a number of cells into a
- * stacked RNN cell (i.e., `StackedRNNCell` internally) and use it to create an
- * RNN. For example:
- *
- * ```js
- * const cells = [
- *   tf.layers.gruCell({units: 4}),
- *   tf.layers.gruCell({units: 8}),
- * ];
- * const rnn = tf.layers.rnn({cell: cells, returnSequences: true});
- *
- * // Create an input with 10 time steps and a length-20 vector at each step.
- * const input = tf.input({shape: [10, 20]});
- * const output = rnn.apply(input);
- *
- * console.log(JSON.stringify(output.shape));
- * // [null, 10, 8]: 1st dimension is unknown batch size; 2nd dimension is the
- * // same as the sequence length of `input`, due to `returnSequences`: `true`;
- * // 3rd dimension is the last `gruCell`'s number of units.
- * ```
- *
- * To create an `RNN` consisting of only *one* `GRUCell`, use the
- * `tf.layers.gru`.
- */
 export class GRUCell extends RNNCell {
   /** @nocollapse */
   static className = 'GRUCell';
@@ -1711,27 +1545,6 @@ export declare interface GRULayerArgs extends SimpleRNNLayerArgs {
   implementation?: number;
 }
 
-/**
- * Gated Recurrent Unit - Cho et al. 2014.
- *
- * This is an `RNN` layer consisting of one `GRUCell`. However, unlike
- * the underlying `GRUCell`, the `apply` method of `SimpleRNN` operates
- * on a sequence of inputs. The shape of the input (not including the first,
- * batch dimension) needs to be at least 2-D, with the first dimension being
- * time steps. For example:
- *
- * ```js
- * const rnn = tf.layers.gru({units: 8, returnSequences: true});
- *
- * // Create an input with 10 time steps.
- * const input = tf.input({shape: [10, 20]});
- * const output = rnn.apply(input);
- *
- * console.log(JSON.stringify(output.shape));
- * // [null, 10, 8]: 1st dimension is unknown batch size; 2nd dimension is the
- * // same as the sequence length of `input`, due to `returnSequences`: `true`;
- * // 3rd dimension is the `GRUCell`'s number of units.
- */
 export class GRU extends RNN {
   /** @nocollapse */
   static className = 'GRU';
@@ -1903,49 +1716,6 @@ export declare interface LSTMCellLayerArgs extends SimpleRNNCellLayerArgs {
   implementation?: number;
 }
 
-/**
- * Cell class for `LSTM`.
- *
- * `LSTMCell` is distinct from the `RNN` subclass `LSTM` in that its
- * `apply` method takes the input data of only a single time step and returns
- * the cell's output at the time step, while `LSTM` takes the input data
- * over a number of time steps. For example:
- *
- * ```js
- * const cell = tf.layers.lstmCell({units: 2});
- * const input = tf.input({shape: [10]});
- * const output = cell.apply(input);
- *
- * console.log(JSON.stringify(output.shape));
- * // [null, 10]: This is the cell's output at a single time step. The 1st
- * // dimension is the unknown batch size.
- * ```
- *
- * Instance(s) of `LSTMCell` can be used to construct `RNN` layers. The
- * most typical use of this workflow is to combine a number of cells into a
- * stacked RNN cell (i.e., `StackedRNNCell` internally) and use it to create an
- * RNN. For example:
- *
- * ```js
- * const cells = [
- *   tf.layers.lstmCell({units: 4}),
- *   tf.layers.lstmCell({units: 8}),
- * ];
- * const rnn = tf.layers.rnn({cell: cells, returnSequences: true});
- *
- * // Create an input with 10 time steps and a length-20 vector at each step.
- * const input = tf.input({shape: [10, 20]});
- * const output = rnn.apply(input);
- *
- * console.log(JSON.stringify(output.shape));
- * // [null, 10, 8]: 1st dimension is unknown batch size; 2nd dimension is the
- * // same as the sequence length of `input`, due to `returnSequences`: `true`;
- * // 3rd dimension is the last `lstmCell`'s number of units.
- * ```
- *
- * To create an `RNN` consisting of only *one* `LSTMCell`, use the
- * `tf.layers.lstm`.
- */
 export class LSTMCell extends RNNCell {
   /** @nocollapse */
   static className = 'LSTMCell';
@@ -2193,27 +1963,6 @@ export declare interface LSTMLayerArgs extends SimpleRNNLayerArgs {
   implementation?: number;
 }
 
-/**
- * Long-Short Term Memory layer - Hochreiter 1997.
- *
- * This is an `RNN` layer consisting of one `LSTMCell`. However, unlike
- * the underlying `LSTMCell`, the `apply` method of `LSTM` operates
- * on a sequence of inputs. The shape of the input (not including the first,
- * batch dimension) needs to be at least 2-D, with the first dimension being
- * time steps. For example:
- *
- * ```js
- * const lstm = tf.layers.lstm({units: 8, returnSequences: true});
- *
- * // Create an input with 10 time steps.
- * const input = tf.input({shape: [10, 20]});
- * const output = lstm.apply(input);
- *
- * console.log(JSON.stringify(output.shape));
- * // [null, 10, 8]: 1st dimension is unknown batch size; 2nd dimension is the
- * // same as the sequence length of `input`, due to `returnSequences`: `true`;
- * // 3rd dimension is the `LSTMCell`'s number of units.
- */
 export class LSTM extends RNN {
   /** @nocollapse */
   static className = 'LSTM';
@@ -2360,11 +2109,6 @@ export declare interface StackedRNNCellsArgs extends LayerArgs {
   cells: RNNCell[];
 }
 
-/**
- * Wrapper allowing a stack of RNN cells to behave as a single cell.
- *
- * Used to implement efficient stacked RNNs.
- */
 export class StackedRNNCells extends RNNCell {
   /** @nocollapse */
   static className = 'StackedRNNCells';

--- a/src/layers/wrappers.ts
+++ b/src/layers/wrappers.ts
@@ -148,50 +148,6 @@ export abstract class Wrapper extends Layer {
   }
 }
 
-/**
- * This wrapper applies a layer to every temporal slice of an input.
- *
- * The input should be at least 3D,  and the dimension of the index `1` will be
- * considered to be the temporal dimension.
- *
- * Consider a batch of 32 samples, where each sample is a sequence of 10 vectors
- * of 16 dimensions. The batch input shape of the layer is then `[32,  10,
- * 16]`, and the `inputShape`, not including the sample dimension, is
- * `[10, 16]`.
- *
- * You can then use `TimeDistributed` to apply a `Dense` layer to each of the 10
- * timesteps, independently:
- *
- * ```js
- * const model = tf.sequential();
- * model.add(tf.layers.timeDistributed({
- *   layer: tf.layers.dense({units: 8}),
- *   inputShape: [10, 16],
- * }));
- *
- * // Now model.outputShape = [null, 10, 8].
- * // The output will then have shape `[32, 10, 8]`.
- *
- * // In subsequent layers, there is no need for `inputShape`:
- * model.add(tf.layers.timeDistributed({layer: tf.layers.dense({units: 32})}));
- * console.log(JSON.stringify(model.outputs[0].shape));
- * // Now model.outputShape = [null, 10, 32].
- * ```
- *
- * The output will then have shape `[32, 10, 32]`.
- *
- * `TimeDistributed` can be used with arbitrary layers, not just `Dense`, for
- * instance a `Conv2D` layer.
- *
- * ```js
- * const model = tf.sequential();
- * model.add(tf.layers.timeDistributed({
- *   layer: tf.layers.conv2d({filters: 64, kernelSize: [3, 3]}),
- *   inputShape: [10, 299, 299, 3],
- * }));
- * console.log(JSON.stringify(model.outputs[0].shape));
- * ```
- */
 export class TimeDistributed extends Wrapper {
   /** @nocollapse */
   static className = 'TimeDistributed';

--- a/src/losses.ts
+++ b/src/losses.ts
@@ -35,64 +35,14 @@ export function l2Normalize(x: Tensor, axis?: number): Tensor {
   });
 }
 
-/**
- * Loss or metric function: Mean squared error.
- *
- * ```js
- * const yTrue = tf.tensor2d([[0, 1], [3, 4]]);
- * const yPred = tf.tensor2d([[0, 1], [-3, -4]]);
- * const mse = tf.metrics.meanSquaredError(yTrue, yPred);
- * mse.print();
- * ```
- *
- * Aliases: `tf.metrics.MSE`, `tf.metrics.mse`.
- *
- * @param yTrue Truth Tensor.
- * @param yPred Prediction Tensor.
- * @return Mean squared error Tensor.
- */
 export function meanSquaredError(yTrue: Tensor, yPred: Tensor): Tensor {
   return tidy(() => tfc.mean(K.square(tfc.sub(yPred, yTrue)), -1));
 }
 
-/**
- * Loss or metric function: Mean absolute error.
- *
- * Mathematically, mean absolute error is defined as:
- *   `mean(abs(yPred - yTrue))`,
- * wherein the `mean` is applied over feature dimensions.
- *
- * ```js
- * const yTrue = tf.tensor2d([[0, 1], [0, 0], [2, 3]]);
- * const yPred = tf.tensor2d([[0, 1], [0, 1], [-2, -3]]);
- * const mse = tf.metrics.meanAbsoluteError(yTrue, yPred);
- * mse.print();
- * ```
- *
- * @param yTrue Truth Tensor.
- * @param yPred Prediction Tensor.
- * @return Mean absolute error Tensor.
- */
 export function meanAbsoluteError(yTrue: Tensor, yPred: Tensor): Tensor {
   return tidy(() => tfc.mean(tfc.abs(tfc.sub(yPred, yTrue)), -1));
 }
 
-/**
- * Loss or metric function: Mean absolute percentage error.
- *
- * ```js
- * const yTrue = tf.tensor2d([[0, 1], [10, 20]]);
- * const yPred = tf.tensor2d([[0, 1], [11, 24]]);
- * const mse = tf.metrics.meanAbsolutePercentageError(yTrue, yPred);
- * mse.print();
- * ```
- *
- * Aliases: `tf.metrics.MAPE`, `tf.metrics.mape`.
- *
- * @param yTrue Truth Tensor.
- * @param yPred Prediction Tensor.
- * @return Mean absolute percentage error Tensor.
- */
 export function meanAbsolutePercentageError(
     yTrue: Tensor, yPred: Tensor): Tensor {
   return tidy(() => {
@@ -158,15 +108,6 @@ export function logcosh(yTrue: Tensor, yPred: Tensor): Tensor {
   });
 }
 
-/**
- * Categorical crossentropy between an output tensor and a target tensor.
- *
- * @param target A tensor of the same shape as `output`.
- * @param output A tensor resulting from a softmax (unless `fromLogits` is
- *  `true`, in which case `output` is expected to be the logits).
- * @param fromLogits Boolean, whether `output` is the result of a softmax, or is
- *   a tensor of logits.
- */
 export function categoricalCrossentropy(
     target: Tensor, output: Tensor, fromLogits = false): Tensor {
   return tidy(() => {
@@ -273,25 +214,6 @@ export function poisson(yTrue: Tensor, yPred: Tensor): Tensor {
   });
 }
 
-/**
- * Loss or metric function: Cosine proximity.
- *
- * Mathematically, cosine proximity is defined as:
- *   `-sum(l2Normalize(yTrue) * l2Normalize(yPred))`,
- * wherein `l2Normalize()` normalizes the L2 norm of the input to 1 and `*`
- * represents element-wise multiplication.
- *
- * ```js
- * const yTrue = tf.tensor2d([[1, 0], [1, 0]]);
- * const yPred = tf.tensor2d([[1 / Math.sqrt(2), 1 / Math.sqrt(2)], [0, 1]]);
- * const proximity = tf.metrics.cosineProximity(yTrue, yPred);
- * proximity.print();
- * ```
- *
- * @param yTrue Truth Tensor.
- * @param yPred Prediction Tensor.
- * @return Cosine proximity Tensor.
- */
 export function cosineProximity(yTrue: Tensor, yPred: Tensor): Tensor {
   return tidy(() => {
     const trueNormalized = l2Normalize(yTrue, -1);

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -20,33 +20,6 @@ import {categoricalCrossentropy as categoricalCrossentropyLoss, cosineProximity,
 import {binaryCrossentropy as lossBinaryCrossentropy} from './losses';
 import {LossOrMetricFn} from './types';
 
-/**
- * Binary accuracy metric function.
- *
- * `yTrue` and `yPred` can have 0-1 values. Example:
- * ```js
- * const x = tensor2d([[1, 1, 1, 1], [0, 0, 0, 0]], [2, 4]);
- * const y = tensor2d([[1, 0, 1, 0], [0, 0, 0, 1]], [2, 4]);
- * const accuracy = tfl.metrics.binaryAccuracy(x, y);
- * accuracy.print();
- * ```
- *
- * `yTrue` and `yPred` can also have floating-number values between 0 and 1, in
- * which case the values will be thresholded at 0.5 to yield 0-1 values (i.e.,
- * a value >= 0.5 and <= 1.0 is interpreted as 1.
- * )
- * Example:
- * ```js
- * const x = tensor1d([1, 1, 1, 1, 0, 0, 0, 0]);
- * const y = tensor1d([0.2, 0.4, 0.6, 0.8, 0.2, 0.3, 0.4, 0.7]);
- * const accuracy = tf.metrics.binaryAccuracy(x, y);
- * accuracy.print();
- * ```
- *
- * @param yTrue Binary Tensor of truth.
- * @param yPred Binary Tensor of prediction.
- * @return Accuracy Tensor.
- */
 export function binaryAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
   return tidy(() => {
     const threshold = tfc.mul(.5, tfc.onesLike(yPred));
@@ -55,22 +28,6 @@ export function binaryAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
   });
 }
 
-/**
- * Categorical accuracy metric function.
- *
- * Example:
- * ```js
- * const x = tensor2d([[0, 0, 0, 1], [0, 0, 0, 1]]);
- * const y = tensor2d([[0.1, 0.8, 0.05, 0.05], [0.1, 0.05, 0.05, 0.8]]);
- * const accuracy = tf.metrics.categoricalAccuracy(x, y);
- * accuracy.print();
- * ```
- *
- * @param yTrue Binary Tensor of truth: one-hot encoding of categories.
- * @param yPred Binary Tensor of prediction: probabilities or logits for the
- *   same categories as in `yTrue`.
- * @return Accuracy Tensor.
- */
 export function categoricalAccuracy(yTrue: Tensor, yPred: Tensor): Tensor {
   return tidy(
       () => K.cast(
@@ -95,39 +52,6 @@ function falsePositives(yTrue: Tensor, yPred: Tensor): Tensor {
   });
 }
 
-/**
- * Computes the precision of the predictions with respect to the labels.
- *
- * Example:
- * ```js
- * const x = tensor2d(
- *    [
- *      [0, 0, 0, 1],
- *      [0, 1, 0, 0],
- *      [0, 0, 0, 1].
- *      [1, 0, 0, 0],
- *      [0, 0, 1, 0]
- *    ]
- * );
- *
- * const y = tensor2d(
- *    [
- *      [0, 0, 1, 0],
- *      [0, 1, 0, 0],
- *      [0, 0, 0, 1].
- *      [0, 1, 0, 0],
- *      [0, 1, 0, 0]
- *    ]
- * );
- *
- * const precision = tf.metrics.precision(x, y);
- * precision.print();
- * ```
- *
- * @param yTrue The ground truth values. Expected to be contain only 0-1 values.
- * @param yPred The predicted values. Expected to be contain only 0-1 values.
- * @return Precision Tensor.
- */
 export function precision(yTrue: Tensor, yPred: Tensor): Tensor {
   return tidy(() => {
     const tp = truePositives(yTrue, yPred);
@@ -140,39 +64,6 @@ export function precision(yTrue: Tensor, yPred: Tensor): Tensor {
   });
 }
 
-/**
- * Computes the recall of the predictions with respect to the labels.
- *
- * Example:
- * ```js
- * const x = tensor2d(
- *    [
- *      [0, 0, 0, 1],
- *      [0, 1, 0, 0],
- *      [0, 0, 0, 1].
- *      [1, 0, 0, 0],
- *      [0, 0, 1, 0]
- *    ]
- * );
- *
- * const y = tensor2d(
- *    [
- *      [0, 0, 1, 0],
- *      [0, 1, 0, 0],
- *      [0, 0, 0, 1].
- *      [0, 1, 0, 0],
- *      [0, 1, 0, 0]
- *    ]
- * );
- *
- * const recall = tf.metrics.recall(x, y);
- * recall.print();
- * ```
- *
- * @param yTrue The ground truth values. Expected to be contain only 0-1 values.
- * @param yPred The predicted values. Expected to be contain only 0-1 values.
- * @return Recall Tensor.
- */
 export function recall(yTrue: Tensor, yPred: Tensor): Tensor {
   return tidy(() => {
     const tp = truePositives(yTrue, yPred);
@@ -185,40 +76,10 @@ export function recall(yTrue: Tensor, yPred: Tensor): Tensor {
   });
 }
 
-/**
- * Binary crossentropy metric function.
- *
- * Example:
- * ```js
- * const x = tensor2d([[0], [1], [1], [1]]);
- * const y = tensor2d([[0], [0], [0.5], [1]]);
- * const crossentropy = tf.metrics.binaryCrossentropy(x, y);
- * crossentropy.print();
- * ```
- *
- * @param yTrue Binary Tensor of truth.
- * @param yPred Binary Tensor of prediction, probabilities for the `1` case.
- * @return Accuracy Tensor.
- */
 export function binaryCrossentropy(yTrue: Tensor, yPred: Tensor): Tensor {
   return lossBinaryCrossentropy(yTrue, yPred);
 }
 
-/**
- * Sparse categorical accuracy metric function.
- *
- * ```Example:
- * const yTrue = tensor1d([1, 1, 2, 2, 0]);
- * const yPred = tensor2d(
- *      [[0, 1, 0], [1, 0, 0], [0, 0.4, 0.6], [0, 0.6, 0.4], [0.7, 0.3, 0]]);
- * const crossentropy = tf.metrics.sparseCategoricalAccuracy(yTrue, yPred);
- * crossentropy.print();
- * ```
- *
- * @param yTrue True labels: indices.
- * @param yPred Predicted probabilities or logits.
- * @returns Accuracy tensor.
- */
 export function sparseCategoricalAccuracy(
     yTrue: Tensor, yPred: Tensor): Tensor {
   if (yTrue.rank === yPred.rank) {

--- a/src/models.ts
+++ b/src/models.ts
@@ -935,7 +935,7 @@ export class Sequential extends LayersModel {
    *   information collected during training.
    */
   /**
-   * @doc {heading: 'Models', subheading: 'Classes'}
+   * @doc {heading: 'Models', subheading: 'Classes', ignoreCI: true}
    */
   async fitDataset<T>(dataset: Dataset<T>, args: ModelFitDatasetArgs<T>):
       Promise<History> {

--- a/src/regularizers.ts
+++ b/src/regularizers.ts
@@ -39,13 +39,6 @@ export interface L2Args {
   l2: number;
 }
 
-/**
- * Regularizer for L1 and L2 regularization.
- *
- * Adds a term to the loss to penalize large weights:
- * loss += sum(l1 * abs(x)) + sum(l2 * x^2)
- */
-/** @doc {heading: 'Regularizers', namespace: 'regularizers'} */
 export class L1L2 extends Regularizer {
   /** @nocollapse */
   static className = 'L1L2';
@@ -94,24 +87,10 @@ export class L1L2 extends Regularizer {
 }
 serialization.registerClass(L1L2);
 
-/**
- * Regularizer for L1 regularization.
- *
- * Adds a term to the loss to penalize large weights:
- * loss += sum(l1 * abs(x))
- * @param args l1 config.
- */
 export function l1(args?: L1Args) {
   return new L1L2({l1: args != null ? args.l1 : null, l2: 0});
 }
 
-/**
- * Regularizer for L2 regularization.
- *
- * Adds a term to the loss to penalize large weights:
- * loss += sum(l2 * x^2)
- * @param args l2 config.
- */
 export function l2(args: L2Args) {
   return new L1L2({l2: args != null ? args.l2 : null, l1: 0});
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,8 +17,7 @@
     "noUnusedParameters": false,
     "pretty": true,
     "noFallthroughCasesInSwitch": true,
-    "allowUnreachableCode": false,
-    "preserveSymlinks": true
+    "allowUnreachableCode": false
   },
   "include": ["src/"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
     "noUnusedParameters": false,
     "pretty": true,
     "noFallthroughCasesInSwitch": true,
-    "allowUnreachableCode": false
+    "allowUnreachableCode": false,
+    "preserveSymlinks": true
   },
   "include": ["src/"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,8 +17,8 @@
     "noUnusedParameters": false,
     "pretty": true,
     "noFallthroughCasesInSwitch": true,
-    "allowUnreachableCode": false,
-    "preserveSymlinks": true
+    "allowUnreachableCode": false
   },
-  "include": ["src/"]
+  "include": ["src/"],
+  "exclude": ["node_modules/"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,8 +17,8 @@
     "noUnusedParameters": false,
     "pretty": true,
     "noFallthroughCasesInSwitch": true,
-    "allowUnreachableCode": false
+    "allowUnreachableCode": false,
+    "preserveSymlinks": true
   },
-  "include": ["src/"],
-  "exclude": ["node_modules/"]
+  "include": ["src/"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@tensorflow/tfjs-core@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.2.0.tgz#3c51af02688085a67588a899fe7c847996a761d3"
-  integrity sha512-PF04HsiGiJEllwHpFTSMjoDN4M5RvzoFYwI4QHVyemDY14qz9ngCIzxSLTfCF20JEs/6j7Ep6KQLp0SKa5s61g==
+"@tensorflow/tfjs-core@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.2.1.tgz#0ff54aa7fd412b8c17e39f6ec5a97bf032e8f530"
+  integrity sha512-cpSHl+tP7cketq0cAyJPbIGxNlPV7mR6lkMLLDvZAmZUTBSyBufCdJg/KwgjHMZksE/KqjL4/RyccOGBAQcb7g==
   dependencies:
     "@types/seedrandom" "2.4.27"
     "@types/webgl-ext" "0.0.30"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@tensorflow/tfjs-core@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.1.2.tgz#efb8b3688fbff353e51d41a3d832dde8c1bc321d"
-  integrity sha512-xCAUIAh14OFnHt+IQUUZIH/P/jH/EWvewL0Ty6q6USUx4YZ+HvKwNw1G7h/gKki4A31BJ0avD04ylBKc75laGg==
+"@tensorflow/tfjs-core@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.2.0.tgz#3c51af02688085a67588a899fe7c847996a761d3"
+  integrity sha512-PF04HsiGiJEllwHpFTSMjoDN4M5RvzoFYwI4QHVyemDY14qz9ngCIzxSLTfCF20JEs/6j7Ep6KQLp0SKa5s61g==
   dependencies:
     "@types/seedrandom" "2.4.27"
     "@types/webgl-ext" "0.0.30"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@tensorflow/tfjs-core@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.2.0.tgz#3c51af02688085a67588a899fe7c847996a761d3"
-  integrity sha512-PF04HsiGiJEllwHpFTSMjoDN4M5RvzoFYwI4QHVyemDY14qz9ngCIzxSLTfCF20JEs/6j7Ep6KQLp0SKa5s61g==
+"@tensorflow/tfjs-core@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.1.2.tgz#efb8b3688fbff353e51d41a3d832dde8c1bc321d"
+  integrity sha512-xCAUIAh14OFnHt+IQUUZIH/P/jH/EWvewL0Ty6q6USUx4YZ+HvKwNw1G7h/gKki4A31BJ0avD04ylBKc75laGg==
   dependencies:
     "@types/seedrandom" "2.4.27"
     "@types/webgl-ext" "0.0.30"
@@ -29,6 +29,11 @@
   version "10.12.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.2.tgz#d77f9faa027cadad9c912cd47f4f8b07b0fb0864"
   integrity sha512-53ElVDSnZeFUUFIYzI8WLQ25IhWzb6vbddNp8UHlXQyU0ET2RhV5zg0NfubzU7iNMh5bBXb0htCzfvrSVNgzaQ==
+
+"@types/node@~9.6.0":
+  version "9.6.48"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.48.tgz#06e765bda1fef91b075c58d540207e8b37dbdc1f"
+  integrity sha512-velR2CyDrHC1WFheHr5Jm25mdCMs0BXJRp6u0zf8PF9yeOy4Xff5sJeusWS7xOmhAoezlSq8LJ0+9M5H7YkTdw==
 
 "@types/seedrandom@2.4.27":
   version "2.4.27"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3860,10 +3860,10 @@ trim-newlines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
   integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
 
-ts-node@~7.0.0:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-7.0.1.tgz#9562dc2d1e6d248d24bc55f773e3f614337d9baf"
-  integrity sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==
+ts-node@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-7.0.0.tgz#a94a13c75e5e1aa6b82814b84c68deb339ba7bff"
+  integrity sha512-klJsfswHP0FuOLsvBZ/zzCfUvakOSSxds78mVeK7I+qP76YWtxf16hEZsp3U+b0kIo82R5UatGFeblYMqabb2Q==
   dependencies:
     arrify "^1.0.0"
     buffer-from "^1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,11 +30,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.2.tgz#d77f9faa027cadad9c912cd47f4f8b07b0fb0864"
   integrity sha512-53ElVDSnZeFUUFIYzI8WLQ25IhWzb6vbddNp8UHlXQyU0ET2RhV5zg0NfubzU7iNMh5bBXb0htCzfvrSVNgzaQ==
 
-"@types/node@~9.6.0":
-  version "9.6.48"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.48.tgz#06e765bda1fef91b075c58d540207e8b37dbdc1f"
-  integrity sha512-velR2CyDrHC1WFheHr5Jm25mdCMs0BXJRp6u0zf8PF9yeOy4Xff5sJeusWS7xOmhAoezlSq8LJ0+9M5H7YkTdw==
-
 "@types/seedrandom@2.4.27":
   version "2.4.27"
   resolved "https://registry.yarnpkg.com/@types/seedrandom/-/seedrandom-2.4.27.tgz#9db563937dd86915f69092bc43259d2f48578e41"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3860,10 +3860,10 @@ trim-newlines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
   integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
 
-ts-node@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-7.0.0.tgz#a94a13c75e5e1aa6b82814b84c68deb339ba7bff"
-  integrity sha512-klJsfswHP0FuOLsvBZ/zzCfUvakOSSxds78mVeK7I+qP76YWtxf16hEZsp3U+b0kIo82R5UatGFeblYMqabb2Q==
+ts-node@~7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-7.0.1.tgz#9562dc2d1e6d248d24bc55f773e3f614337d9baf"
+  integrity sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==
   dependencies:
     arrify "^1.0.0"
     buffer-from "^1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -521,6 +521,11 @@ buffer-fill@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
   integrity sha1-+PeLdniYiO858gXNY39o5wISKyw=
 
+buffer-from@^1.0.0, buffer-from@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
+  integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
 buffer-indexof-polyfill@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.1.tgz#a9fb806ce8145d5428510ce72f278bb363a638bf"
@@ -1058,7 +1063,7 @@ di@^0.0.1:
   resolved "https://registry.yarnpkg.com/di/-/di-0.0.1.tgz#806649326ceaa7caa3306d75d985ea2748ba913c"
   integrity sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=
 
-diff@^3.2.0:
+diff@^3.1.0, diff@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
@@ -2399,6 +2404,11 @@ magic-string@^0.22.4:
   dependencies:
     vlq "^0.2.2"
 
+make-error@^1.1.1:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.5.tgz#efe4e81f6db28cadd605c70f29c831b58ef776c8"
+  integrity sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==
+
 map-cache@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
@@ -3562,12 +3572,20 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
+source-map-support@^0.5.6:
+  version "0.5.12"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.12.tgz#b4f3b10d51857a5af0138d3ce8003b201613d599"
+  integrity sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
-source-map@0.6.1, source-map@^0.6.1, source-map@~0.6.1:
+source-map@0.6.1, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
@@ -3841,6 +3859,20 @@ trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
   integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
+
+ts-node@~7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-7.0.1.tgz#9562dc2d1e6d248d24bc55f773e3f614337d9baf"
+  integrity sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==
+  dependencies:
+    arrify "^1.0.0"
+    buffer-from "^1.1.0"
+    diff "^3.1.0"
+    make-error "^1.1.1"
+    minimist "^1.2.0"
+    mkdirp "^0.5.1"
+    source-map-support "^0.5.6"
+    yn "^2.0.0"
 
 tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.9.3"
@@ -4195,3 +4227,8 @@ yeast@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
   integrity sha1-AI4G2AlDIMNy28L47XagymyKxBk=
+
+yn@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-2.0.0.tgz#e5adabc8acf408f6385fc76495684c88e6af689a"
+  integrity sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=


### PR DESCRIPTION
Also:
- Remove useDocsFrom. This is an unnecessary layer of indirection. It is much better to have the jsdoc on the method that is actually used (so code editors can see them). This also allows the "source" button in API docs to point to the place where the docs are. In this PR, this allows us to run snippets without following useDocsFrom.
- Fixes all of the snippets that were broken.
- Ignores testing some snippets that use local storage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/541)
<!-- Reviewable:end -->
