### PR TITLE
Fixed regular expression for validate tensor names (#1604)

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -103,7 +103,7 @@ export function getUniqueTensorName(scopedName: string): string {
   }
 }
 
-const tensorNameRegex = new RegExp(/^[A-Za-z][-A-Za-z0-9\._\/]*$/);
+const tensorNameRegex = new RegExp(/^[A-Za-z0-9][-A-Za-z0-9\._\/]*$/);
 
 /**
  * Determine whether a string is a valid tensor name.
@@ -111,5 +111,5 @@ const tensorNameRegex = new RegExp(/^[A-Za-z][-A-Za-z0-9\._\/]*$/);
  * @returns A Boolean indicating whether `name` is a valid tensor name.
  */
 export function isValidTensorName(name: string): boolean {
-  return name.match(tensorNameRegex) ? true : false;
+  return !!name.match(tensorNameRegex);
 }

--- a/src/common_test.ts
+++ b/src/common_test.ts
@@ -99,6 +99,8 @@ describe('isValidTensorName', () => {
     expect(isValidTensorName('a/B/c')).toEqual(true);
     expect(isValidTensorName('z_1/z_2/z.3')).toEqual(true);
     expect(isValidTensorName('z-1/z-2/z.3')).toEqual(true);
+    expect(isValidTensorName('1Qux')).toEqual(true);
+    expect(isValidTensorName('5-conv/kernel')).toEqual(true);
   });
 
   it('Invalid tensor names: empty', () => {
@@ -120,7 +122,6 @@ describe('isValidTensorName', () => {
     expect(isValidTensorName('/foo/bar')).toEqual(false);
     expect(isValidTensorName('.baz')).toEqual(false);
     expect(isValidTensorName('_baz')).toEqual(false);
-    expect(isValidTensorName('1Qux')).toEqual(false);
   });
 
   it('Invalid tensor names: non-ASCII', () => {


### PR DESCRIPTION
Fix for issue #1604 (https://github.com/tensorflow/tfjs/issues/1604).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/543)
<!-- Reviewable:end -->
