### PR TITLE
Add non-default noiseShape and seed support to dropout layer

### DIFF
--- a/src/backend/tfjs_backend_test.ts
+++ b/src/backend/tfjs_backend_test.ts
@@ -776,17 +776,9 @@ describeMathCPUAndGPU('dropout', () => {
     const y = K.dropout(x, level, null, seed);
     expect(y.dtype).toEqual(x.dtype);
     expect(y.shape).toEqual(x.shape);
-    const xValue = x.dataSync();
-    const yValue = y.dataSync();
-    let nKept = 0;
-    for (let i = 0; i < xValue.length; ++i) {
-      if (yValue[i] !== 0) {
-        nKept++;
-        expect(yValue[i]).toBeCloseTo(1 / (1 - level) * xValue[i]);
-      }
-    }
-    const numel = K.countParams(x);
-    expect(nKept).toBeLessThan(numel);
+    const yValuesExpected =
+        [0, 0, 12, 16, 0, 0, 0, 0, 0, 0, 0, 48, 52, 0, 0, 0, 68, 0, 76, 0];
+    expectTensorsClose(y, tensor2d(yValuesExpected, [10, 2]));
   });
 });
 

--- a/src/backend/tfjs_backend_test.ts
+++ b/src/backend/tfjs_backend_test.ts
@@ -742,6 +742,57 @@ describeMathCPUAndGPU('dropout', () => {
       }
     });
   }
+
+  it('Level=0.75, with noiseShape', () => {
+    const x = tensor2d(range(1, 21), [10, 2]);
+    const level = 0.75;
+    const noiseShape = [10, 1];
+    const y = K.dropout(x, level, noiseShape);
+    expect(y.dtype).toEqual(x.dtype);
+    expect(y.shape).toEqual(x.shape);
+    const xValue = x.dataSync();
+    const yValue = y.dataSync();
+    let nKept = 0;
+    for (let i = 0; i < xValue.length; ++i) {
+      if (yValue[i] !== 0) {
+        nKept++;
+        expect(yValue[i]).toBeCloseTo(1 / (1 - level) * xValue[i]);
+      }
+    }
+    for (let i = 0; i < x.shape[0]; i++) {
+      const maskedValue = yValue[i * x.shape[1]];
+      for (let j = 0; j < x.shape[1]; j++) {
+        const indice = i * x.shape[1] + j;
+        if (maskedValue !== 0) {
+          expect(yValue[indice]).toBeCloseTo(1 / (1 - level) * xValue[indice]);
+        } else {
+          expect(yValue[indice]).toEqual(0);
+        }
+      }
+    }
+    const numel = K.countParams(x);
+    expect(nKept).toBeLessThan(numel);
+  });
+
+  it('Level=0.75, with seed', () => {
+    const x = tensor2d(range(1, 21), [10, 2]);
+    const level = 0.75;
+    const seed = 23;
+    const y = K.dropout(x, level, null, seed);
+    expect(y.dtype).toEqual(x.dtype);
+    expect(y.shape).toEqual(x.shape);
+    const xValue = x.dataSync();
+    const yValue = y.dataSync();
+    let nKept = 0;
+    for (let i = 0; i < xValue.length; ++i) {
+      if (yValue[i] !== 0) {
+        nKept++;
+        expect(yValue[i]).toBeCloseTo(1 / (1 - level) * xValue[i]);
+      }
+    }
+    const numel = K.countParams(x);
+    expect(nKept).toBeLessThan(numel);
+  });
 });
 
 describeMathCPUAndGPU('biasAdd', () => {

--- a/src/backend/tfjs_backend_test.ts
+++ b/src/backend/tfjs_backend_test.ts
@@ -753,17 +753,12 @@ describeMathCPUAndGPU('dropout', () => {
     const xValue = x.dataSync();
     const yValue = y.dataSync();
     let nKept = 0;
-    for (let i = 0; i < xValue.length; ++i) {
-      if (yValue[i] !== 0) {
-        nKept++;
-        expect(yValue[i]).toBeCloseTo(1 / (1 - level) * xValue[i]);
-      }
-    }
     for (let i = 0; i < x.shape[0]; i++) {
       const maskedValue = yValue[i * x.shape[1]];
       for (let j = 0; j < x.shape[1]; j++) {
         const indice = i * x.shape[1] + j;
         if (maskedValue !== 0) {
+          nKept++;
           expect(yValue[indice]).toBeCloseTo(1 / (1 - level) * xValue[indice]);
         } else {
           expect(yValue[indice]).toEqual(0);

--- a/src/layers/core.ts
+++ b/src/layers/core.ts
@@ -18,7 +18,7 @@ import {Activation as ActivationFn, getActivation, serializeActivation} from '..
 import * as K from '../backend/tfjs_backend';
 import {Constraint, ConstraintIdentifier, getConstraint, serializeConstraint} from '../constraints';
 import {DisposeResult, InputSpec, Layer, LayerArgs} from '../engine/topology';
-import {NotImplementedError, ValueError} from '../errors';
+import {ValueError} from '../errors';
 import {getInitializer, Initializer, InitializerIdentifier, serializeInitializer} from '../initializers';
 import {ActivationIdentifier} from '../keras_format/activation_config';
 import {Shape} from '../keras_format/common';
@@ -69,11 +69,6 @@ export class Dropout extends Layer {
     // So that the scalar doesn't get tidied up between executions.
     this.noiseShape = args.noiseShape;
     this.seed = args.seed;
-    if (this.seed != null) {
-      throw new NotImplementedError(
-          'Non-default seed is not implemented in Dropout layer yet: ' +
-          this.seed);
-    }
     this.supportsMasking = true;
   }
 
@@ -94,12 +89,6 @@ export class Dropout extends Layer {
     return tidy(() => {
       this.invokeCallHook(inputs, kwargs);
       const input = getExactlyOneTensor(inputs);
-      if (this.noiseShape != null &&
-          !util.arraysEqual(input.shape, this.noiseShape)) {
-        throw new NotImplementedError(
-            'Non-default noise shape is not implemented in Dropout ' +
-            'layer yet: ' + JSON.stringify(this.noiseShape));
-      }
       if (0 < this.rate && this.rate < 1) {
         const training =
             kwargs['training'] == null ? false : kwargs['training'];

--- a/src/layers/core_test.ts
+++ b/src/layers/core_test.ts
@@ -70,7 +70,7 @@ describeMathCPUAndGPU('Dropout Layer', () => {
               const xValue = x.dataSync();
               const yValue = y.dataSync();
               let nKept = 0;
-              if (noiseShape === noiseShapes[2]) { // customized noiseShape
+              if (noiseShape === noiseShapes[2]) {  // customized noiseShape
                 for (let i = 0; i < x.shape[0]; ++i) {
                   for (let j = 0; j < x.shape[1]; ++j) {
                     const maskedValue =
@@ -92,7 +92,7 @@ describeMathCPUAndGPU('Dropout Layer', () => {
                     }
                   }
                 }
-              } else { // default noiseShape
+              } else {  // default noiseShape
                 for (let i = 0; i < xValue.length; ++i) {
                   if (yValue[i] !== 0) {
                     nKept++;


### PR DESCRIPTION
This PR makes dropout layer support non-default `noiseShape` and `seed`, adds relative tests for these feature in `dropout` layer and backend's `dropout` op.

The `noiseShape` feature in `dropout` layer would benefit further development, for example, `SpatialDropout2D` layer, feature requested in [tensorflow/tfjs#1453](https://github.com/tensorflow/tfjs/issues/1453). Send this PR to ensure there won't be any broken change for further `noiseShape` related features.

**Note:**
This PR depends on [tensorflow/tfjs-core#1782](https://github.com/tensorflow/tfjs-core/pull/1782), which makes dropout op support non-default `noiseShape`.

---
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/556)
<!-- Reviewable:end -->
