### PR TITLE
Add maxPooling3d layer & averagePooling3d layer

### DIFF
--- a/src/exports_layers.ts
+++ b/src/exports_layers.ts
@@ -19,7 +19,7 @@ import {Embedding, EmbeddingLayerArgs} from './layers/embeddings';
 import {Add, Average, Concatenate, ConcatenateLayerArgs, Dot, DotLayerArgs, Maximum, Minimum, Multiply} from './layers/merge';
 import {BatchNormalization, BatchNormalizationLayerArgs} from './layers/normalization';
 import {ZeroPadding2D, ZeroPadding2DLayerArgs} from './layers/padding';
-import {AveragePooling1D, AveragePooling2D, GlobalAveragePooling1D, GlobalAveragePooling2D, GlobalMaxPooling1D, GlobalMaxPooling2D, GlobalPooling2DLayerArgs, MaxPooling1D, MaxPooling2D, Pooling1DLayerArgs, Pooling2DLayerArgs} from './layers/pooling';
+import {AveragePooling1D, AveragePooling2D, AveragePooling3D, GlobalAveragePooling1D, GlobalAveragePooling2D, GlobalMaxPooling1D, GlobalMaxPooling2D, GlobalPooling2DLayerArgs, MaxPooling1D, MaxPooling2D, MaxPooling3D, Pooling1DLayerArgs, Pooling2DLayerArgs, Pooling3DLayerArgs} from './layers/pooling';
 import {GRU, GRUCell, GRUCellLayerArgs, GRULayerArgs, LSTM, LSTMCell, LSTMCellLayerArgs, LSTMLayerArgs, RNN, RNNCell, RNNLayerArgs, SimpleRNN, SimpleRNNCell, SimpleRNNCellLayerArgs, SimpleRNNLayerArgs, StackedRNNCells, StackedRNNCellsArgs} from './layers/recurrent';
 import {Bidirectional, BidirectionalLayerArgs, TimeDistributed, WrapperLayerArgs} from './layers/wrappers';
 import {GaussianNoiseArgs, GaussianNoise, GaussianDropoutArgs, GaussianDropout, AlphaDropoutArgs, AlphaDropout} from './layers/noise';
@@ -474,6 +474,26 @@ export function avgPooling2d(args: Pooling2DLayerArgs): Layer {
  *   heading: 'Layers',
  *   subheading: 'Pooling',
  *   namespace: 'layers',
+ *   useDocsFrom: 'AveragePooling3D'
+ * }
+ */
+export function averagePooling3d(args: Pooling3DLayerArgs): Layer {
+  return new AveragePooling3D(args);
+}
+export function avgPool3d(args: Pooling3DLayerArgs): Layer {
+  return averagePooling3d(args);
+}
+// For backwards compatibility.
+// See https://github.com/tensorflow/tfjs/issues/152
+export function avgPooling3d(args: Pooling3DLayerArgs): Layer {
+  return averagePooling3d(args);
+}
+
+/**
+ * @doc {
+ *   heading: 'Layers',
+ *   subheading: 'Pooling',
+ *   namespace: 'layers',
  *   useDocsFrom: 'GlobalAveragePooling1D'
  * }
  */
@@ -539,6 +559,18 @@ export function maxPooling1d(args: Pooling1DLayerArgs): Layer {
  */
 export function maxPooling2d(args: Pooling2DLayerArgs): Layer {
   return new MaxPooling2D(args);
+}
+
+/**
+ * @doc {
+ *   heading: 'Layers',
+ *   subheading: 'Pooling',
+ *   namespace: 'layers',
+ *   useDocsFrom: 'MaxPooling3D'
+ * }
+ */
+export function maxPooling3d(args: Pooling3DLayerArgs): Layer {
+  return new MaxPooling3D(args);
 }
 
 // Recurrent Layers.

--- a/src/exports_layers.ts
+++ b/src/exports_layers.ts
@@ -919,13 +919,25 @@ export function avgPooling2d(args: Pooling2DLayerArgs): Layer {
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Pooling',
- *   namespace: 'layers',
- *   useDocsFrom: 'AveragePooling3D'
- * }
+ * Average pooling operation for 3D data.
+ *
+ * Input shape
+ *   - If `dataFormat === channelsLast`:
+ *       5D tensor with shape:
+ *       `[batchSize, depths, rows, cols, channels]`
+ *   - If `dataFormat === channelsFirst`:
+ *      4D tensor with shape:
+ *       `[batchSize, channels, depths, rows, cols]`
+ *
+ * Output shape
+ *   - If `dataFormat=channelsLast`:
+ *       5D tensor with shape:
+ *       `[batchSize, pooledDepths, pooledRows, pooledCols, channels]`
+ *   - If `dataFormat=channelsFirst`:
+ *       5D tensor with shape:
+ *       `[batchSize, channels, pooledDepths, pooledRows, pooledCols]`
  */
+/** @doc {heading: 'Layers', subheading: 'Pooling', namespace: 'layers'} */
 export function averagePooling3d(args: Pooling3DLayerArgs): Layer {
   return new AveragePooling3D(args);
 }
@@ -1033,13 +1045,25 @@ export function maxPooling2d(args: Pooling2DLayerArgs): Layer {
 }
 
 /**
- * @doc {
- *   heading: 'Layers',
- *   subheading: 'Pooling',
- *   namespace: 'layers',
- *   useDocsFrom: 'MaxPooling3D'
- * }
+ * Max pooling operation for 3D data.
+ *
+ * Input shape
+ *   - If `dataFormat === channelsLast`:
+ *       5D tensor with shape:
+ *       `[batchSize, depths, rows, cols, channels]`
+ *   - If `dataFormat === channelsFirst`:
+ *      5D tensor with shape:
+ *       `[batchSize, channels, depths, rows, cols]`
+ *
+ * Output shape
+ *   - If `dataFormat=channelsLast`:
+ *       5D tensor with shape:
+ *       `[batchSize, pooledDepths, pooledRows, pooledCols, channels]`
+ *   - If `dataFormat=channelsFirst`:
+ *       5D tensor with shape:
+ *       `[batchSize, channels, pooledDepths, pooledRows, pooledCols]`
  */
+/** @doc {heading: 'Layers', subheading: 'Pooling', namespace: 'layers'} */
 export function maxPooling3d(args: Pooling3DLayerArgs): Layer {
   return new MaxPooling3D(args);
 }

--- a/src/layers/pooling.ts
+++ b/src/layers/pooling.ts
@@ -532,25 +532,6 @@ export abstract class Pooling3D extends Layer {
   }
 }
 
-/**
- * Max pooling operation for 3D data.
- *
- * Input shape
- *   - If `dataFormat === channelsLast`:
- *       5D tensor with shape:
- *       `[batchSize, depths, rows, cols, channels]`
- *   - If `dataFormat === channelsFirst`:
- *      5D tensor with shape:
- *       `[batchSize, channels, depths, rows, cols]`
- *
- * Output shape
- *   - If `dataFormat=channelsLast`:
- *       5D tensor with shape:
- *       `[batchSize, pooledDepths, pooledRows, pooledCols, channels]`
- *   - If `dataFormat=channelsFirst`:
- *       5D tensor with shape:
- *       `[batchSize, channels, pooledDepths, pooledRows, pooledCols]`
- */
 export class MaxPooling3D extends Pooling3D {
   /** @nocollapse */
   static className = 'MaxPooling3D';
@@ -570,25 +551,6 @@ export class MaxPooling3D extends Pooling3D {
 }
 serialization.registerClass(MaxPooling3D);
 
-/**
- * Average pooling operation for 3D data.
- *
- * Input shape
- *   - If `dataFormat === channelsLast`:
- *       5D tensor with shape:
- *       `[batchSize, depths, rows, cols, channels]`
- *   - If `dataFormat === channelsFirst`:
- *      4D tensor with shape:
- *       `[batchSize, channels, depths, rows, cols]`
- *
- * Output shape
- *   - If `dataFormat=channelsLast`:
- *       5D tensor with shape:
- *       `[batchSize, pooledDepths, pooledRows, pooledCols, channels]`
- *   - If `dataFormat=channelsFirst`:
- *       5D tensor with shape:
- *       `[batchSize, channels, pooledDepths, pooledRows, pooledCols]`
- */
 export class AveragePooling3D extends Pooling3D {
   /** @nocollapse */
   static className = 'AveragePooling3D';

--- a/src/layers/pooling.ts
+++ b/src/layers/pooling.ts
@@ -13,7 +13,7 @@
  */
 
 import * as tfc from '@tensorflow/tfjs-core';
-import {serialization, Tensor, Tensor3D, Tensor4D, tidy} from '@tensorflow/tfjs-core';
+import {serialization, Tensor, Tensor3D, Tensor4D, Tensor5D, tidy} from '@tensorflow/tfjs-core';
 
 import {imageDataFormat} from '../backend/common';
 import * as K from '../backend/tfjs_backend';
@@ -27,7 +27,7 @@ import {convOutputLength} from '../utils/conv_utils';
 import {assertPositiveInteger} from '../utils/generic_utils';
 import {getExactlyOneShape, getExactlyOneTensor} from '../utils/types_utils';
 
-import {preprocessConv2DInput} from './convolutional';
+import {preprocessConv2DInput, preprocessConv3DInput} from './convolutional';
 
 /**
  * 2D pooling.
@@ -82,6 +82,52 @@ export function pool2d(
   });
 }
 
+/**
+ * 3D pooling.
+ * @param x
+ * @param poolSize. Default to [1, 1, 1].
+ * @param strides strides. Defaults to [1, 1, 1].
+ * @param padding padding. Defaults to 'valid'.
+ * @param dataFormat data format. Defaults to 'channelsLast'.
+ * @param poolMode Mode of pooling. Defaults to 'max'.
+ * @returns Result of the 3D pooling.
+ */
+export function pool3d(
+    x: Tensor5D, poolSize: [number, number, number],
+    strides?: [number, number, number], padding?: PaddingMode,
+    dataFormat?: DataFormat, poolMode?: PoolMode): Tensor {
+  return tidy(() => {
+    checkDataFormat(dataFormat);
+    checkPoolMode(poolMode);
+    checkPaddingMode(padding);
+    if (strides == null) {
+      strides = [1, 1, 1];
+    }
+    if (padding == null) {
+      padding = 'valid';
+    }
+    if (dataFormat == null) {
+      dataFormat = imageDataFormat();
+    }
+    if (poolMode == null) {
+      poolMode = 'max';
+    }
+
+    // x is NDHWC after preprocessing.
+    x = preprocessConv3DInput(x as Tensor, dataFormat) as Tensor5D;
+    let y: Tensor;
+    const paddingString = (padding === 'same') ? 'same' : 'valid';
+    if (poolMode === 'max') {
+      y = tfc.maxPool3d(x, poolSize, strides, paddingString);
+    } else {  // 'avg'
+      y = tfc.avgPool3d(x, poolSize, strides, paddingString);
+    }
+    if (dataFormat === 'channelsFirst') {
+      y = tfc.transpose(y, [0, 4, 1, 2, 3]);  // NDHWC -> NCDHW.
+    }
+    return y;
+  });
+}
 
 export declare interface Pooling1DLayerArgs extends LayerArgs {
   /**
@@ -425,6 +471,198 @@ export class AveragePooling2D extends Pooling2D {
   }
 }
 serialization.registerClass(AveragePooling2D);
+
+export declare interface Pooling3DLayerArgs extends LayerArgs {
+  /**
+   * Factors by which to downscale in each dimension [depth, height, width].
+   * Expects an integer or an array of 3 integers.
+   *
+   * For example, `[2, 2, 2]` will halve the input in three dimensions.
+   * If only one integer is specified, the same window length
+   * will be used for all dimensions.
+   */
+  poolSize?: number|[number, number, number];
+
+  /**
+   * The size of the stride in each dimension of the pooling window. Expects
+   * an integer or an array of 3 integers. Integer, tuple of 3 integers, or
+   * None.
+   *
+   * If `null`, defaults to `poolSize`.
+   */
+  strides?: number|[number, number, number];
+
+  /** The padding type to use for the pooling layer. */
+  padding?: PaddingMode;
+  /** The data format to use for the pooling layer. */
+  dataFormat?: DataFormat;
+}
+
+/**
+ * Abstract class for different pooling 3D layers.
+ */
+export abstract class Pooling3D extends Layer {
+  protected readonly poolSize: [number, number, number];
+  protected readonly strides: [number, number, number];
+  protected readonly padding: PaddingMode;
+  protected readonly dataFormat: DataFormat;
+
+  constructor(args: Pooling3DLayerArgs) {
+    if (args.poolSize == null) {
+      args.poolSize = [2, 2, 2];
+    }
+    super(args);
+    this.poolSize = Array.isArray(args.poolSize) ?
+        args.poolSize :
+        [args.poolSize, args.poolSize, args.poolSize];
+    if (args.strides == null) {
+      this.strides = this.poolSize;
+    } else if (Array.isArray(args.strides)) {
+      if (args.strides.length !== 3) {
+        throw new ValueError(
+            `If the strides property of a 3D pooling layer is an Array, ` +
+            `it is expected to have a length of 3, but received length ` +
+            `${args.strides.length}.`);
+      }
+      this.strides = args.strides;
+    } else {
+      // `config.strides` is a number.
+      this.strides = [args.strides, args.strides, args.strides];
+    }
+    assertPositiveInteger(this.poolSize, 'poolSize');
+    assertPositiveInteger(this.strides, 'strides');
+    this.padding = args.padding == null ? 'valid' : args.padding;
+    this.dataFormat =
+        args.dataFormat == null ? 'channelsLast' : args.dataFormat;
+    checkDataFormat(this.dataFormat);
+    checkPaddingMode(this.padding);
+
+    this.inputSpec = [new InputSpec({ndim: 5})];
+  }
+
+  computeOutputShape(inputShape: Shape|Shape[]): Shape|Shape[] {
+    inputShape = getExactlyOneShape(inputShape);
+    let depths =
+        this.dataFormat === 'channelsFirst' ? inputShape[2] : inputShape[1];
+    let rows =
+        this.dataFormat === 'channelsFirst' ? inputShape[3] : inputShape[2];
+    let cols =
+        this.dataFormat === 'channelsFirst' ? inputShape[4] : inputShape[3];
+    depths = convOutputLength(
+        depths, this.poolSize[0], this.padding, this.strides[0]);
+    rows = convOutputLength(
+        rows, this.poolSize[1], this.padding, this.strides[1]);
+    cols = convOutputLength(
+        cols, this.poolSize[2], this.padding, this.strides[2]);
+    if (this.dataFormat === 'channelsFirst') {
+      return [inputShape[0], inputShape[1], depths, rows, cols];
+    } else {
+      return [inputShape[0], depths, rows, cols, inputShape[4]];
+    }
+  }
+
+  protected abstract poolingFunction(
+      inputs: Tensor, poolSize: [number, number, number],
+      strides: [number, number, number], padding: PaddingMode,
+      dataFormat: DataFormat): Tensor;
+
+  call(inputs: Tensor|Tensor[], kwargs: Kwargs): Tensor|Tensor[] {
+    return tidy(() => {
+      this.invokeCallHook(inputs, kwargs);
+      return this.poolingFunction(
+          getExactlyOneTensor(inputs), this.poolSize, this.strides,
+          this.padding, this.dataFormat);
+    });
+  }
+
+  getConfig(): serialization.ConfigDict {
+    const config = {
+      poolSize: this.poolSize,
+      padding: this.padding,
+      strides: this.strides,
+      dataFormat: this.dataFormat
+    };
+    const baseConfig = super.getConfig();
+    Object.assign(config, baseConfig);
+    return config;
+  }
+}
+
+/**
+ * Max pooling operation for 3D data.
+ *
+ * Input shape
+ *   - If `dataFormat === channelsLast`:
+ *       5D tensor with shape:
+ *       `[batchSize, depths, rows, cols, channels]`
+ *   - If `dataFormat === channelsFirst`:
+ *      5D tensor with shape:
+ *       `[batchSize, channels, depths, rows, cols]`
+ *
+ * Output shape
+ *   - If `dataFormat=channelsLast`:
+ *       5D tensor with shape:
+ *       `[batchSize, pooledDepths, pooledRows, pooledCols, channels]`
+ *   - If `dataFormat=channelsFirst`:
+ *       5D tensor with shape:
+ *       `[batchSize, channels, pooledDepths, pooledRows, pooledCols]`
+ */
+export class MaxPooling3D extends Pooling3D {
+  /** @nocollapse */
+  static className = 'MaxPooling3D';
+  constructor(args: Pooling3DLayerArgs) {
+    super(args);
+  }
+
+  protected poolingFunction(
+      inputs: Tensor, poolSize: [number, number, number],
+      strides: [number, number, number], padding: PaddingMode,
+      dataFormat: DataFormat): Tensor {
+    checkDataFormat(dataFormat);
+    checkPaddingMode(padding);
+    return pool3d(
+        inputs as Tensor5D, poolSize, strides, padding, dataFormat, 'max');
+  }
+}
+serialization.registerClass(MaxPooling3D);
+
+/**
+ * Average pooling operation for 3D data.
+ *
+ * Input shape
+ *   - If `dataFormat === channelsLast`:
+ *       5D tensor with shape:
+ *       `[batchSize, depths, rows, cols, channels]`
+ *   - If `dataFormat === channelsFirst`:
+ *      4D tensor with shape:
+ *       `[batchSize, channels, depths, rows, cols]`
+ *
+ * Output shape
+ *   - If `dataFormat=channelsLast`:
+ *       5D tensor with shape:
+ *       `[batchSize, pooledDepths, pooledRows, pooledCols, channels]`
+ *   - If `dataFormat=channelsFirst`:
+ *       5D tensor with shape:
+ *       `[batchSize, channels, pooledDepths, pooledRows, pooledCols]`
+ */
+export class AveragePooling3D extends Pooling3D {
+  /** @nocollapse */
+  static className = 'AveragePooling3D';
+  constructor(args: Pooling3DLayerArgs) {
+    super(args);
+  }
+
+  protected poolingFunction(
+      inputs: Tensor, poolSize: [number, number, number],
+      strides: [number, number, number], padding: PaddingMode,
+      dataFormat: DataFormat): Tensor {
+    checkDataFormat(dataFormat);
+    checkPaddingMode(padding);
+    return pool3d(
+        inputs as Tensor5D, poolSize, strides, padding, dataFormat, 'avg');
+  }
+}
+serialization.registerClass(AveragePooling3D);
 
 /**
  * Abstract class for different global pooling 1D layers.

--- a/src/layers/pooling.ts
+++ b/src/layers/pooling.ts
@@ -494,10 +494,10 @@ export abstract class Pooling3D extends Layer {
         this.dataFormat === 'channelsFirst' ? inputShape[4] : inputShape[3];
     depths = convOutputLength(
         depths, this.poolSize[0], this.padding, this.strides[0]);
-    rows = convOutputLength(
-        rows, this.poolSize[1], this.padding, this.strides[1]);
-    cols = convOutputLength(
-        cols, this.poolSize[2], this.padding, this.strides[2]);
+    rows =
+        convOutputLength(rows, this.poolSize[1], this.padding, this.strides[1]);
+    cols =
+        convOutputLength(cols, this.poolSize[2], this.padding, this.strides[2]);
     if (this.dataFormat === 'channelsFirst') {
       return [inputShape[0], inputShape[1], depths, rows, cols];
     } else {

--- a/src/layers/pooling_test.ts
+++ b/src/layers/pooling_test.ts
@@ -13,7 +13,7 @@
  */
 
 import * as tfc from '@tensorflow/tfjs-core';
-import {Tensor, tensor2d, Tensor2D, tensor3d, tensor4d, Tensor4D, util} from '@tensorflow/tfjs-core';
+import {Tensor, tensor2d, Tensor2D, tensor3d, tensor4d, tensor5d, Tensor4D, Tensor5D, util} from '@tensorflow/tfjs-core';
 
 import {SymbolicTensor} from '../engine/topology';
 import * as tfl from '../index';
@@ -21,7 +21,7 @@ import {DataFormat, PaddingMode, PoolMode} from '../keras_format/common';
 import {convOutputLength} from '../utils/conv_utils';
 import {describeMathCPUAndGPU, expectTensorsClose} from '../utils/test_utils';
 
-import {pool2d} from './pooling';
+import {pool2d, pool3d} from './pooling';
 
 describeMathCPUAndGPU('pool2d', () => {
   const x4by4Data = [[[
@@ -113,6 +113,148 @@ describeMathCPUAndGPU('pool2d', () => {
       const y =
           pool2d(x5by5, [2, 2], [2, 2], 'valid', 'channelsLast', poolMode);
       expectTensorsClose(y, tfc.transpose(yExpected, [0, 2, 3, 1]));
+    });
+  }
+});
+
+describeMathCPUAndGPU('pool3d', () => {
+  const x4by4by4Data = [[[
+    [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]],
+    [[17, 18, 19, 20], [21, 22, 23, 24], [25, 26, 27, 28], [19, 30, 31, 32]],
+    [[33 ,34, 35 ,36], [37, 38, 39, 40], [41, 42, 43, 44], [45, 46, 47, 48]],
+    [[49, 50, 51, 52], [53, 54, 55, 56], [57, 58, 59, 60], [61, 62, 63 ,64]]
+  ]]];
+  const x5by5by5Data = [[[
+    [
+      [1, 2, 3, 4, 5], [6, 7, 8, 9, 10], [11, 12, 13, 14, 15],
+      [16, 17, 18, 19, 20], [21, 22, 23, 24, 25]
+    ], [
+      [26, 27, 28, 29, 30], [31, 32, 33, 34, 35], [36, 37, 38, 39, 40],
+      [41, 42, 43, 44, 45], [46, 47, 48, 49, 50]
+    ], [
+      [51, 52, 53, 54, 55], [56, 57, 58, 59, 60], [61, 62, 63, 64, 65],
+      [66, 67, 68, 69, 70], [71, 72, 73, 74, 75]
+    ], [
+      [76, 77, 78, 79, 80], [81, 82, 83, 84, 85], [86, 87, 88, 89, 90],
+      [91, 92, 93, 94, 95], [96, 97, 98, 99, 100]
+    ], [
+      [101, 102, 103, 104, 105], [106, 107, 108, 109, 110],
+      [111, 112, 113, 114, 115], [116, 117, 118, 119, 120],
+      [121, 122, 123, 124, 125]
+    ]
+  ]]];
+
+  const poolModes: PoolMode[] = [undefined, 'max', 'avg'];
+  const dataFormats: DataFormat[] =
+      [undefined, 'channelsFirst', 'channelsLast'];
+  const stridesArray = [1, 2];
+  for (const poolMode of poolModes) {
+    for (const dataFormat of dataFormats) {
+      for (const stride of stridesArray) {
+        const testTitle = `4x4x4, ${stride}, same, ${dataFormat}, ` +
+            `${poolMode}`;
+        it(testTitle, () => {
+          let x: Tensor5D = tensor5d(x4by4by4Data, [1, 1, 4, 4, 4]);
+          if (dataFormat !== 'channelsFirst') {
+            x = tfc.transpose(x, [0, 2, 3, 4, 1]);  // NDHWC -> NCDHW.
+          }
+          let yExpected: Tensor5D;
+          if (poolMode === 'avg') {
+            if (stride === 1) {
+              yExpected = tensor5d(
+                  [[[
+                    [
+                      [11.5, 12.5, 13.5, 14], [15.5, 16.5, 17.5, 18],
+                      [18.25, 20.5, 21.5, 22], [19, 22.5, 23.5, 24]
+                    ], [
+                      [27.5, 28.5, 29.5, 30], [31.5, 32.5, 33.5, 34],
+                      [34.25, 36.5, 37.5, 38], [35, 38.5, 39.5, 40]
+                    ], [
+                      [43.5, 44.5, 45.5, 46], [47.5, 48.5, 49.5, 50],
+                      [51.5, 52.5, 53.5, 54], [53.5, 54.5, 55.5, 56]
+                    ], [
+                      [51.5, 52.5, 53.5, 54], [55.5, 56.5, 57.5, 58],
+                      [59.5, 60.5, 61.5, 62], [61.5, 62.5, 63.5, 64]]
+                  ]]],
+                  [1, 1, 4, 4, 4]);
+            } else {
+              yExpected = tensor5d([[[[[11.5, 13.5], [18.25, 21.5]],
+                    [[43.5, 45.5], [51.5, 53.5]]]]], [1, 1, 2, 2, 2]);
+            }
+          } else {
+            if (stride === 1) {
+              yExpected = tensor5d(
+                  [[[
+                    [
+                      [22, 23, 24, 24], [26, 27, 28, 28],
+                      [30, 31, 32, 32], [30, 31, 32, 32]
+                    ], [
+                      [38, 39, 40, 40], [42, 43, 44, 44],
+                      [46, 47, 48, 48], [46, 47, 48, 48]
+                    ], [
+                      [54, 55, 56, 56], [58, 59, 60, 60],
+                      [62, 63, 64, 64], [62, 63, 64, 64]
+                    ], [
+                      [54, 55, 56, 56], [58, 59, 60, 60],
+                      [62, 63, 64, 64], [62, 63, 64, 64]]
+                  ]]], [1, 1, 4, 4, 4]);
+            } else if (stride === 2) {
+              yExpected =
+                  tensor5d([[[[[22, 24], [30, 32]], [[54, 56], [62, 64]]]]],
+                      [1, 1, 2, 2, 2]);
+            }
+          }
+          if (dataFormat !== 'channelsFirst') {
+            yExpected = tfc.transpose(yExpected, [0, 2, 3, 4, 1]);
+          }
+          const y = pool3d(x, [2, 2, 2], [stride, stride, stride], 'same',
+              dataFormat, poolMode);
+          expectTensorsClose(y, yExpected as Tensor);
+        });
+      }
+    }
+  }
+
+  for (const poolMode of poolModes) {
+    it(`5x5x5, 2, same, CHANNEL_FIRST, ${poolMode}`, () => {
+      const x5by5by5 = tensor5d(x5by5by5Data, [1, 1, 5, 5, 5]);
+      let yExpected: Tensor5D;
+      if (poolMode === 'avg') {
+        yExpected = tensor5d([[[
+          [[16.5, 18.5, 20], [26.5, 28.5, 30], [34, 36, 37.5]],
+          [[66.5, 68.5, 70], [76.5, 78.5, 80], [84, 86, 87.5]],
+          [[104, 106, 107.5], [114, 116, 117.5], [121.5, 123.5, 125]]
+        ]]], [1, 1, 3, 3, 3]);
+      } else {
+        yExpected = tensor5d([[[
+          [[32, 34, 35], [42, 44, 45], [47, 49, 50]],
+          [[82, 84, 85], [92, 94, 95], [97, 99, 100]],
+          [[107, 109, 110], [117, 119, 120], [122, 124, 125]]
+        ]]], [1, 1, 3, 3, 3]);
+      }
+      const y = pool3d(x5by5by5, [2, 2, 2], [2, 2, 2], 'same', 'channelsFirst',
+          poolMode);
+      expectTensorsClose(y, yExpected as Tensor);
+    });
+  }
+
+  for (const poolMode of poolModes) {
+    it(`5x5x5, 2, valid, CHANNEL_LAST, ${poolMode}`, () => {
+      const x5by5by5 = tfc.transpose(
+          tensor5d(x5by5by5Data, [1, 1, 5, 5, 5]), [0, 2, 3, 4, 1]);
+      let yExpected: Tensor5D;
+      if (poolMode === 'avg') {
+        yExpected = tensor5d(
+            [[[[[16.5, 18.5], [26.5, 28.5]], [[66.5, 68.5], [76.5, 78.5]]]]],
+            [1, 1, 2, 2, 2]);
+      } else {
+        yExpected = tensor5d(
+            [[[[[32, 34], [42, 44]], [[82, 84], [92, 94]]]]],
+            [1, 1, 2, 2, 2]);
+      }
+      const y = pool3d(x5by5by5, [2, 2, 2], [2, 2, 2], 'valid', 'channelsLast',
+          poolMode);
+      expectTensorsClose(y, tfc.transpose(yExpected, [0, 2, 3, 4, 1]));
     });
   }
 });
@@ -437,6 +579,222 @@ describeMathCPUAndGPU('Pooling Layers 2D: Tensor', () => {
     expect(config['poolSize']).toEqual([2, 2]);
     expect(config['strides']).toEqual([2, 2]);
   });
+});
+
+describe('Pooling Layers 3D: Symbolic', () => {
+  const poolSizes = [2, 3];
+  const poolModes = ['avg', 'max'];
+  const paddingModes: PaddingMode[] = [undefined, 'valid', 'same'];
+  const dataFormats: DataFormat[] = ['channelsFirst', 'channelsLast'];
+  const poolSizeIsNumberValues = [false, true];
+
+  for (const poolMode of poolModes) {
+    for (const paddingMode of paddingModes) {
+      for (const dataFormat of dataFormats) {
+        for (const poolSize of poolSizes) {
+          for (const poolSizeIsNumber of poolSizeIsNumberValues) {
+            const testTitle = `poolSize=${poolSize}, ` +
+                `${dataFormat}, ${paddingMode}, ` +
+                `${poolMode}, ` +
+                `poollSizeIsNumber=${poolSizeIsNumber}`;
+            it(testTitle, () => {
+              const inputShape = dataFormat === 'channelsFirst' ?
+                  [2, 16, 11, 9, 7] :
+                  [2, 11, 9, 7, 16];
+              const symbolicInput =
+                  new SymbolicTensor('float32', inputShape, null, [], null);
+
+              const poolConstructor = poolMode === 'avg' ?
+                  tfl.layers.averagePooling3d :
+                  tfl.layers.maxPooling3d;
+              const poolingLayer = poolConstructor({
+                poolSize: poolSizeIsNumber ? poolSize :
+                    [poolSize, poolSize, poolSize],
+                padding: paddingMode,
+                dataFormat,
+              });
+
+              const output =
+                  poolingLayer.apply(symbolicInput) as SymbolicTensor;
+
+              let outputDepths = poolSize === 2 ? 5: 3;
+              if (paddingMode === 'same') {
+                outputDepths++;
+              }
+
+              let outputRows = poolSize === 2 ? 4 : 3;
+              if (paddingMode === 'same' && poolSize === 2) {
+                outputRows++;
+              }
+              let outputCols = poolSize === 2 ? 3 : 2;
+              if (paddingMode === 'same') {
+                outputCols++;
+              }
+
+              let expectedShape: [number, number, number, number, number];
+              if (dataFormat === 'channelsFirst') {
+                expectedShape = [2, 16, outputDepths, outputRows, outputCols];
+              } else {
+                expectedShape = [2, outputDepths, outputRows, outputCols, 16];
+              }
+
+              expect(output.shape).toEqual(expectedShape);
+              expect(output.dtype).toEqual(symbolicInput.dtype);
+            });
+          }
+        }
+      }
+    }
+  }
+
+  const stridesValues: Array<number|[number, number, number]> =
+      [1, [1, 1, 1], [2, 1, 2]];
+  for (const strides of stridesValues) {
+    it(`custom strides: ${strides}`, () => {
+      const inputShape = [2, 16, 11, 15, 3];
+      const symbolicInput =
+          new SymbolicTensor('float32', inputShape, null, [], null);
+      const poolingLayer =
+          tfl.layers.maxPooling3d({poolSize: [2, 2, 2], strides});
+      const output = poolingLayer.apply(symbolicInput) as tfl.SymbolicTensor;
+      if (Array.isArray(strides) && util.arraysEqual(strides, [1, 1, 1])) {
+        expect(output.shape).toEqual([2, 15, 10, 14, 3]);
+      } else if (Array.isArray(strides) &&
+          util.arraysEqual(strides, [2, 1, 2])) {
+        expect(output.shape).toEqual([2, 8, 10, 7, 3]);
+      } else {
+        // strides = 1
+        expect(output.shape).toEqual([2, 15, 10, 14, 3]);
+      }
+    });
+  }
+
+  it('Incorrect strides array length leads to error', () => {
+    // tslint:disable-next-line:no-any
+    expect(() => tfl.layers.maxPooling3d({poolSize: 2, strides: [2]} as any))
+        .toThrowError(/expected to have a length of 3/);
+    expect(
+        // tslint:disable-next-line:no-any
+        () => tfl.layers.maxPooling3d({poolSize: 2, strides: [2, 3]} as any))
+        .toThrowError(/expected to have a length of 3/);
+    expect(() => tfl.layers.averagePooling3d(
+        // tslint:disable-next-line:no-any
+        {poolSize: 2, strides: [2]} as any))
+        .toThrowError(/expected to have a length of 3/);
+    expect(() => tfl.layers.averagePooling3d(
+            // tslint:disable-next-line:no-any
+            {poolSize: 2, strides: [2, 3]} as any))
+        .toThrowError(/expected to have a length of 3/);
+  });
+
+  it('Invalid poolSize', () => {
+    expect(() => tfl.layers.maxPooling3d({poolSize: 2.5, strides: 2}))
+        .toThrowError(/poolSize.*positive integer.*2\.5\.$/);
+    expect(() => tfl.layers.maxPooling3d({poolSize: 0, strides: 2}))
+        .toThrowError(/poolSize.*positive integer.*0\.$/);
+    expect(() => tfl.layers.maxPooling3d({poolSize: -2, strides: 2}))
+        .toThrowError(/poolSize.*positive integer.*-2\.$/);
+    expect(() => tfl.layers.averagePooling3d({poolSize: 2.5, strides: 2}))
+        .toThrowError(/poolSize.*positive integer.*2\.5\.$/);
+    expect(() => tfl.layers.averagePooling3d({poolSize: 0, strides: 2}))
+        .toThrowError(/poolSize.*positive integer.*0\.$/);
+    expect(() => tfl.layers.averagePooling3d({poolSize: -2, strides: 2}))
+        .toThrowError(/poolSize.*positive integer.*-2\.$/);
+  });
+
+  it('Invalid strides leads to Error', () => {
+    expect(() => tfl.layers.maxPooling3d({poolSize: 3, strides: 2.5}))
+        .toThrowError(/strides.*positive integer.*2\.5\.$/);
+    expect(() => tfl.layers.maxPooling3d({poolSize: 3, strides: 0}))
+        .toThrowError(/strides.*positive integer.*0\.$/);
+    expect(() => tfl.layers.maxPooling3d({poolSize: 3, strides: -2}))
+        .toThrowError(/strides.*positive integer.*-2\.$/);
+    expect(() => tfl.layers.averagePooling3d({poolSize: 3, strides: 2.5}))
+        .toThrowError(/strides.*positive integer.*2\.5\.$/);
+    expect(() => tfl.layers.averagePooling3d({poolSize: 3, strides: 0}))
+        .toThrowError(/strides.*positive integer.*0\.$/);
+    expect(() => tfl.layers.averagePooling3d({poolSize: 3, strides: -2}))
+        .toThrowError(/strides.*positive integer.*-2\.$/);
+  });
+});
+
+describeMathCPUAndGPU('Pooling Layers 3D: Tensor', () => {
+  const x4by4by4Data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+        16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33,
+        34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51,
+        52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64];
+
+  const poolModes: PoolMode[] = ['avg', 'max'];
+  const strides = [1, 2];
+  const batchSizes = [2, 4];
+  const channelsArray = [1, 3];
+  for (const poolMode of poolModes) {
+    for (const stride of strides) {
+      for (const batchSize of batchSizes) {
+        for (const channels of channelsArray) {
+          const testTitle = `stride=${stride}, ${poolMode}, ` +
+              `batchSize=${batchSize}, channels=${channels}`;
+          it(testTitle, () => {
+            let xArrayData: number[] = [];
+            for (let b = 0; b < batchSize; ++b) {
+              for (let c = 0; c < channels; ++c) {
+                xArrayData = xArrayData.concat(x4by4by4Data);
+              }
+            }
+            const x4by4by4 =
+                tensor5d(xArrayData, [batchSize, channels, 4, 4, 4]);
+
+            const poolConstructor = poolMode === 'avg' ?
+                tfl.layers.averagePooling3d :
+                tfl.layers.maxPooling3d;
+            const poolingLayer = poolConstructor({
+              poolSize: [2, 2, 2],
+              strides: [stride, stride, stride],
+              padding: 'valid',
+              dataFormat: 'channelsFirst',
+            });
+
+            const output = poolingLayer.apply(x4by4by4 as Tensor) as Tensor;
+
+            let expectedShape: [number, number, number, number, number];
+            let expectedOutputSlice: number[];
+            if (poolMode === 'avg') {
+              if (stride === 1) {
+                expectedShape = [batchSize, channels, 3, 3, 3];
+                expectedOutputSlice = [11.5, 12.5, 13.5, 15.5, 16.5, 17.5,
+                  19.5, 20.5, 21.5, 27.5, 28.5, 29.5, 31.5, 32.5, 33.5, 35.5,
+                  36.5, 37.5, 43.5, 44.5, 45.5, 47.5, 48.5, 49.5, 51.5, 52.5,
+                  53.5];
+              } else if (stride === 2) {
+                expectedShape = [batchSize, channels, 2, 2, 2];
+                expectedOutputSlice =
+                    [11.5, 13.5, 19.5, 21.5, 43.5, 45.5, 51.5, 53.5];
+              }
+            } else {
+              if (stride === 1) {
+                expectedShape = [batchSize, channels, 3, 3, 3];
+                expectedOutputSlice = [22, 23, 24, 26, 27, 28, 30, 31, 32, 38,
+                  39, 40, 42, 43, 44, 46, 47, 48, 54, 55, 56, 58, 59, 60, 62,
+                  63, 64];
+              } else if (stride === 2) {
+                expectedShape = [batchSize, channels, 2, 2, 2];
+                expectedOutputSlice = [22, 24, 30, 32, 54, 56, 62, 64];
+              }
+            }
+            let expectedOutputArray: number[] = [];
+            for (let b = 0; b < batchSize; ++b) {
+              for (let c = 0; c < channels; ++c) {
+                expectedOutputArray =
+                    expectedOutputArray.concat(expectedOutputSlice);
+              }
+            }
+            expectTensorsClose(output,
+                tensor5d(expectedOutputArray, expectedShape) as Tensor);
+          });
+        }
+      }
+    }
+  }
 });
 
 describe('1D Global pooling Layers: Symbolic', () => {


### PR DESCRIPTION
This PR adds `averagePooling3d` layer & `maxPooling3d` layer(feature requested in [tensorflow/tfjs#1035](https://github.com/tensorflow/tfjs/issues/1035)).

Features in this PR:
* Add `pool3d` function to compute 3D pooling
* Add relative tests for `pool3d` function
* Add `Pooling3DLayerArgs` interface  
* Add abstract `Pooling3D` class
* Add `MaxPooling3D` class
* Add `AveragePooling3D` class
* Export `averagePooling3d` layer
* Add relative tests for `averagePooling3d` layer
* Export `maxPooling3d` layer
* Add relative tests for `maxPooling3d` layer

 **Note:**

This PR depends on PR [tensorflow/tfjs-core#1778](https://github.com/tensorflow/tfjs-core/pull/1778), which adds `maxPool3d` op, `avgPool3d` op, and exports `Tensor5D` type.

**Reference:**
* [Keras AveragePooling3D layer](https://keras.io/layers/pooling/)
* [Keras MaxPooling3D layer](https://keras.io/layers/pooling/)
---
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/555)
<!-- Reviewable:end -->
