### PR TITLE
Fix onProgress for http url in loadLayersModel

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -242,7 +242,7 @@ export async function loadLayersModelInternal(
     options = {};
   }
   if (typeof pathOrIOHandler === 'string') {
-    const handlers = io.getLoadHandlers(pathOrIOHandler);
+    const handlers = io.getLoadHandlers(pathOrIOHandler, options.onProgress);
     if (handlers.length === 0) {
       // For backward compatibility: if no load handler can be found,
       // assume it is a relative http path.

--- a/src/models_test.ts
+++ b/src/models_test.ts
@@ -666,7 +666,8 @@ describeMathCPU('loadLayersModel from URL', () => {
     expectTensorsClose(weightValues[1], zeros([32]));
   });
 
-  it('loadLayersModel: with onProgress callback', async () => {
+  it('loadLayersModel: with onProgress callback from relative path',
+      async () => {
     const modelTopology =
         JSON.parse(JSON.stringify(fakeSequentialModel)).modelTopology;
     const weightsManifest: io.WeightsManifestConfig = [
@@ -721,7 +722,69 @@ describeMathCPU('loadLayersModel from URL', () => {
     expectTensorsClose(weightValues[0], ones([32, 32]));
     expectTensorsClose(weightValues[1], zeros([32]));
     // There are three files: a JSON file and two weight files. So the progress
-    // callback should have been called four, times.
+    // callback should have been called four times (twice the weight files'
+    // number).
+    expect(progressFractions).toEqual([0.25, 0.5, 0.75, 1]);
+  });
+
+  it('loadLayersModel: with onProgress callback from URL', async () => {
+    const modelTopology =
+        JSON.parse(JSON.stringify(fakeSequentialModel)).modelTopology;
+    const weightsManifest: io.WeightsManifestConfig = [
+      {
+        'paths': ['weight_0'],
+        'weights':
+            [{'name': `dense_6/kernel`, 'dtype': 'float32', 'shape': [32, 32]}],
+      },
+      {
+        'paths': ['weight_1'],
+        'weights':
+            [{'name': `dense_6/bias`, 'dtype': 'float32', 'shape': [32]}],
+      }
+    ];
+
+    spyOn(util, 'fetch').and.callFake((path: string) => {
+      return new Promise((resolve, reject) => {
+        if (path === 'https://url/to/model/model.json') {
+          resolve(new Response(
+              JSON.stringify({
+                modelTopology,
+                weightsManifest,
+              }),
+              {'headers': {'Content-Type': JSON_TYPE}}));
+        } else if (path === 'https://url/to/model/weight_0') {
+          resolve(new Response(
+              ones([32, 32], 'float32').dataSync() as Float32Array,
+              {'headers': {'Content-Type': OCTET_STREAM_TYPE}}));
+        } else if (path === 'https://url/to/model/weight_1') {
+          resolve(new Response(
+              zeros([32], 'float32').dataSync() as Float32Array,
+              {'headers': {'Content-Type': OCTET_STREAM_TYPE}}));
+        } else {
+          reject(new Error(`Invalid path: ${path}`));
+        }
+      });
+    });
+
+    const progressFractions: number[] = [];
+    const model = await tfl.loadLayersModel('https://url/to/model/model.json',
+        {
+          onProgress: (fraction: number) => {
+            progressFractions.push(fraction);
+          }
+        });
+    expect(model.layers.length).toEqual(2);
+    expect(model.inputs.length).toEqual(1);
+    expect(model.inputs[0].shape).toEqual([null, 32]);
+    expect(model.outputs.length).toEqual(1);
+    expect(model.outputs[0].shape).toEqual([null, 32]);
+    const weightValues = model.getWeights();
+    expect(weightValues.length).toEqual(2);
+    expectTensorsClose(weightValues[0], ones([32, 32]));
+    expectTensorsClose(weightValues[1], zeros([32]));
+    // There are three files: a JSON file and two weight files. So the progress
+    // callback should have been called four times (twice the weight files'
+    // number).
     expect(progressFractions).toEqual([0.25, 0.5, 0.75, 1]);
   });
 


### PR DESCRIPTION
BUG

Issue [tensorflow/tfjs#1610](https://github.com/tensorflow/tfjs/issues/1610) pointed out that `onProgress` callback of tf.loadGraphModel breaks when using HTTP url. While I found that it also breaks in tf.loadLayersModel, for example:

```javascript
// onProgress works
const model = await tf.loadLayersModel('./PATH/TO/MODEL/model.json', {
  onProgress: function(fraction) {
    console.log(fraction);
  }
});
```

```javascript
// onProgress breaks
const model = await tf.loadLayersModel('https://URL/TO/MODEL/model.json', {
  onProgress: function(fraction) {
    console.log(fraction);
  }
});
```
This PR passes `onProgress` to io.getLoadHandlers to fix the bug.

**Note:**
This PR depends on [tensorflow/tfjs-core#1769](https://github.com/tensorflow/tfjs-core/pull/1769)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/544)
<!-- Reviewable:end -->
