### PR TITLE
fix CamelCase for sigmoidCrossentropyWithLogits

### DIFF
--- a/src/losses.ts
+++ b/src/losses.ts
@@ -167,7 +167,7 @@ export function sparseCategoricalCrossentropy(
  * @param labels The labels.
  * @param logits The logits.
  */
-export function sigmoidCrossEntropyWithLogits(
+export function sigmoidCrossentropyWithLogits(
     labels: Tensor, logits: Tensor): Tensor {
   if (!util.arraysEqual(labels.shape, logits.shape)) {
     throw new ValueError(
@@ -187,12 +187,16 @@ export function sigmoidCrossEntropyWithLogits(
   });
 }
 
+// TODO(bileschi): This symbol was misspelled, but as it is part of the public
+// 1.x.x API it must remain until tfjs 2.0.0
+export const sigmoidCrossEntropyWithLogits = sigmoidCrossentropyWithLogits;
+
 export function binaryCrossentropy(yTrue: Tensor, yPred: Tensor): Tensor {
   return tidy(() => {
     let y: Tensor;
     y = tfc.clipByValue(yPred, epsilon(), 1 - epsilon());
     y = tfc.log(tfc.div(y, tfc.sub(1, y)));
-    return tfc.mean(sigmoidCrossEntropyWithLogits(yTrue, y), -1);
+    return tfc.mean(sigmoidCrossentropyWithLogits(yTrue, y), -1);
   });
 }
 
@@ -264,7 +268,7 @@ export function get(identifierOrFn: string|LossOrMetricFn): LossOrMetricFn {
     if (identifierOrFn.toLowerCase().includes('softmaxcrossentropy')) {
       errMsg = `Unknown loss ${identifierOrFn}. ` +
           'Use "categoricalCrossentropy" as the string name for ' +
-          'tf.losses.softmaxCrossEntropy';
+          'tf.losses.softmaxCrossentropy';
     }
     throw new ValueError(errMsg);
   } else {

--- a/src/losses_test.ts
+++ b/src/losses_test.ts
@@ -251,7 +251,7 @@ describeMathCPUAndGPU('sigmoidCrossEntropyWithLogits', () => {
     const expected = tfc.add(
         tfc.mul(target, tfc.neg(tfc.log(sigmoidX))),
         tfc.mul(targetComplement, tfc.neg(tfc.log(sigmoidXComplement))));
-    const result = losses.sigmoidCrossEntropyWithLogits(target, x);
+    const result = losses.sigmoidCrossentropyWithLogits(target, x);
     expectTensorsClose(result, expected);
   });
 
@@ -281,7 +281,7 @@ describeMathCPUAndGPU('sigmoidCrossEntropyWithLogits', () => {
         [[-10, -10, -10], [-5, -5, -5], [0, 0, 0], [0.5, 0.5, 0.5], [2, 2, 2]]);
     const labels = tensor2d(
         [[0, 0.5, 1], [0, 0.5, 1], [0, 0.5, 1], [0, 0.5, 1], [0, 0.5, 1]]);
-    const outputs = losses.sigmoidCrossEntropyWithLogits(labels, logits);
+    const outputs = losses.sigmoidCrossentropyWithLogits(labels, logits);
     expectTensorsClose(outputs, tensor2d([
                          [4.5398901e-05, 5.0000453e+00, 1.0000046e+01],
                          [6.7153485e-03, 2.5067153e+00, 5.0067153e+00],
@@ -426,7 +426,7 @@ describeMathCPUAndGPU('l2Normalize', () => {
     const result = losses.l2Normalize(x);
     expectTensorsClose(result, x);
   });
-  
+
   it('normalizes casts int32 as float32.', () => {
     const x = tensor2d([[1, 2], [3, 4]], [2, 2], 'int32');
     const norm = Math.sqrt(1 * 1 + 2 * 2 + 3 * 3 + 4 * 4);
@@ -435,12 +435,11 @@ describeMathCPUAndGPU('l2Normalize', () => {
     const result = losses.l2Normalize(x);
     expectTensorsClose(result, expected);
   });
-  
+
   it('normalizes casts bool as float32.', () => {
     const x = tensor2d([[1, 1]], [1, 2], 'bool');
     const norm = Math.sqrt(1 * 1 + 1 * 1);
-    const expected =
-        tensor2d([[1 / norm, 1 / norm]], [1, 2]);
+    const expected = tensor2d([[1 / norm, 1 / norm]], [1, 2]);
     const result = losses.l2Normalize(x);
     expectTensorsClose(result, expected);
   });


### PR DESCRIPTION
Fixes bad CamelCasing for sigmoidCrossEntropyWithLogits -> sigmoidCrossentropyWithLogits 

Motivated by but does not fix https://github.com/tensorflow/tfjs/issues/1743

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/565)
<!-- Reviewable:end -->
