### PR TITLE
Fix memory leak with loaded models containing nested Sequential layers

### DIFF
--- a/src/engine/container.ts
+++ b/src/engine/container.ts
@@ -59,6 +59,8 @@ export abstract class Container extends Layer {
   layersByDepth: {[depth: string]: Layer[]};
   nodesByDepth: {[depth: string]: Node[]};
 
+  internalContainerRefs: Container[];
+
   containerNodes = new Set<string>();
 
   // TODO(michaelterry): Add cache support
@@ -138,6 +140,12 @@ export abstract class Container extends Layer {
       Includes input and output layers.
     */
     this.layers = [];
+
+    /*
+      References to container layers that were constructed internally. We need
+      these to properly dispose of tensors from nested containers.
+    */
+    this.internalContainerRefs = [];
 
     // TODO(michaelterry): Determine if caching still needed with eager
     // backend.
@@ -379,6 +387,9 @@ export abstract class Container extends Layer {
         return 0;
       });
       for (const layer of layersForDepth) {
+        if (layer instanceof Container) {
+          this.internalContainerRefs.push(layer);
+        }
         this.layers.push(layer);
       }
     }
@@ -499,6 +510,12 @@ export abstract class Container extends Layer {
     if (--this._refCount === 0) {
       for (const layer of this.layers) {
         result.numDisposedVariables += layer.dispose().numDisposedVariables;
+      }
+
+      // After disposing of layers, make sure any tensors from any internally
+      // created containers are disposed.
+      for (const container of this.internalContainerRefs) {
+        result.numDisposedVariables += container.dispose().numDisposedVariables;
       }
     }
     result.refCountAfterDispose = this._refCount;


### PR DESCRIPTION
If a model loaded with loadLayersModel contains a nested Sequential layer, disposing  of the main model leaves the tensors of the nested model behind. This is because the refCount of the nested model doesn't go to zero during the call to `dispose` since the nested model's refCount is incremented twice: once during sub-model creation and once when the sub-model is added as a layer.

This commit makes it so references to each internally constructed sub-container are tracked and disposed when the parent model is disposed. This ensures the refCount will hit 0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-layers/578)
<!-- Reviewable:end -->
