### PR TITLE
Add support for user-defined metadata; Simplify fromMemory() usage

### DIFF
--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -1890,8 +1890,8 @@ export class LayersModel extends Container implements tfc.InferenceModel {
    *
    * The metadata is supplied via one of the two routes:
    *   1. By calling `setUserDefinedMetadata()`.
-   *   2. Loaded during model loading (if the model is constructed)
-   *      by `tf.loadLayersModel()`.
+   *   2. Loaded during model loading (if the model is constructed
+   *      via `tf.loadLayersModel()`.)
    *
    * If no user-defined metadata is available from either of the
    * two routes, this function will return `undefined`.

--- a/src/model_save_test.ts
+++ b/src/model_save_test.ts
@@ -290,9 +290,7 @@ describeMathGPU('Save-load round trips', () => {
 
     const getInitSpy = spyOn(initializers, 'getInitializer').and.callThrough();
     const gramSchmidtSpy = spyOn(linalg, 'gramSchmidt').and.callThrough();
-    const modelPrime = await tfl.loadLayersModel(io.fromMemory(
-        savedArtifacts.modelTopology, savedArtifacts.weightSpecs,
-        savedArtifacts.weightData));
+    const modelPrime = await tfl.loadLayersModel(io.fromMemory(savedArtifacts));
     const weightsPrime = modelPrime.getWeights();
     expect(weightsPrime.length).toEqual(weights.length);
     for (let i = 0; i < weights.length; ++i) {
@@ -321,9 +319,7 @@ describeMathGPU('Save-load round trips', () => {
 
     const getInitSpy = spyOn(initializers, 'getInitializer').and.callThrough();
     const gramSchmidtSpy = spyOn(linalg, 'gramSchmidt').and.callThrough();
-    const modelPrime = await tfl.loadLayersModel(io.fromMemory(
-        savedArtifacts.modelTopology, savedArtifacts.weightSpecs,
-        savedArtifacts.weightData));
+    const modelPrime = await tfl.loadLayersModel(io.fromMemory(savedArtifacts));
     const weightsPrime = modelPrime.getWeights();
     expect(weightsPrime.length).toEqual(weights.length);
     for (let i = 0; i < weights.length; ++i) {
@@ -357,9 +353,7 @@ describeMathGPU('Save-load round trips', () => {
 
     const getInitSpy = spyOn(initializers, 'getInitializer').and.callThrough();
     const gramSchmidtSpy = spyOn(linalg, 'gramSchmidt').and.callThrough();
-    const modelPrime = await tfl.loadLayersModel(io.fromMemory(
-        savedArtifacts.modelTopology, savedArtifacts.weightSpecs,
-        savedArtifacts.weightData));
+    const modelPrime = await tfl.loadLayersModel(io.fromMemory(savedArtifacts));
     const weightsPrime = modelPrime.getWeights();
     expect(weightsPrime.length).toEqual(weights.length);
     for (let i = 0; i < weights.length; ++i) {
@@ -395,9 +389,7 @@ describeMathGPU('Save-load round trips', () => {
 
     const getInitSpy = spyOn(initializers, 'getInitializer').and.callThrough();
     const gramSchmidtSpy = spyOn(linalg, 'gramSchmidt').and.callThrough();
-    const modelPrime = await tfl.loadLayersModel(io.fromMemory(
-        savedArtifacts.modelTopology, savedArtifacts.weightSpecs,
-        savedArtifacts.weightData));
+    const modelPrime = await tfl.loadLayersModel(io.fromMemory(savedArtifacts));
     const weightsPrime = modelPrime.getWeights();
     expect(weightsPrime.length).toEqual(weights.length);
     for (let i = 0; i < weights.length; ++i) {
@@ -452,10 +444,7 @@ describeMathGPU('Save-load round trips', () => {
     const gramSchmidtSpy = spyOn(linalg, 'gramSchmidt').and.callThrough();
     const strict = false;
     const modelPrime = await tfl.loadLayersModel(
-        io.fromMemory(
-            savedArtifacts.modelTopology, savedArtifacts.weightSpecs,
-            savedArtifacts.weightData),
-        {strict});
+        io.fromMemory(savedArtifacts), {strict});
     const weightsPrime = modelPrime.getWeights();
     expect(weightsPrime.length).toEqual(weights.length);
     expectTensorsClose(weightsPrime[0], weights[0]);
@@ -486,10 +475,7 @@ describeMathGPU('Save-load round trips', () => {
     const gramSchmidtSpy = spyOn(linalg, 'gramSchmidt').and.callThrough();
     const strict = false;
     const modelPrime = await tfl.loadLayersModel(
-        io.fromMemory(
-            savedArtifacts.modelTopology, savedArtifacts.weightSpecs,
-            savedArtifacts.weightData),
-        {strict});
+        io.fromMemory(savedArtifacts), {strict});
     const weightsPrime = modelPrime.getWeights();
     expect(weightsPrime.length).toEqual(weights.length);
     expectTensorsClose(weightsPrime[0], weights[0]);

--- a/src/models.ts
+++ b/src/models.ts
@@ -306,6 +306,9 @@ export async function loadLayersModelFromIOHandler(
   if (trainingConfig != null) {
     model.loadTrainingConfig(trainingConfig);
   }
+  if (artifacts.userDefinedMetadata != null) {
+    model.setUserDefinedMetadata(artifacts.userDefinedMetadata);
+  }
 
   // If weightData is present, load the weights into the model.
   if (artifacts.weightData != null) {

--- a/src/models.ts
+++ b/src/models.ts
@@ -84,9 +84,12 @@ export async function modelFromJSON(
   const model = deserialize(tsConfig, customObjects) as LayersModel;
 
   if (modelAndWeightsConfig.weightsManifest != null) {
+    console.log('modelFromJSON(): loading weights');  // DEBUG
     // Load the weight values keyed by the original tensor names in the model
     // file that was loaded.  These should match the keys of the weight
     // manifest.
+    console.log(`weightsManifest = ${
+        JSON.stringify(modelAndWeightsConfig.weightsManifest)}`);  // DEBUG
     const weightValues =
         await io.loadWeights(
             modelAndWeightsConfig.weightsManifest,

--- a/src/models.ts
+++ b/src/models.ts
@@ -84,12 +84,9 @@ export async function modelFromJSON(
   const model = deserialize(tsConfig, customObjects) as LayersModel;
 
   if (modelAndWeightsConfig.weightsManifest != null) {
-    console.log('modelFromJSON(): loading weights');  // DEBUG
     // Load the weight values keyed by the original tensor names in the model
     // file that was loaded.  These should match the keys of the weight
     // manifest.
-    console.log(`weightsManifest = ${
-        JSON.stringify(modelAndWeightsConfig.weightsManifest)}`);  // DEBUG
     const weightValues =
         await io.loadWeights(
             modelAndWeightsConfig.weightsManifest,

--- a/src/models_test.ts
+++ b/src/models_test.ts
@@ -557,10 +557,8 @@ describeMathCPU('loadLayersModel from URL', () => {
                           }));
       };
 
-  // const isModelConfigNestedValues = [false, true];
-  // const pathPrefixes = ['.', './', './model-home', './model-home/'];
-  const isModelConfigNestedValues = [false];
-  const pathPrefixes = ['.'];
+  const isModelConfigNestedValues = [false, true];
+  const pathPrefixes = ['.', './', './model-home', './model-home/'];
   for (const isModelConfigNested of isModelConfigNestedValues) {
     for (const pathPrefix of pathPrefixes) {
       it(`pathPrefix=${pathPrefix}`, done => {
@@ -699,7 +697,6 @@ describeMathCPU('loadLayersModel from URL', () => {
               ones([32, 32], 'float32').dataSync() as Float32Array,
               {'headers': {'Content-Type': OCTET_STREAM_TYPE}}));
         } else if (path === 'model/weight_1') {
-          console.log('Responding to model/weights_1');
           resolve(new Response(
               zeros([32], 'float32').dataSync() as Float32Array,
               {'headers': {'Content-Type': OCTET_STREAM_TYPE}}));

--- a/src/models_test.ts
+++ b/src/models_test.ts
@@ -551,7 +551,6 @@ describeMathCPU('loadLayersModel from URL', () => {
            {[filename: string]: Float32Array|Int32Array|ArrayBuffer}) => {
         spyOn(util, 'fetch')
             .and.callFake((path: string) => new Promise(resolve => {
-                            console.warn('In fake fetch');  // DEBUG
                             resolve(new Response(fileBufferMap[path], {
                               'headers': {'Content-Type': OCTET_STREAM_TYPE}
                             }));
@@ -565,14 +564,12 @@ describeMathCPU('loadLayersModel from URL', () => {
   for (const isModelConfigNested of isModelConfigNestedValues) {
     for (const pathPrefix of pathPrefixes) {
       it(`pathPrefix=${pathPrefix}`, done => {
-        console.log('=== BEGIN ===');
         const path0 = pathPrefix.endsWith('/') ? `${pathPrefix}weight_0` :
                                                  `${pathPrefix}/weight_0`;
         const path1 = pathPrefix.endsWith('/') ? `${pathPrefix}weight_1` :
                                                  `${pathPrefix}/weight_1`;
         const fileBufferMap:
             {[filename: string]: Float32Array|Int32Array|ArrayBuffer} = {};
-        console.log(`path0 = ${path0}; path1 = ${path1}`);  // DEBUG
         fileBufferMap[path0] =
             ones([32, 32], 'float32').dataSync() as Float32Array;
         fileBufferMap[path1] = ones([32], 'float32').dataSync() as Float32Array;
@@ -692,7 +689,6 @@ describeMathCPU('loadLayersModel from URL', () => {
     ];
 
     spyOn(util, 'fetch').and.callFake((path: string) => {
-      console.log('In spy fetch');  // DEBUG
       return new Promise((resolve, reject) => {
         if (path === 'model/model.json') {
           resolve(new Response(
@@ -702,10 +698,6 @@ describeMathCPU('loadLayersModel from URL', () => {
               }),
               {'headers': {'Content-Type': JSON_TYPE}}));
         } else if (path === 'model/weight_0') {
-          console.log('Responding to model/weights_0');  // DEBUG
-          const response0ByteLength = (
-              ones([32, 32], 'float32').dataSync() as Float32Array).byteLength;
-          console.log(`response0ByteLength = ${response0ByteLength}`);  // DEBUG
           resolve(new Response(
               ones([32, 32], 'float32').dataSync() as Float32Array,
               {'headers': {'Content-Type': OCTET_STREAM_TYPE}}));

--- a/src/models_test.ts
+++ b/src/models_test.ts
@@ -595,7 +595,6 @@ describeMathCPU('loadLayersModel from URL', () => {
             }],
           }
         ];
-        console.log('=== 100 ===');
         // JSON.parse and stringify to deep copy fakeSequentialModel.
         let modelTopology =
             JSON.parse(JSON.stringify(fakeSequentialModel)).modelTopology;
@@ -605,10 +604,8 @@ describeMathCPU('loadLayersModel from URL', () => {
           // `model_config`, but also other data, such as training.
           modelTopology = {'model_config': modelTopology};
         }
-        console.log('=== 200 ===');
         modelFromJSON({modelTopology, weightsManifest, pathPrefix})
             .then(model => {
-              console.log('=== 300 ===');
               expectTensorsClose(
                   model.weights[0].read(), ones([32, 32], 'float32'));
               expectTensorsClose(

--- a/src/user_defined_metadata.ts
+++ b/src/user_defined_metadata.ts
@@ -65,7 +65,6 @@ export function plainObjectCheck(x: any, assertObject = true): boolean {
     // Note: typeof `null` is 'object', and `null` is valid in JSON.
     return !assertObject;
   } else if (typeof x === 'object') {
-    // console.log('typeof x is object');  // DEBUG
     if (Object.getPrototypeOf(x) === Object.prototype) {
       const keys = Object.keys(x);
       for (const key of keys) {
@@ -73,7 +72,6 @@ export function plainObjectCheck(x: any, assertObject = true): boolean {
           // JSON keys must be strings.
           return false;
         }
-        // console.log(`key = ${key}`);  // DEBUG
         // Recursive call.
         if (!plainObjectCheck(x[key], false /* assertObject */)) {
           return false;
@@ -85,7 +83,6 @@ export function plainObjectCheck(x: any, assertObject = true): boolean {
     } else {
       if (Array.isArray(x)) {
         for (const item of x) {
-          // console.log(`item = ${item}`);  // DEBUG
           // Recursive call.
           if (!plainObjectCheck(item, false /* assertObject */)) {
             return false;

--- a/src/user_defined_metadata.ts
+++ b/src/user_defined_metadata.ts
@@ -40,9 +40,9 @@ export function checkUserDefinedMetadata(
       console.warn(
           `User-defined metadata of model "${modelName}" is too large in ` +
           `size (length=${out.length} when serialized). It is not ` +
-          `recommended to store such large objects in user-defined metadata.` +
+          `recommended to store such large objects in user-defined metadata. ` +
           `Please make sure its serialized length is <= ` +
-          `${MAX_USER_DEFINED_METADATA_SERIALIZED_LENGTH}`);
+          `${MAX_USER_DEFINED_METADATA_SERIALIZED_LENGTH}.`);
     }
   }
 }

--- a/src/user_defined_metadata.ts
+++ b/src/user_defined_metadata.ts
@@ -1,0 +1,105 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ * =============================================================================
+ */
+
+/** Utility functions related to user-defined metadata. */
+
+// Maximum recommended serialized size for user-defined metadata.
+// Beyond this limit, a warning message will be printed during model loading and
+// saving.
+export const MAX_USER_DEFINED_METADATA_SERIALIZED_LENGTH = 1 * 1024 * 1024;
+
+/**
+ * Check validity of user-defined metadata.
+ *
+ * @param userDefinedMetadata
+ * @param modelName Name of the model that the user-defined metadata belongs to.
+ *   Used during construction of error messages.
+ * @param checkSize Whether to check the size of the metadata is under
+ *   recommended limit. Default: `false`. If `true`, will try stringify the
+ *   JSON object and print a console warning if the serialzied size is above the
+ *   limit.
+ * @throws Error if `userDefinedMetadata` is not a plain JSON object.
+ */
+export function checkUserDefinedMetadata(
+    userDefinedMetadata: {}, modelName: string, checkSize = false): void {
+  if (!plainObjectCheck(userDefinedMetadata)) {
+    throw new Error(
+        'User-defined metadata is expected to be a JSON object, but is not.');
+  }
+
+  if (checkSize) {
+    const out = JSON.stringify(userDefinedMetadata);
+    if (out.length > MAX_USER_DEFINED_METADATA_SERIALIZED_LENGTH) {
+      console.warn(
+          `User-defined metadata of model "${modelName}" is too large in ` +
+          `size (length=${out.length} when serialized). It is not ` +
+          `recommended to store such large objects in user-defined metadata.` +
+          `Please make sure its serialized length is <= ` +
+          `${MAX_USER_DEFINED_METADATA_SERIALIZED_LENGTH}`);
+    }
+  }
+}
+
+/**
+ * Check if an input is plain JSON.
+ *
+ * @param x The input to be checked.
+ * @param assertObject Whether to assert `x` is a JSON object, i.e., reject
+ *   cases of arrays and primitives.
+ * @return If `assertObject` is `true`, returns `true` if and only if `x`
+ *   is a plain JSON object. If `assertObject` is `false`, returns `true`
+ *   if and only if `x` is a plain JSON object, a JSON-valid primitive
+ *   including string, number, boolean and null, or an array of the said
+ *   types.
+ */
+// tslint:disable-next-line:no-any
+export function plainObjectCheck(x: any, assertObject = true): boolean {
+  if (x === null) {
+    // Note: typeof `null` is 'object', and `null` is valid in JSON.
+    return !assertObject;
+  } else if (typeof x === 'object') {
+    // console.log('typeof x is object');  // DEBUG
+    if (Object.getPrototypeOf(x) === Object.prototype) {
+      const keys = Object.keys(x);
+      for (const key of keys) {
+        if (typeof key !== 'string') {
+          // JSON keys must be strings.
+          return false;
+        }
+        // console.log(`key = ${key}`);  // DEBUG
+        // Recursive call.
+        if (!plainObjectCheck(x[key], false /* assertObject */)) {
+          return false;
+        }
+      }
+      return true;
+    } else if (assertObject) {
+      return false;
+    } else {
+      if (Array.isArray(x)) {
+        for (const item of x) {
+          // console.log(`item = ${item}`);  // DEBUG
+          // Recursive call.
+          if (!plainObjectCheck(item, false /* assertObject */)) {
+            return false;
+          }
+        }
+        return true;
+      } else {
+        return false;
+      }
+    }
+  } else if (assertObject) {
+    return false;
+  } else {
+    const xType = typeof x;
+    return xType === 'string' || xType === 'number' || xType === 'boolean';
+  }
+}

--- a/src/user_defined_metadata.ts
+++ b/src/user_defined_metadata.ts
@@ -67,6 +67,7 @@ export function plainObjectCheck(x: any): boolean {
     return true;
   } else if (typeof x === 'object') {
     if (Object.getPrototypeOf(x) === Object.prototype) {
+      // `x` is a JavaScript object and its prototype is Object.
       const keys = Object.keys(x);
       for (const key of keys) {
         if (typeof key !== 'string') {
@@ -79,7 +80,9 @@ export function plainObjectCheck(x: any): boolean {
       }
       return true;
     } else {
+      // `x` is a JavaScript object but its prototype is not Object.
       if (Array.isArray(x)) {
+        // `x` is a JavaScript array.
         for (const item of x) {
           if (!plainObjectCheck(item)) {  // Recursive call.
             return false;
@@ -87,10 +90,14 @@ export function plainObjectCheck(x: any): boolean {
         }
         return true;
       } else {
+        // `x` is a JavaScript object and its prototype is not Object,
+        // and it's not an Array. I.e., it's a complex object such as
+        // `Error` and `Date`.
         return false;
       }
     }
   } else {
+    // `x` is not a JavaScript object or `null`.
     const xType = typeof x;
     return xType === 'string' || xType === 'number' || xType === 'boolean';
   }

--- a/src/user_defined_metadata_test.ts
+++ b/src/user_defined_metadata_test.ts
@@ -15,28 +15,20 @@ import {Sequential} from './models';
 import {plainObjectCheck, MAX_USER_DEFINED_METADATA_SERIALIZED_LENGTH} from './user_defined_metadata';
 
 describe('plainObjectCheck', () => {
-  it('Primitives under assertObject = default true', () => {
-    expect(plainObjectCheck(undefined)).toEqual(false);
-    expect(plainObjectCheck(null)).toEqual(false);
-    expect(plainObjectCheck(true)).toEqual(false);
-    expect(plainObjectCheck(1337)).toEqual(false);
-    expect(plainObjectCheck('foo')).toEqual(false);
-  });
-  it('Primitives under assertObject = false', () => {
-    const assertObject = false;
+  it('Primitives', () => {
     // `undefined` is not valid JSON.
-    expect(plainObjectCheck(undefined, assertObject)).toEqual(false);
-    expect(plainObjectCheck(null, assertObject)).toEqual(true);
-    expect(plainObjectCheck(true, assertObject)).toEqual(true);
-    expect(plainObjectCheck(1337, assertObject)).toEqual(true);
-    expect(plainObjectCheck('foo', assertObject)).toEqual(true);
+    expect(plainObjectCheck(undefined)).toEqual(false);
+    // `null` is valid JSON.
+    expect(plainObjectCheck(null)).toEqual(true);
+    expect(plainObjectCheck(true)).toEqual(true);
+    expect(plainObjectCheck(1337)).toEqual(true);
+    expect(plainObjectCheck('foo')).toEqual(true);
   });
   it('Complex objects lead to false', () => {
-    const assertObject = false;
-    expect(plainObjectCheck(new Date(), assertObject)).toEqual(false);
-    expect(plainObjectCheck(new Float32Array([1, 2]), assertObject))
+    expect(plainObjectCheck(new Date())).toEqual(false);
+    expect(plainObjectCheck(new Float32Array([1, 2])))
         .toEqual(false);
-    expect(plainObjectCheck(new ArrayBuffer(4), assertObject)).toEqual(false);
+    expect(plainObjectCheck(new ArrayBuffer(4))).toEqual(false);
     expect(plainObjectCheck(new Error())).toEqual(false);
     expect(plainObjectCheck(zeros([2, 3]))).toEqual(false);
   });
@@ -57,7 +49,7 @@ describe('plainObjectCheck', () => {
       'key3': false
     })).toEqual(true);
   });
-  it('POJOs with bad values lead to false', () => {
+  it('POJOs with invalid value types lead to false', () => {
     expect(plainObjectCheck({
       'key1': new Date(),
       'key2': 1337
@@ -77,14 +69,14 @@ describe('plainObjectCheck', () => {
       }
     })).toEqual(false);
   });
-  it('Arrays of POJO lead to false', () => {
-    expect(plainObjectCheck([])).toEqual(false);
-    expect(plainObjectCheck([{}, {}])).toEqual(false);
+  it('Arrays of POJO lead to true', () => {
+    expect(plainObjectCheck([])).toEqual(true);
+    expect(plainObjectCheck([{}, {}])).toEqual(true);
     expect(plainObjectCheck([{
       'key1': 'foo',
       'key2': 1337,
       'key3': false
-    }])).toEqual(false);
+    }])).toEqual(true);
     expect(plainObjectCheck([{
       'key1': {
         'key1_1': [1, 3, 3, 7],
@@ -93,7 +85,7 @@ describe('plainObjectCheck', () => {
       },
       'key2': 1337,
       'key3': false
-    }])).toEqual(false);
+    }])).toEqual(true);
   });
 });
 

--- a/src/user_defined_metadata_test.ts
+++ b/src/user_defined_metadata_test.ts
@@ -90,6 +90,7 @@ describe('plainObjectCheck', () => {
 });
 
 describe('Save and load model with metadata', () => {
+
   function createSequentialModelForTest(): Sequential {
     const model = tfl.sequential();
     model.add(tfl.layers.dense({
@@ -99,6 +100,7 @@ describe('Save and load model with metadata', () => {
     }));
     return model;
   }
+
   function createFunctionalModelForTest(): tfl.LayersModel {
     const input1 = tfl.input({shape: [3]});
     const input2 = tfl.input({shape: [4]});
@@ -110,6 +112,7 @@ describe('Save and load model with metadata', () => {
         tfl.SymbolicTensor;
     return tfl.model({inputs: [input1, input2], outputs: output});
   }
+
   for (const modelType of ['sequential', 'functional']) {
     it(`Valid user-defined metadata round trip: ${modelType}`, async () => {
       const model = modelType === 'sequential' ?

--- a/src/user_defined_metadata_test.ts
+++ b/src/user_defined_metadata_test.ts
@@ -1,0 +1,159 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ * =============================================================================
+ */
+
+import {io, zeros} from '@tensorflow/tfjs-core';
+
+import * as tfl from './index';
+import {Sequential} from './models';
+import {plainObjectCheck} from './user_defined_metadata';
+
+describe('plainObjectCheck', () => {
+  it('Primitives under assertObject = default true', () => {
+    expect(plainObjectCheck(undefined)).toEqual(false);
+    expect(plainObjectCheck(null)).toEqual(false);
+    expect(plainObjectCheck(true)).toEqual(false);
+    expect(plainObjectCheck(1337)).toEqual(false);
+    expect(plainObjectCheck('foo')).toEqual(false);
+  });
+  it('Primitives under assertObject = false', () => {
+    const assertObject = false;
+    // `undefined` is not valid JSON.
+    expect(plainObjectCheck(undefined, assertObject)).toEqual(false);
+    expect(plainObjectCheck(null, assertObject)).toEqual(true);
+    expect(plainObjectCheck(true, assertObject)).toEqual(true);
+    expect(plainObjectCheck(1337, assertObject)).toEqual(true);
+    expect(plainObjectCheck('foo', assertObject)).toEqual(true);
+  });
+  it('Complex objects lead to false', () => {
+    const assertObject = false;
+    // `undefined` is not valid JSON.
+    expect(plainObjectCheck(new Date(), assertObject)).toEqual(false);
+    expect(plainObjectCheck(new Float32Array([1, 2]), assertObject))
+        .toEqual(false);
+    expect(plainObjectCheck(new ArrayBuffer(4), assertObject)).toEqual(false);
+    expect(plainObjectCheck(new Error())).toEqual(false);
+    expect(plainObjectCheck(zeros([2, 3]))).toEqual(false);
+  });
+  it('POJOs lead to true', () => {
+    // `undefined` is not valid JSON.
+    expect(plainObjectCheck({})).toEqual(true);
+    expect(plainObjectCheck({
+      'key1': 'foo',
+      'key2': 1337,
+      'key3': false
+    })).toEqual(true);
+    expect(plainObjectCheck({
+      'key1': {
+        'key1_1': [1, 3, 3, 7, [42]],
+        'key1_2': null,
+        'key1_3': ['foo', 'bar', null, {}, {'qux': 233}],
+      },
+      'key2': 1337,
+      'key3': false
+    })).toEqual(true);
+  });
+  it('POJOs with bad values lead to false', () => {
+    // `undefined` is not valid JSON.
+    expect(plainObjectCheck({
+      'key1': new Date(),
+      'key2': 1337
+    })).toEqual(false);
+    expect(plainObjectCheck({
+      'key1': new ArrayBuffer(3),
+      'key2': 1337
+    })).toEqual(false);
+    expect(plainObjectCheck({
+      'key1': 'foo',
+      'key2': undefined
+    })).toEqual(false);
+    expect(plainObjectCheck({
+      'key1': 'foo',
+      'key2': {
+        'tensor': zeros([2, 3])
+      }
+    })).toEqual(false);
+  });
+  it('Arrays of POJO lead to false', () => {
+    // `undefined` is not valid JSON.
+    expect(plainObjectCheck([])).toEqual(false);
+    expect(plainObjectCheck([{}, {}])).toEqual(false);
+    expect(plainObjectCheck([{
+      'key1': 'foo',
+      'key2': 1337,
+      'key3': false
+    }])).toEqual(false);
+    expect(plainObjectCheck([{
+      'key1': {
+        'key1_1': [1, 3, 3, 7],
+        'key1_2': null,
+        'key1_3': ['foo', 'bar', null, {}, {'qux': 233}],
+      },
+      'key2': 1337,
+      'key3': false
+    }])).toEqual(false);
+  });
+});
+
+describe('Save and load model with metadata', () => {
+  function createSequentialModelForTest(): Sequential {
+    const model = tfl.sequential();
+    model.add(tfl.layers.dense({
+      units: 3,
+      inputShape: [10],
+      activation: 'softmax'
+    }));
+    return model;
+  }
+  function createFunctionalModelForTest(): tfl.LayersModel {
+    const input1 = tfl.input({shape: [3]});
+    const input2 = tfl.input({shape: [4]});
+    const dense1 = tfl.layers.dense({units: 2, inputShape: [3]});
+    const dense2 = tfl.layers.dense({units: 1, inputShape: [4]});
+    const y1 = dense1.apply(input1) as tfl.SymbolicTensor;
+    const y2 = dense2.apply(input2) as tfl.SymbolicTensor;
+    const output = tfl.layers.concatenate().apply([y1, y2]) as
+        tfl.SymbolicTensor;
+    return tfl.model({inputs: [input1, input2], outputs: output});
+  }
+  for (const modelType of ['sequential', 'functional']) {
+    it(`Valid user-defined metadata round trip: ${modelType}`, async () => {
+      const model = modelType === 'sequential' ?
+          createSequentialModelForTest() : createFunctionalModelForTest();
+      const userDefinedMetadata = {'outputLabels': ['foo', 'bar', 'baz']};
+      model.setUserDefinedMetadata(userDefinedMetadata);
+      expect(model.getUserDefinedMetadata()).toEqual(userDefinedMetadata);
+      let savedArtifacts: io.ModelArtifacts;
+      await model.save(
+          io.withSaveHandler(async (artifacts: io.ModelArtifacts) => {
+            savedArtifacts = artifacts;
+            return {modelArtifactsInfo: null};
+          }));
+      const reloadedModel = await tfl.loadLayersModel(
+          io.fromMemory(savedArtifacts));
+      expect(reloadedModel.getUserDefinedMetadata())
+          .toEqual(userDefinedMetadata);
+    });
+  }
+  for (const modelType in ['sequential', 'functional']) {
+    it(`Invalid user metadata leads to error: ${modelType}`, async () => {
+      const model = modelType === 'sequential' ?
+          createSequentialModelForTest() : createFunctionalModelForTest();
+      expect(() => model.setUserDefinedMetadata(
+          JSON.stringify({'outputLabels': ['foo', 'bar', 'baz']})))
+          .toThrowError(/is expected to be a JSON object, but is not/);
+      expect(() => model.setUserDefinedMetadata(
+          ['foo', 'bar', 'baz']))
+          .toThrowError(/is expected to be a JSON object, but is not/);
+      expect(() => model.setUserDefinedMetadata(
+          {'foo': zeros([2, 3]), 'outputLabels': ['foo', 'bar', 'baz']}))
+          .toThrowError(/is expected to be a JSON object, but is not/);
+    });
+  }
+});

--- a/src/user_defined_metadata_test.ts
+++ b/src/user_defined_metadata_test.ts
@@ -33,7 +33,6 @@ describe('plainObjectCheck', () => {
   });
   it('Complex objects lead to false', () => {
     const assertObject = false;
-    // `undefined` is not valid JSON.
     expect(plainObjectCheck(new Date(), assertObject)).toEqual(false);
     expect(plainObjectCheck(new Float32Array([1, 2]), assertObject))
         .toEqual(false);
@@ -42,7 +41,6 @@ describe('plainObjectCheck', () => {
     expect(plainObjectCheck(zeros([2, 3]))).toEqual(false);
   });
   it('POJOs lead to true', () => {
-    // `undefined` is not valid JSON.
     expect(plainObjectCheck({})).toEqual(true);
     expect(plainObjectCheck({
       'key1': 'foo',
@@ -60,7 +58,6 @@ describe('plainObjectCheck', () => {
     })).toEqual(true);
   });
   it('POJOs with bad values lead to false', () => {
-    // `undefined` is not valid JSON.
     expect(plainObjectCheck({
       'key1': new Date(),
       'key2': 1337
@@ -81,7 +78,6 @@ describe('plainObjectCheck', () => {
     })).toEqual(false);
   });
   it('Arrays of POJO lead to false', () => {
-    // `undefined` is not valid JSON.
     expect(plainObjectCheck([])).toEqual(false);
     expect(plainObjectCheck([{}, {}])).toEqual(false);
     expect(plainObjectCheck([{


### PR DESCRIPTION
FEATURE

- Add two public methods to `tf.LayersModel` and `tf.Sequential`
  - `setUserDefinedMetadata()`
  - `getUserDefinedMetadata()`
  These methods allow user to set and get custom metadata about the model.
- Any set user metadata is serialized together with the model.
- User-defined metadata are also deserialized (i.e., loaded) together with the topology and/or weights of the model.
- The user-defined metadata is required to be a plain JSON object. This PR implements the enforcement mechanisms that will throw errors if this condition is not met.
- During serialization and deserializatoin, the size of the JSON object will be checked. If it is greater than 1 MB in length, a warning will be thrown.

Towards https://github.com/tensorflow/tfjs/issues/1596

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/571)
<!-- Reviewable:end -->
