### PR TITLE
Fix docstring issues

### DIFF
--- a/src/layers/core.ts
+++ b/src/layers/core.ts
@@ -526,9 +526,10 @@ serialization.registerClass(RepeatVector);
  * ```
  *
  * Input shape:
- *   Arbitrary: although all dimensions in the input shape must be fixed.
- *     Use the ReshapeLayerConfig field `input_shape` when using this layer
- *     as the first layer in a model.
+ *   Arbitrary, although all dimensions in the input shape must be fixed.
+ *   Use the configuration `inputShape` when using this layer as the
+ *   first layer in a model.
+ *
  *
  * Output shape:
  *   [batchSize, targetShape[0], targetShape[1], ...,
@@ -669,7 +670,7 @@ export declare interface PermuteLayerArgs extends LayerArgs {
  *
  * Input shape:
  *   Arbitrary. Use the configuration field `inputShape` when using this
- *   layer as othe first layer in a model.
+ *   layer as the first layer in a model.
  *
  * Output shape:
  *   Same rank as the input shape, but with the dimensions re-ordered (i.e.,
@@ -748,16 +749,16 @@ export declare interface MaskingArgs extends LayerArgs {
  * If any downstream layer does not support masking yet receives such
  * an input mask, an exception will be raised.
  *
- * # Arguments
- *     maskValue: Either None or mask value to skip.
+ * Arguments:
+ *   - `maskValue`: Either None or mask value to skip.
  *
- * # Input shape
- *     Arbitrary. Use the keyword argument `input_shape`
- *     (tuple of integers, does not include the samples axis)
- *     when using this layer as the first layer in a model.
+ * Input shape:
+ *   Arbitrary. Use the keyword argument `inputShape`
+ *   (tuple of integers, does not include the samples axis)
+ *   when using this layer as the first layer in a model.
  *
- * # Output shape
- *     Same shape as input.
+ * Output shape:
+ *   Same shape as input.
  */
 export class Masking extends Layer {
 

--- a/src/layers/noise.ts
+++ b/src/layers/noise.ts
@@ -36,16 +36,16 @@ export declare interface GaussianNoiseArgs extends LayerArgs {
  * Gaussian Noise (GS) is a natural choice as corruption process
  * for real valued inputs.
  *
- * # Arguments
- *     stddev: float, standard deviation of the noise distribution.
+ * Arguments:
+ *   - `stddev`: float, standard deviation of the noise distribution.
  *
- * # Input shape
- *         Arbitrary. Use the keyword argument `input_shape`
- *         (tuple of integers, does not include the samples axis)
- *         when using this layer as the first layer in a model.
+ * Input shape:
+ *   Arbitrary. Use the keyword argument `inputShape`
+ *   (tuple of integers, does not include the samples axis)
+ *   when using this layer as the first layer in a model.
  *
- * # Output shape
- *         Same shape as input.
+ * Output shape:
+ *   Same shape as input.
  */
 export class GaussianNoise extends Layer {
   static className = 'GaussianNoise';
@@ -93,22 +93,22 @@ export declare interface GaussianDropoutArgs extends LayerArgs {
  *
  * As it is a regularization layer, it is only active at training time.
  *
- * # Arguments
- *     rate: float, drop probability (as with `Dropout`).
- *        The multiplicative noise will have
- *        standard deviation `sqrt(rate / (1 - rate))`.
+ * Arguments:
+ *   - `rate`: float, drop probability (as with `Dropout`).
+ *     The multiplicative noise will have
+ *     standard deviation `sqrt(rate / (1 - rate))`.
  *
- * # Input shape
- *     Arbitrary. Use the keyword argument `input_shape`
- *     (tuple of integers, does not include the samples axis)
- *     when using this layer as the first layer in a model.
+ * Input shape:
+ *   Arbitrary. Use the keyword argument `inputShape`
+ *   (tuple of integers, does not include the samples axis)
+ *   when using this layer as the first layer in a model.
  *
- * # Output shape
- *     Same shape as input.
+ * Output shape:
+ *   Same shape as input.
  *
- * # References
- *     - [Dropout: A Simple Way to Prevent Neural Networks from Overfitting](
- *        http://www.cs.toronto.edu/~rsalakhu/papers/srivastava14a.pdf)
+ * References:
+ *   - [Dropout: A Simple Way to Prevent Neural Networks from Overfitting](
+ *      http://www.cs.toronto.edu/~rsalakhu/papers/srivastava14a.pdf)
  *
  */
 export class GaussianDropout extends Layer {
@@ -170,24 +170,23 @@ export declare interface AlphaDropoutArgs extends LayerArgs {
  * Alpha Dropout fits well to Scaled Exponential Linear Units
  * by randomly setting activations to the negative saturation value.
  *
- * # Arguments
- *    rate: float, drop probability (as with `Dropout`).
- *        The multiplicative noise will have
- *        standard deviation `sqrt(rate / (1 - rate))`.
- *    noise_shape: A 1-D `Tensor` of type `int32`, representing the
- *         shape for randomly generated keep/drop flags.
+ * Arguments:
+ *   - `rate`: float, drop probability (as with `Dropout`).
+ *     The multiplicative noise will have
+ *     standard deviation `sqrt(rate / (1 - rate))`.
+ *   - `noise_shape`: A 1-D `Tensor` of type `int32`, representing the
+ *     shape for randomly generated keep/drop flags.
  *
+ * Input shape:
+ *   Arbitrary. Use the keyword argument `inputShape`
+ *   (tuple of integers, does not include the samples axis)
+ *   when using this layer as the first layer in a model.
  *
- * # Input shape
- *         Arbitrary. Use the keyword argument `input_shape`
- *         (tuple of integers, does not include the samples axis)
- *         when using this layer as the first layer in a model.
+ * Output shape:
+ *   Same shape as input.
  *
- * # Output shape
- *         Same shape as input.
- *
- * # References
- *     - [Self-Normalizing Neural Networks](https://arxiv.org/abs/1706.02515)
+ * References:
+ *   - [Self-Normalizing Neural Networks](https://arxiv.org/abs/1706.02515)
  */
 export class AlphaDropout extends Layer {
   static className = 'AlphaDropout';


### PR DESCRIPTION
This fixes some references in the API docs mentioning input_shape when it should be inputShape. 

Reference: https://github.com/tensorflow/tfjs/issues/1448

Other formatting issues were also addressed in this commit. Some docstrings had unnecessary indentation and headings leading to some bulking rendering on the site where reference links aren't linked correctly. E.g. https://js.tensorflow.org/api/latest/#layers.gaussianDropout . This PR fixes those issues and makes the formatting consistent with other docstrings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/552)
<!-- Reviewable:end -->
