### PR TITLE
Pin FireFox version at 66 to avoid timeout on OS X

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -57,7 +57,9 @@ module.exports = function(config) {
       bs_firefox_mac: {
         base: 'BrowserStack',
         browser: 'firefox',
-        browser_version: 'latest',
+        // TODO(cais): Change to latest after browser stack infrastructure
+        // stabilizes. https://github.com/tensorflow/tfjs/issues/1620
+        browser_version: '66.0',
         os: 'OS X',
         os_version: 'High Sierra'
       },


### PR DESCRIPTION
DEV

https://github.com/tensorflow/tfjs/issues/1620

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/549)
<!-- Reviewable:end -->
