### PR TITLE
Fix implementation bug in AlphaDropout and GaussianDropout

### DIFF
--- a/src/layers/noise.ts
+++ b/src/layers/noise.ts
@@ -139,7 +139,7 @@ export class GaussianDropout extends Layer {
       if (this.rate > 0 && this.rate < 1) {
         const noised = () => {
           const stddev = Math.sqrt(this.rate / (1 - this.rate));
-          return K.dot(input, K.randomNormal(input.shape, 1, stddev));
+          return input.mul(K.randomNormal(input.shape, 1, stddev));
         };
         return K.inTrainPhase(noised, () => input, kwargs['training'] || false);
       }
@@ -238,7 +238,7 @@ export class AlphaDropout extends Layer {
           const b = -a * alphaP * this.rate;
 
           // Apply mask.
-          const x = K.dot(input, keptIdx).add(keptIdx.add(-1).mul(alphaP));
+          const x = input.mul(keptIdx).add(keptIdx.add(-1).mul(alphaP));
 
           return x.mul(a).add(b);
         };

--- a/src/layers/noise_test.ts
+++ b/src/layers/noise_test.ts
@@ -102,7 +102,7 @@ describeMathCPU('GaussianDropout: Symbolic', () => {
 
 describeMathCPUAndGPU('GaussianDropout: Tensor', () => {
   it('GaussianDropout: Predict', () => {
-    const input = ones([2, 2]);
+    const input = ones([1, 2]);
     const gaussianDropoutLayer = tfl.layers.gaussianDropout({rate: 0.5});
     let output = gaussianDropoutLayer.apply(input, {training: false}) as Tensor;
     output = getExactlyOneTensor(output);
@@ -110,7 +110,7 @@ describeMathCPUAndGPU('GaussianDropout: Tensor', () => {
   });
 
   it('GaussianDropout: Train', () => {
-    const input = ones([2, 2]);
+    const input = ones([1, 2]);
     const gaussianDropoutLayer = tfl.layers.gaussianDropout({rate: 0.5});
     let output = gaussianDropoutLayer.apply(input, {training: true}) as Tensor;
     output = getExactlyOneTensor(output);
@@ -122,11 +122,11 @@ describeMathCPUAndGPU('GaussianDropout: Tensor', () => {
 
   it('GaussianDropout: Successive Call', () => {
     const training = true;
-    const inputA = ones([2, 2]);
+    const inputA = ones([1, 2]);
     const gaussianDropoutLayer = tfl.layers.gaussianDropout({rate: 0.5});
     let outputA = gaussianDropoutLayer.apply(inputA, {training}) as Tensor;
     outputA = getExactlyOneTensor(outputA);
-    const inputB = ones([2, 2]);
+    const inputB = ones([1, 2]);
     let outputB = gaussianDropoutLayer.apply(inputB, {training}) as Tensor;
     outputB = getExactlyOneTensor(outputA);
     expectTensorsClose(outputA, outputB);
@@ -159,7 +159,7 @@ describeMathCPU('AlphaDropout: Symbolic', () => {
 
 describeMathCPUAndGPU('AlphaDropout: Tensor', () => {
   it('AlphaDropout: Predict', () => {
-    const input = ones([2, 2]);
+    const input = ones([1, 2]);
     const alphaDropoutLayer = tfl.layers.alphaDropout({rate: 0.5});
     let output = alphaDropoutLayer.apply(input, {training: false}) as Tensor;
     output = getExactlyOneTensor(output);
@@ -167,7 +167,7 @@ describeMathCPUAndGPU('AlphaDropout: Tensor', () => {
   });
 
   it('AlphaDropout: Train', () => {
-    const input = ones([2, 2]);
+    const input = ones([1, 2]);
     const alphaDropoutLayer = tfl.layers.alphaDropout({rate: 0.5});
     let output = alphaDropoutLayer.apply(input, {training: true}) as Tensor;
     output = getExactlyOneTensor(output);
@@ -179,11 +179,11 @@ describeMathCPUAndGPU('AlphaDropout: Tensor', () => {
 
   it('AlphaDropout: Successive Call', () => {
     const training = true;
-    const inputA = ones([2, 2]);
+    const inputA = ones([1, 2]);
     const alphaDropoutLayer = tfl.layers.alphaDropout({rate: 0.5});
     let outputA = alphaDropoutLayer.apply(inputA, {training}) as Tensor;
     outputA = getExactlyOneTensor(outputA);
-    const inputB = ones([2, 2]);
+    const inputB = ones([1, 2]);
     let outputB = alphaDropoutLayer.apply(inputB, {training}) as Tensor;
     outputB = getExactlyOneTensor(outputA);
     expectTensorsClose(outputA, outputB);


### PR DESCRIPTION
BUG

* Fixes [tensorflow/tfjs#1617](https://github.com/tensorflow/tfjs/issues/1617)
* Improves test cases to ensure AlphaDropout and GaussianDropout work well
* Issue mentioned the bug in `AlphaDropout`, while it seems that `GaussianDropout` also has the same bug.

Explanation
* Caused by implementation error, based on `AlphaDropout` and `GaussianDropout` implementation in `Keras` ([GaussianDropout](https://github.com/keras-team/keras/blob/master/keras/layers/noise.py#L91), [AlphaDropout](https://github.com/keras-team/keras/blob/master/keras/layers/noise.py#L162)), should replace `dot` with `mul`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/546)
<!-- Reviewable:end -->
