### PR TITLE
Switch K.dropout implementation to tfjs-core's dropout op

### DIFF
--- a/src/backend/tfjs_backend.ts
+++ b/src/backend/tfjs_backend.ts
@@ -13,7 +13,7 @@
  */
 
 import * as tfc from '@tensorflow/tfjs-core';
-import {onesLike as coreOnesLike, scalar, Tensor, Tensor1D, tensor1d, Tensor2D, Tensor3D, Tensor4D, tidy, util, where, zerosLike as coreZerosLike} from '@tensorflow/tfjs-core';
+import {onesLike as coreOnesLike, scalar, Tensor, Tensor1D, tensor1d, Tensor2D, Tensor3D, Tensor4D, tidy, where, zerosLike as coreZerosLike} from '@tensorflow/tfjs-core';
 import {checkDataFormat} from '../common';
 import {NotImplementedError, ValueError} from '../errors';
 import {DataFormat, Shape} from '../keras_format/common';
@@ -660,29 +660,13 @@ export function softsign(x: Tensor): Tensor {
  * @param x input tensor.
  * @param level fraction of the entries in the tensor that will be set to 0.
  * @param noiseShape shape of randomly generated keep/drop flags, must be
- *   broadcastable to the shape of `x`.
- * @param seed random seed to ensure determinism.
+ *   broadcastable to the shape of `x`. Optional
+ * @param seed random seed to ensure determinism. Optional
  * @returns Result of the dropout operation.
  */
 export function dropout(
     x: Tensor, level: number, noiseShape?: number[], seed?: number): Tensor {
-  return tidy(() => {
-    // TODO(cais): Switch to deeplearn.js implementation of dropout when it
-    //   becomes avaialable.
-    if (noiseShape != null && !util.arraysEqual(x.shape, noiseShape)) {
-      throw new NotImplementedError(
-          'Non-default noise shape is not implemented yet: ' +
-          JSON.stringify(noiseShape));
-    }
-    if (seed != null) {
-      throw new NotImplementedError('seed is not implemented for dropout yet.');
-    }
-    let multiplier =
-        tfc.step(tfc.add(-level, tfc.randomUniform(x.shape, 0, 1, 'float32')));
-    // Scale the kept elements, so the expected sum is unchanged.
-    multiplier = tfc.mul(1 / (1 - level), multiplier);
-    return tfc.mul(x, multiplier);
-  });
+  return tidy(() => tfc.dropout(x, level, noiseShape, seed));
 }
 
 /**

--- a/src/backend/tfjs_backend.ts
+++ b/src/backend/tfjs_backend.ts
@@ -660,8 +660,8 @@ export function softsign(x: Tensor): Tensor {
  * @param x input tensor.
  * @param level fraction of the entries in the tensor that will be set to 0.
  * @param noiseShape shape of randomly generated keep/drop flags, must be
- *   broadcastable to the shape of `x`. Optional
- * @param seed random seed to ensure determinism. Optional
+ *   broadcastable to the shape of `x`. Optional.
+ * @param seed random seed to ensure determinism. Optional.
  * @returns Result of the dropout operation.
  */
 export function dropout(

--- a/src/layers/recurrent_test.ts
+++ b/src/layers/recurrent_test.ts
@@ -583,16 +583,14 @@ describeMathCPUAndGPU('SimpleRNN Tensor', () => {
           kwargs['training'] = true;
         }
         const input = tfc.ones([batchSize, timeSteps, inputSize]);
-        spyOn(tfc, 'randomUniform').and.callThrough();
+        spyOn(tfc, 'dropout').and.callThrough();
         let numTensors = 0;
         for (let i = 0; i < 2; i++){
           tfc.dispose(simpleRNN.apply(input, kwargs) as Tensor);
           if (dropout !== 0.0 && training) {
-            expect(tfc.randomUniform).toHaveBeenCalledTimes(1  * (i + 1));
-            expect(tfc.randomUniform).toHaveBeenCalledWith(
-              [batchSize, inputSize], 0, 1, 'float32');
+            expect(tfc.dropout).toHaveBeenCalledTimes(1  * (i + 1));
           } else {
-            expect(tfc.randomUniform).toHaveBeenCalledTimes(0);
+            expect(tfc.dropout).toHaveBeenCalledTimes(0);
           }
           if (i === 0) {
             numTensors = tfc.memory().numTensors;
@@ -624,16 +622,14 @@ describeMathCPUAndGPU('SimpleRNN Tensor', () => {
           kwargs['training'] = true;
         }
         const input = tfc.ones([batchSize, timeSteps, inputSize]);
-        spyOn(tfc, 'randomUniform').and.callThrough();
+        spyOn(tfc, 'dropout').and.callThrough();
         let numTensors = 0;
         for (let i = 0; i < 2; i++){
           tfc.dispose(simpleRNN.apply(input, kwargs) as Tensor);
           if (recurrentDropout !== 0.0 && training) {
-            expect(tfc.randomUniform).toHaveBeenCalledTimes(1 * (i + 1));
-            expect(tfc.randomUniform).toHaveBeenCalledWith(
-              [batchSize, units], 0, 1, 'float32');
+            expect(tfc.dropout).toHaveBeenCalledTimes(1 * (i + 1));
           } else {
-              expect(tfc.randomUniform).toHaveBeenCalledTimes(0);
+              expect(tfc.dropout).toHaveBeenCalledTimes(0);
           }
           if (i === 0) {
             numTensors = tfc.memory().numTensors;
@@ -1192,16 +1188,14 @@ describeMathCPUAndGPU('GRU Tensor', () => {
           kwargs['training'] = true;
         }
         const input = tfc.ones([batchSize, timeSteps, inputSize]);
-        spyOn(tfc, 'randomUniform').and.callThrough();
+        spyOn(tfc, 'dropout').and.callThrough();
         let numTensors = 0;
         for (let i = 0; i < 2; i++){
           tfc.dispose(gru.apply(input, kwargs) as Tensor);
           if (dropout !== 0.0 && training) {
-            expect(tfc.randomUniform).toHaveBeenCalledTimes(3  * (i + 1));
-            expect(tfc.randomUniform).toHaveBeenCalledWith(
-              [batchSize, inputSize], 0, 1, 'float32');
+            expect(tfc.dropout).toHaveBeenCalledTimes(3  * (i + 1));
           } else {
-            expect(tfc.randomUniform).toHaveBeenCalledTimes(0);
+            expect(tfc.dropout).toHaveBeenCalledTimes(0);
           }
           if (i === 0) {
             numTensors = tfc.memory().numTensors;
@@ -1233,16 +1227,14 @@ describeMathCPUAndGPU('GRU Tensor', () => {
           kwargs['training'] = true;
         }
         const input = tfc.ones([batchSize, timeSteps, inputSize]);
-        spyOn(tfc, 'randomUniform').and.callThrough();
+        spyOn(tfc, 'dropout').and.callThrough();
         let numTensors = 0;
         for (let i = 0; i < 2; i++){
           tfc.dispose(gru.apply(input, kwargs) as Tensor);
           if (recurrentDropout !== 0.0 && training) {
-            expect(tfc.randomUniform).toHaveBeenCalledTimes(3 * (i + 1));
-            expect(tfc.randomUniform).toHaveBeenCalledWith(
-              [batchSize, units], 0, 1, 'float32');
+            expect(tfc.dropout).toHaveBeenCalledTimes(3 * (i + 1));
           } else {
-            expect(tfc.randomUniform).toHaveBeenCalledTimes(0);
+            expect(tfc.dropout).toHaveBeenCalledTimes(0);
           }
           if (i === 0) {
             numTensors = tfc.memory().numTensors;
@@ -1736,16 +1728,14 @@ describeMathCPUAndGPU('LSTM Tensor', () => {
           kwargs['training'] = true;
         }
         const input = tfc.ones([batchSize, timeSteps, inputSize]);
-        spyOn(tfc, 'randomUniform').and.callThrough();
+        spyOn(tfc, 'dropout').and.callThrough();
         let numTensors = 0;
         for (let i = 0; i < 2; i++){
           tfc.dispose(lstm.apply(input, kwargs) as Tensor);
           if (dropout !== 0.0 && training) {
-            expect(tfc.randomUniform).toHaveBeenCalledTimes(4 * (i + 1));
-            expect(tfc.randomUniform).toHaveBeenCalledWith(
-              [batchSize, inputSize], 0, 1, 'float32');
+            expect(tfc.dropout).toHaveBeenCalledTimes(4 * (i + 1));
           } else {
-            expect(tfc.randomUniform).toHaveBeenCalledTimes(0);
+            expect(tfc.dropout).toHaveBeenCalledTimes(0);
           }
           if (i === 0) {
             numTensors = tfc.memory().numTensors;
@@ -1777,16 +1767,14 @@ describeMathCPUAndGPU('LSTM Tensor', () => {
           kwargs['training'] = true;
         }
         const input = tfc.ones([batchSize, timeSteps, inputSize]);
-        spyOn(tfc, 'randomUniform').and.callThrough();
+        spyOn(tfc, 'dropout').and.callThrough();
         let numTensors = 0;
         for (let i = 0; i < 2; i++){
           tfc.dispose(lstm.apply(input, kwargs) as Tensor);
           if (recurrentDropout !== 0.0 && training) {
-            expect(tfc.randomUniform).toHaveBeenCalledTimes(4 * (i + 1));
-            expect(tfc.randomUniform).toHaveBeenCalledWith(
-              [batchSize, units], 0, 1, 'float32');
+            expect(tfc.dropout).toHaveBeenCalledTimes(4 * (i + 1));
           } else {
-            expect(tfc.randomUniform).toHaveBeenCalledTimes(0);
+            expect(tfc.dropout).toHaveBeenCalledTimes(0);
           }
           if (i === 0) {
             numTensors = tfc.memory().numTensors;


### PR DESCRIPTION
Change

This PR cleans up a TODO. As dropout op has been checked in through PR [tensorflow/tfjs-core#1343](https://github.com/tensorflow/tfjs-core/pull/1343) and released, this PR safely switches `K.dropout` implementation to tfjs-core's `dropout` op. The switch of `K.dropout` implementation would benefit further dropout op related development.

Some changes in switching:
* As `tfc.dropout` op would assert `NotImplementedError` for `noiseShape`, removed the assertion in `K.dropout`.
* As `seed` has already supported in `tf.randomUniform`, removed `NotImplementedError` for it.
* The test cases for `SimpleRNN Tensor`, `GRU Tensor`, `LSTM Tensor` spy on function `tfc.randomUniform` which is used in K.dropout before, as the implementation with `tfc.randomUniform` is gone, replaced spy on `tfc.randomUniform` with spy on `tfc.dropout` which has the same called times. 
* When RNN cell calling the `K.dropout`, it will create an anonymous Tensor, for example, [src/layers/recurrent.ts#L2563](https://github.com/tensorflow/tfjs-layers/blob/master/src/layers/recurrent.ts#L2563), we can not track it, so removed the `toHaveBeenCalledWith` check.

---
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/553)
<!-- Reviewable:end -->
