### PR TITLE
Remove `updatable` flag (dead code elimination)

### DIFF
--- a/src/engine/container.ts
+++ b/src/engine/container.ts
@@ -88,7 +88,6 @@ export abstract class Container extends Layer {
 
     this.supportsMasking = false;
     this.trainable_ = true;
-    this.updatable = true;
 
     // TODO(michaelterry): Initialize perInputLosses/Updates here.
 

--- a/src/engine/topology.ts
+++ b/src/engine/topology.ts
@@ -372,10 +372,8 @@ export declare interface LayerArgs {
   dtype?: DataType;
   /** Name for this layer. */
   name?: string;
-  /** Whether this layer is trainable. Defaults to true. */
+  /** Whether the weights of this layer are updatable by `fit`. Defaults to true.  */
   trainable?: boolean;
-  /** Whether the weights of this layer are updatable by `fit`. */
-  updatable?: boolean;
   /**
    * Initial weight values of the layer.
    */
@@ -414,7 +412,6 @@ export abstract class Layer extends serialization.Serializable {
   supportsMasking: boolean;
   /** Whether the layer weights will be updated during training. */
   protected trainable_: boolean;
-  updatable: boolean;
   batchInputShape: Shape;
   dtype: DataType;
   initialWeights: Tensor[];
@@ -482,7 +479,6 @@ export abstract class Layer extends serialization.Serializable {
     this.name = name;
 
     this.trainable_ = args.trainable == null ? true : args.trainable;
-    this.updatable = args.updatable == null ? true : args.updatable;
 
     if (args.inputShape != null || args.batchInputShape != null) {
       /*

--- a/src/engine/topology.ts
+++ b/src/engine/topology.ts
@@ -372,7 +372,10 @@ export declare interface LayerArgs {
   dtype?: DataType;
   /** Name for this layer. */
   name?: string;
-  /** Whether the weights of this layer are updatable by `fit`. Defaults to true.  */
+  /**
+   * Whether the weights of this layer are updatable by `fit`.
+   * Defaults to true.
+   */
   trainable?: boolean;
   /**
    * Initial weight values of the layer.

--- a/src/keras_format/topology_config.ts
+++ b/src/keras_format/topology_config.ts
@@ -22,7 +22,6 @@ export interface LayerConfig extends PyJsonDict {
   dtype?: DataType;
   name?: string;
   trainable?: boolean;
-  updatable?: boolean;
   input_dtype?: DataType;
 }
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -358,13 +358,11 @@ export class Sequential extends LayersModel {
   /** @nocollapse */
   static className = 'Sequential';
   private model: LayersModel;
-  private _updatable: boolean;
   constructor(args?: SequentialArgs) {
     super({inputs: [], outputs: []});
     args = args || {};
 
     this.trainable = true;
-    this._updatable = true;
     this.built = false;
 
     // Set model name.
@@ -564,7 +562,6 @@ export class Sequential extends LayersModel {
       name: this.name + '_model'
     });
     this.model.trainable = this.trainable;
-    this.model.updatable = this.updatable;
 
     // mirror model attributes
     this.supportsMasking = this.model.supportsMasking;
@@ -642,17 +639,6 @@ export class Sequential extends LayersModel {
       this.build();
     }
     this.model.setWeights(weights);
-  }
-
-  get updatable(): boolean {
-    return this._updatable;
-  }
-
-  set updatable(value: boolean) {
-    if (this.built) {
-      this.model.updatable = value;
-    }
-    this._updatable = value;
   }
 
   /**


### PR DESCRIPTION
Based on the following twitter discussion, the removal of the `updatable` flag was devised:

> Yeah, `updatable` seems to be unused and should be removed. Thanks for pinging us about it.
> https://twitter.com/sqcai/status/1141735803506368512

The correct flag to use for the purpose `updatable` was assigned was the `trainable` flag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/560)
<!-- Reviewable:end -->
