### PR TITLE
Update test spy to match changes in core

### DIFF
--- a/src/models_test.ts
+++ b/src/models_test.ts
@@ -8,7 +8,7 @@
  * =============================================================================
  */
 
-import {DataType, io, memory, ones, randomNormal, Scalar, scalar, serialization, sum, Tensor, tensor1d, tensor2d, tensor3d, train, zeros, util} from '@tensorflow/tfjs-core';
+import {DataType, io, memory, ones, randomNormal, Scalar, scalar, serialization, sum, Tensor, tensor1d, tensor2d, tensor3d, train, zeros, ENV} from '@tensorflow/tfjs-core';
 import {ConfigDict} from '@tensorflow/tfjs-core/dist/serialization';
 
 import {LayersModel} from './engine/training';
@@ -549,7 +549,7 @@ describeMathCPU('loadLayersModel from URL', () => {
   const setupFakeWeightFiles =
       (fileBufferMap:
            {[filename: string]: Float32Array|Int32Array|ArrayBuffer}) => {
-        spyOn(util, 'fetch')
+        spyOn(ENV.platform, 'fetch')
             .and.callFake((path: string) => new Promise(resolve => {
                             resolve(new Response(fileBufferMap[path], {
                               'headers': {'Content-Type': OCTET_STREAM_TYPE}
@@ -631,7 +631,7 @@ describeMathCPU('loadLayersModel from URL', () => {
       }
     ];
 
-    spyOn(util, 'fetch').and.callFake((path: string) => {
+    spyOn(ENV.platform, 'fetch').and.callFake((path: string) => {
       return new Promise((resolve, reject) => {
         if (path === 'model/model.json') {
           resolve(new Response(
@@ -683,7 +683,7 @@ describeMathCPU('loadLayersModel from URL', () => {
       }
     ];
 
-    spyOn(util, 'fetch').and.callFake((path: string) => {
+    spyOn(ENV.platform, 'fetch').and.callFake((path: string) => {
       return new Promise((resolve, reject) => {
         if (path === 'model/model.json') {
           resolve(new Response(
@@ -743,7 +743,7 @@ describeMathCPU('loadLayersModel from URL', () => {
       }
     ];
 
-    spyOn(util, 'fetch').and.callFake((path: string) => {
+    spyOn(ENV.platform, 'fetch').and.callFake((path: string) => {
       return new Promise((resolve, reject) => {
         if (path === 'https://url/to/model/model.json') {
           resolve(new Response(
@@ -806,7 +806,7 @@ describeMathCPU('loadLayersModel from URL', () => {
 
     const kernelData = ones([32, 32], 'float32').dataSync() as Float32Array;
     const biasData = zeros([32], 'float32').dataSync() as Float32Array;
-    spyOn(util, 'fetch').and.callFake((path: string) => {
+    spyOn(ENV.platform, 'fetch').and.callFake((path: string) => {
       return new Promise((resolve, reject) => {
         if (path === 'model/model.json') {
           resolve(new Response(
@@ -871,7 +871,7 @@ describeMathCPU('loadLayersModel from URL', () => {
                [{'name': `dense_2/bias`, 'dtype': 'float32', 'shape': [1]}],
          }
        ];
-       spyOn(util, 'fetch').and.callFake((path: string) => {
+       spyOn(ENV.platform, 'fetch').and.callFake((path: string) => {
          return new Promise((resolve, reject) => {
            if (path === 'model/model.json') {
              resolve(new Response(
@@ -940,7 +940,7 @@ describeMathCPU('loadLayersModel from URL', () => {
         'weights': [{'name': `dense_2/bias`, 'dtype': 'float32', 'shape': [1]}],
       }
     ];
-    spyOn(util, 'fetch').and.callFake((path: string) => {
+    spyOn(ENV.platform, 'fetch').and.callFake((path: string) => {
       return new Promise((resolve, reject) => {
         if (path === 'model/model.json') {
           resolve(new Response(
@@ -1007,7 +1007,7 @@ describeMathCPU('loadLayersModel from URL', () => {
 
        const requestHeaders: Array<{[key: string]: string | {}}> = [];
        const requestCredentials: string[] = [];
-       spyOn(util, 'fetch')
+       spyOn(ENV.platform, 'fetch')
            .and.callFake((path: string, requestInit?: RequestInit) => {
              if (requestInit != null) {
                requestHeaders.push(requestInit.headers as {});
@@ -1085,7 +1085,7 @@ describeMathCPU('loadLayersModel from URL', () => {
                  [{'name': `dense_6/bias`, 'dtype': 'float32', 'shape': [32]}],
            }
          ];
-         spyOn(util, 'fetch').and.callFake((path: string) => {
+         spyOn(ENV.platform, 'fetch').and.callFake((path: string) => {
            return new Promise((resolve, reject) => {
              if (path === `${protocol}localhost:8888/models/model.json`) {
                resolve(new Response(

--- a/src/models_test.ts
+++ b/src/models_test.ts
@@ -8,7 +8,7 @@
  * =============================================================================
  */
 
-import {DataType, io, memory, ones, randomNormal, Scalar, scalar, serialization, sum, Tensor, tensor1d, tensor2d, tensor3d, train, zeros, ENV} from '@tensorflow/tfjs-core';
+import {DataType, ENV, io, memory, ones, randomNormal, Scalar, scalar, serialization, sum, Tensor, tensor1d, tensor2d, tensor3d, train, zeros} from '@tensorflow/tfjs-core';
 import {ConfigDict} from '@tensorflow/tfjs-core/dist/serialization';
 
 import {LayersModel} from './engine/training';


### PR DESCRIPTION
The internal mechanism of weightsLoader in tfjs-core changed to use
ENV.platform.fetch instead of util.fetch.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/573)
<!-- Reviewable:end -->
