### PR TITLE
create entry for miniprogram for package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "module": "dist/tf-layers.esm.js",
   "jsdelivr": "dist/tf-layers.min.js",
   "unpkg": "dist/tf-layers.min.js",
+  "miniprogram": "dist/miniprogram",
   "devDependencies": {
     "@tensorflow/tfjs-core": "1.2.3",
     "@types/jasmine": "~2.5.53",

--- a/scripts/build-npm.sh
+++ b/scripts/build-npm.sh
@@ -21,5 +21,11 @@ rimraf dist/
 yarn
 yarn build
 rollup -c
+
+# Use minified files for miniprogram
+mkdir dist/miniprogram
+cp dist/tf-layers.min.js dist/miniprogram/index.js
+cp dist/tf-layers.min.js.map dist/miniprogram/index.js.map
+
 echo "Stored standalone library at dist/tf-layers(.min).js"
 npm pack


### PR DESCRIPTION
Wechat mini app has a size limit, and their minification can not reduce the size as good as ours.
create a dist/miniprogram directory and copy the minified version of tf-layers there.

https://github.com/tensorflow/tfjs-wechat/issues/13

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/567)
<!-- Reviewable:end -->
