### PR TITLE
Fix batch size detection for multi-input models

### DIFF
--- a/src/engine/training.ts
+++ b/src/engine/training.ts
@@ -1130,7 +1130,7 @@ export class LayersModel extends Container implements tfc.InferenceModel {
     checkInputData(x, this.inputNames, this.feedInputShapes, true);
     // TODO(cais): Take care of the learning_phase boolean flag.
     //   if (this.useLearningPhase) ...
-    return this.predictLoop(x, x.shape[0]);
+    return this.predictLoop(x, Array.isArray(x) ? x[0].shape[0] : x.shape[0]);
   }
 
   protected standardizeUserDataXY(


### PR DESCRIPTION
On second thought, maybe predictOnBatch should take Tensor|Tensor[] as argument like checkInputData but this can maybe be taken as a separate fix?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/572)
<!-- Reviewable:end -->
